### PR TITLE
XER5-1528: After FR mld12 mld13 interface MTU value changing to 1500

### DIFF
--- a/platform/qualcomm/platform_xer5.c
+++ b/platform/qualcomm/platform_xer5.c
@@ -997,6 +997,11 @@ static int qca_create_mld_interfaces(wifi_vap_info_map_t *map)
                                             vap->vap_index, MAC2STR(mld_mac_addr));
             wifi_hal_info_print("%s:%d Executing %s\n", __func__, __LINE__, cmd);
             system(cmd);
+	    if (is_wifi_hal_vap_mesh_backhaul(vap->vap_index)) {
+		    snprintf(cmd, sizeof(cmd), "ip link set dev mld%d mtu 1600", vap->vap_index);
+		    wifi_hal_info_print("adding 1600 MTU value to mld%d \n", vap->vap_index);
+		    system(cmd);
+	    }
         }
     }
     return RETURN_OK;


### PR DESCRIPTION
Reason for change: After FR mld12 mld13 interface MTU value not changing to 1600
Test Procedure: check mld12 and mld13 MTU values after FR Risks: Low
Priority: P1