### PR TITLE
RDKB-58215 Expected base and max supported mode

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -2518,12 +2518,15 @@ static int decode_bss_info_to_neighbor_ap_info(wifi_neighbor_ap2_t *ap, const wi
     }
 
     // - ap_SupportedStandards
-    if (wifi_ieee80211Variant_to_str(ap->ap_SupportedStandards, sizeof(ap->ap_SupportedStandards), bss->supp_standards)) {
+    // 4th argument - Any prefix to be added before the standard i.e., 802.11
+    if (wifi_ieee80211Variant_to_str(ap->ap_SupportedStandards, sizeof(ap->ap_SupportedStandards),
+            bss->supp_standards, "")) {
         ret = RETURN_ERR;
     }
 
     // - ap_OperatingStandards
-    if (wifi_ieee80211Variant_to_str(ap->ap_OperatingStandards, sizeof(ap->ap_OperatingStandards), bss->oper_standards)) {
+    if (wifi_ieee80211Variant_to_str(ap->ap_OperatingStandards, sizeof(ap->ap_OperatingStandards),
+            bss->oper_standards, "")) {
         ret = RETURN_ERR;
     }
 

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -3520,11 +3520,51 @@ fail:
     return RETURN_ERR;
 }
 
-int wifi_ieee80211Variant_to_str(char *dest, size_t dest_size, wifi_ieee80211Variant_t variant)
+int wifi_ieee80211Variant_to_str(char *dest, size_t dest_size, wifi_ieee80211Variant_t variant,
+    const char *str)
 {
-    return wifi_enum_bitmap_to_str(dest, dest_size,
-        wifi_variant_Map, ARRAY_SIZE(wifi_variant_Map),
-        "802.11", (int)variant);
+    const char *mode;
+
+    if (*str != '\0') {
+        return wifi_enum_bitmap_to_str(dest, dest_size, wifi_variant_Map,
+            ARRAY_SIZE(wifi_variant_Map), str, (int)variant);
+    } else {
+        if ((dest != NULL) && (dest_size != 0)) {
+            *dest = '\0';
+
+            if (variant & WIFI_80211_VARIANT_A) {
+                mode = "a";
+                str_list_append(dest, dest_size, mode);
+            }
+            if (variant & WIFI_80211_VARIANT_B) {
+                mode = "b";
+                str_list_append(dest, dest_size, mode);
+            }
+            if (variant & WIFI_80211_VARIANT_G) {
+                mode = "g";
+                str_list_append(dest, dest_size, mode);
+            }
+            if (variant &
+                (WIFI_80211_VARIANT_N | WIFI_80211_VARIANT_AC | WIFI_80211_VARIANT_AX |
+                    WIFI_80211_VARIANT_BE)) {
+                if (variant & WIFI_80211_VARIANT_BE) {
+                    mode = "be";
+                } else if (variant & WIFI_80211_VARIANT_AX) {
+                    mode = "ax";
+                } else if (variant & WIFI_80211_VARIANT_AC) {
+                    mode = "ac";
+                } else {
+                    mode = "n";
+                }
+                str_list_append(dest, dest_size, mode);
+            }
+        } else {
+            wifi_hal_error_print("%s:%d: NULL or zero-size buffer\n", __func__, __LINE__);
+            return RETURN_ERR;
+        }
+    }
+
+    return RETURN_OK;
 }
 
 int wifi_channelBandwidth_to_str(char *dest, size_t dest_size, wifi_channelBandwidth_t bandwidth)

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -1219,7 +1219,8 @@ int wifi_strcpy(char *dest, size_t dest_size, const char *src);
 int wifi_strcat(char *dest, size_t dest_size, const char *src);
 int wifi_strncpy(char *dest, size_t dest_size, const char *src, size_t count);
 int str_list_append(char *dest, size_t dest_size, const char *src);
-int wifi_ieee80211Variant_to_str(char *dest, size_t dest_size, wifi_ieee80211Variant_t variant);
+int wifi_ieee80211Variant_to_str(char *dest, size_t dest_size, wifi_ieee80211Variant_t variant,
+    const char *str);
 int wifi_channelBandwidth_to_str(char *dest, size_t dest_size, wifi_channelBandwidth_t bandwidth);
 int wifi_bitrate_to_str(char *dest, size_t dest_size, wifi_bitrate_t bitrate);
 void init_interface_map(void);


### PR DESCRIPTION
Reason for change: 802.11 prefix not required and expected only base and max supported standards as per broadcom implementation.

Test Procedure: Test spectrum analysis from GUI and should see expected supported standards modes.