### PR TITLE
RDKB-58538: Do not invoke ACL functionality in Raspberry Pi

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13106,7 +13106,9 @@ int wifi_drv_set_ap(void *priv, struct wpa_driver_ap_params *params)
         }
     }
 
-#ifdef NL80211_ACL
+#if defined(NL80211_ACL) && !defined(PLATFORM_LINUX)
+    //TODO: Remove/Refine the check of !defined(PLATFORM_LINUX) based on
+    //support for ACL in latest versions of Raspberry PI driver.
     nl80211_put_acl(msg, interface);
 #endif
 


### PR DESCRIPTION
Reason for change: Raspberry Pi built in WiFi and adapters does not support ACL functionality, thus
do not invoke the call.
Test Procedure: Tested beacon working and set_ssid working with Easymesh agent and controller.
Risks: Low
Priority: P0