### PR TITLE
RDKB-58153: fixed association status for hotspot VAPs

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -1147,8 +1147,8 @@ static int platform_set_hostap_ctrl(wifi_radio_info_t *radio, uint vap_index, in
 
     if (enable) {
         assoc_ctrl = ASSOC_HOSTAP_FULL_CTRL;
-    } else if (radio->oper_param.band != WIFI_FREQUENCY_6_BAND &&
-        is_wifi_hal_vap_hotspot_open(vap_index) && is_wifi_hal_vap_hotspot_secure(vap_index)) {
+    } else if (is_wifi_hal_vap_hotspot_open(vap_index) ||
+        is_wifi_hal_vap_hotspot_secure(vap_index)) {
         assoc_ctrl = ASSOC_HOSTAP_STATUS_CTRL;
     } else {
         assoc_ctrl = ASSOC_DRIVER_CTRL;


### PR DESCRIPTION
Reason for change:
  wrong condition check reset driver split_assoc_req configuration to 0
Test Procedure:
  check hotspot VAPs have split_assoc_req 1 by default
wl -i wl0.3 split_assoc_req
wl -i wl1.3 split_assoc_req
wl -i wl2.3 split_assoc_req
wl -i wl0.5 split_assoc_req
wl -i wl1.5 split_assoc_req
wl -i wl2.5 split_assoc_req
Risks: Low
Priority: P1