### PR TITLE
RDKB-57868: Ignore error of switch channel in case of non-first inter…

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -6389,6 +6389,7 @@ int nl80211_switch_channel(wifi_radio_info_t *radio)
     u8 seg0;
     char country[8];
     int ret = 0;
+    bool is_first_interface;
 
     param = &radio->oper_param;
     get_coutry_str_from_code(param->countryCode, country);
@@ -6458,6 +6459,7 @@ int nl80211_switch_channel(wifi_radio_info_t *radio)
     wifi_hal_dbg_print("%s:%d chan_freq: %d center_freq: %d bandwidth: %d sec_chan_offset: %d\n",
         __func__, __LINE__, freq, freq1, bandwidth, sec_chan_offset);
 
+    is_first_interface = true;
     hash_map_foreach(radio->interface_map, interface) {
         if (!interface->bss_started) {
             continue;
@@ -6470,13 +6472,16 @@ int nl80211_switch_channel(wifi_radio_info_t *radio)
         ret = hostapd_switch_channel(&interface->u.ap.hapd, &csa_settings);
         pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
 
-        if (ret != 0) {
+        /* Ignore the error if the error is not on first interface,
+           as CSA would be in progress after the first interface channel switch. */
+        if (ret != 0 && is_first_interface == true) {
             wifi_hal_error_print("%s:%d interface: %s failed to switch channel to %d, error: %d\n",
                 __func__, __LINE__, interface->name, param->channel, ret);
+            return ret;
         }
+        is_first_interface = false;
     }
-
-    return ret;
+    return 0;
 }
 
 int nl80211_update_wiphy(wifi_radio_info_t *radio)


### PR DESCRIPTION
RDKB-57868: Ignore error of switch channel in case of non-first interface

Reason for change: In some platform, switch channel for non-first interface can return error due to CSA in progress of first interface. So, ignore the error of switch channel on non-first interface.

Test Procedure: Ensured that the config change is reflected in radio subdoc as part of successful channel change request to agent.

Risks: Low
Priority: P1

Change-Id: If1ac7d077a8179b9586f1ee8b57020d06e711f6e