### PR TITLE
Refactor nl command code changes for RPI

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -86,8 +86,6 @@ struct family_data {
     int id;
 };
 
-struct nl_msg *nl80211_drv_cmd_msg(int nl80211_id, wifi_interface_info_t *intf, int flags, uint8_t cmd);
-
 int nl80211_send_and_recv(struct nl_msg *msg,
              int (*valid_handler)(struct nl_msg *, void *),
              void *valid_data,

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -883,6 +883,7 @@ int     wifi_send_eapol(void *priv, const u8 *addr, const u8 *data,
                     size_t data_len, int encrypt,
                     const u8 *own_addr, u32 flags);
 void   *wifi_drv_init(struct hostapd_data *hapd, struct wpa_init_params *params);
+struct nl_msg *nl80211_drv_cmd_msg(int nl80211_id, wifi_interface_info_t *intf, int flags, uint8_t cmd);
 struct nl_msg *nl80211_drv_vendor_cmd_msg(int nl80211_id, wifi_interface_info_t *intf, int flags,
     uint32_t vendor_id, uint32_t subcmd);
 int nl80211_send_and_recv(struct nl_msg *msg, int (*valid_handler)(struct nl_msg *, void *),


### PR DESCRIPTION
Refactor nl command code changes for RPI

Reason for change: Refactor the code for getting associated device stats using nl commands. Used existing rdk-wifi-hal API for msg creation, send and receive. 
Test Procedure: Ensure associated device stats data is populated for RPI4 device 
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E rakhilpe001@gmail.com