### PR TITLE
RDKB-58464 : high cpuload avg with failed to send action frame

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -4003,6 +4003,8 @@ void wifi_hal_send_mgmt_frame(int apIndex,mac_address_t sta, const unsigned char
     wifi_interface_info_t *interface;
     u8 *buf;
     struct ieee80211_hdr *hdr;
+    mac_address_t bssid_buf;
+    memset(bssid_buf, 0xff, sizeof(bssid_buf));
 
     buf = os_zalloc(24 + data_len);
     if (buf == NULL)
@@ -4019,14 +4021,14 @@ void wifi_hal_send_mgmt_frame(int apIndex,mac_address_t sta, const unsigned char
     }
     os_memcpy(hdr->addr1, sta, ETH_ALEN);
     os_memcpy(hdr->addr2, interface->mac, ETH_ALEN);
-    os_memcpy(hdr->addr3, interface->mac, ETH_ALEN);
+    os_memcpy(hdr->addr3, bssid_buf, ETH_ALEN);
 
-#ifdef HOSTAPD_2_11 //2.11
-    wifi_drv_send_mlme(interface,buf, 24+data_len, 0, 0, NULL, 0,0,0,0);
-#elif HOSTAPD_2_10 //2.10
-    wifi_drv_send_mlme(interface,buf, 24+data_len, 0, 0, NULL, 0,0,0);
+#ifdef HOSTAPD_2_11 // 2.11
+    wifi_drv_send_mlme(interface, buf, 24 + data_len, 1, 0, NULL, 0, 0, 0, 0);
+#elif HOSTAPD_2_10 // 2.10
+    wifi_drv_send_mlme(interface, buf, 24 + data_len, 1, 0, NULL, 0, 0, 0);
 #else
-    wifi_drv_send_mlme(interface,buf,24+data_len, 0, 0, NULL, 0);
+    wifi_drv_send_mlme(interface, buf, 24 + data_len, 1, 0, NULL, 0);
 #endif
 
     os_free(buf);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -1831,8 +1831,11 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
             forward_frame = (WIFI_HAL_UNSUPPORTED == handle_rrm_action_frame(interface, sta, mgmt, len, sig_dbm));
             break;
         case wifi_action_frame_type_public:
-            // - don't handle frame by calling wpa_supplicant_event() if action frame was already handled:
-            forward_frame = (WIFI_HAL_UNSUPPORTED == handle_public_action_frame(vap->vap_index, sta, (wifi_publicActionFrameHdr_t *)mgmt, len));
+            // - don't handle frame by calling wpa_supplicant_event() if action frame was already
+            // handled: The below code is commented as it is causing duplicates. handling of public
+            // action frames is taken care further below of this function via
+            // callbacks->mgmt_frame_rx_callback
+            forward_frame = false;
             break;
         default:
             break;


### PR DESCRIPTION
Reason for change: 1) Added Broadcast address for addr3 as part of wifi_hal_send_mgmt_frame. 2) Commented handling of public action frames while processing mgmt frames as it is causing duplicates. 3) Enabled noack for action frames.
Test Procedure: 1) Passpoint feature should work
2) cpu load average should be under control
Risks: Low
Priority: P0