### PR TITLE
REFPLTB-3307 :[TDK][AUTO][RPI4]Device.WiFi.AccessPoint.{i}.AssociatedDeviceNumberOfEntries not decrementing when connected client is disconnected

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -515,6 +515,7 @@ static int get_sta_stats(wifi_interface_info_t *interface, mac_address_t mac, wi
     return 0;
 }
 
+#ifdef CONFIG_WIFI_EMULATOR
 INT wifi_getApAssociatedDeviceDiagnosticResult3(INT apIndex,
     wifi_associated_dev3_t **associated_dev_array, UINT *output_array_size)
 {
@@ -690,6 +691,8 @@ INT wifi_setDownStreamGroupAddress(INT apIndex, BOOL disabled)
 {
     return 0;
 }
+#endif
+
 INT wifi_getApAssociatedClientDiagnosticResult(INT ap_index, char *key,wifi_associated_dev3_t *assoc)
 {
     return RETURN_ERR;


### PR DESCRIPTION
Reason for change : wifi_getApAssociatedDeviceDiagnosticResult3 stub function is overriding acutual implementation from vendor hal code
Test procedure : Device.WiFi.AccessPoint.{i}.AssociatedDeviceNumberOfEntries should be decremented when connected client is disconnected
Risks : Low