### PR TITLE
RDKB-57124: XWIFI reject telemetry marker

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -3808,6 +3808,19 @@ INT wifi_vapstatus_callback_register(wifi_vapstatus_callback func) {
     return RETURN_OK;
 }
 
+void wifi_hal_ap_max_client_rejection_callback_register(wifi_apMaxClientRejection_callback func)
+{
+    wifi_device_callbacks_t *callbacks;
+
+    callbacks = get_hal_device_callbacks();
+
+    if (callbacks == NULL) {
+        return;
+    }
+
+    callbacks->max_cli_rejection_cb = func;
+}
+
 void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice_callback func)
 {
     wifi_device_callbacks_t *callbacks;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -69,7 +69,7 @@
 #include <rdk_nl80211_hal.h>
 #endif
 
-
+#define AP_UNABLE_TO_HANDLE_ADDITIONAL_ASSOCIATIONS 17
 #define OVS_MODULE "/sys/module/openvswitch"
 #define ONEWIFI_TESTSUITE_TMPFILE "/tmp/onewifi_testsuite_configured"
 
@@ -1876,7 +1876,6 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
         mgmt_type = WIFI_MGMT_FRAME_TYPE_DEAUTH;
         wifi_hal_dbg_print("%s:%d: Received deauth frame from: %s\n", __func__, __LINE__,
                            to_mac_str(sta, sta_mac_str));
-
         if (callbacks->num_apDeAuthEvent_cbs == 0) {
             break;
         }
@@ -10276,8 +10275,10 @@ int wifi_drv_send_mlme(void *priv, const u8 *data,
     u16 fc;
     int use_cookie = 1;
     int res, interface_freq;
-    //mac_addr_str_t mac_str;
+
     char country[8];
+    wifi_device_callbacks_t *callbacks;
+    callbacks = get_hal_device_callbacks();
 
     interface = (wifi_interface_info_t *)priv;
     vap = &interface->vap_info;
@@ -10293,6 +10294,15 @@ int wifi_drv_send_mlme(void *priv, const u8 *data,
 
     mgmt = (struct ieee80211_mgmt *) data;
     fc = le_to_host16(mgmt->frame_control);
+
+    if (WLAN_FC_GET_STYPE(fc) == WLAN_FC_STYPE_AUTH &&
+        mgmt->u.auth.status_code == AP_UNABLE_TO_HANDLE_ADDITIONAL_ASSOCIATIONS &&
+        callbacks->max_cli_rejection_cb != NULL) {
+        mac_addr_str_t mac_str;
+        callbacks->max_cli_rejection_cb(interface->vap_info.vap_index,
+            to_mac_str(mgmt->da, mac_str), AP_UNABLE_TO_HANDLE_ADDITIONAL_ASSOCIATIONS);
+    }
+
     //wifi_hal_dbg_print("nl80211: send_mlme - da= %s noack=%d freq=%u fc=0x%x\n",
     //to_mac_str(mgmt->da, mac_str), noack, freq, fc);
 

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -426,14 +426,13 @@ typedef struct wifi_interface_info_t {
     mac_address_t   mac;
     unsigned int type;
     unsigned int interface_status;
-    bool    primary;
-    wifi_vap_info_t     vap_info;
-    bool    vap_initialized;
-    bool    bss_started;
-   
-    bool    vap_configured; // important flag, flag = true means that hostap is configured for this and 
-                            // interface is ready to receive 802.11 data frames
-    bool    bridge_configured;
+    bool primary;
+    wifi_vap_info_t vap_info;
+    bool vap_initialized;
+    bool bss_started;
+    bool vap_configured; // important flag, flag = true means that hostap is configured for this and
+                         // interface is ready to receive 802.11 data frames
+    bool bridge_configured;
     struct nl_handle *nl_event;
     int nl_event_fd;
     struct nl_cb *nl_cb;
@@ -805,6 +804,7 @@ void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice
 void wifi_hal_radiusEapFailure_callback_register(wifi_radiusEapFailure_callback func);
 void wifi_hal_radiusFallback_failover_callback_register(wifi_radiusFallback_failover_callback func);
 void wifi_hal_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback func);
+void wifi_hal_ap_max_client_rejection_callback_register(wifi_apMaxClientRejection_callback func);
 INT wifi_hal_BTMQueryRequest_callback_register(UINT apIndex,
                                             wifi_BTMQueryRequest_callback btmQueryCallback,
                                             wifi_BTMResponse_callback btmResponseCallback);

--- a/src/wifi_hal_rdk_framework.h
+++ b/src/wifi_hal_rdk_framework.h
@@ -125,6 +125,7 @@ typedef struct {
     struct rtnl_kvr_handle                  rtnl_kvr;
     wifi_newApAssociatedDevice_callback     assoc_cb[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_assoc_cbs;
+    wifi_apMaxClientRejection_callback      max_cli_rejection_cb;
     wifi_apDisassociatedDevice_callback     disassoc_cb[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_disassoc_cbs;
     unsigned int                            num_radius_eap_cbs;


### PR DESCRIPTION
Impacted Platforms: All onewifi platforms

Reason for change: Implementation for XWIFI reject telemetry marker

Test Procedure: 1. Change the maximum client to 2.
                2. Try to connect more than 2 clients.
                3. Check the wifihealth.txt file.

Risks: Low

Priority: P1

Change-Id: I2cf2ba023c94c57951e658b13b4cde1f375b0fd5 Signed-off-by:RaviShankar.R_Rangaraj@comcast.com