### PR TITLE
RDKB-56764 RDKB-58193: ACL over NL80211 - 2.

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -4153,14 +4153,50 @@ bool is_db_upgrade_required(char* inactive_firmware)
     return false;
 }
 
-int wifi_hal_set_acl_mode(uint32_t apIndex, uint32_t mac_filter_mode)
+int wifi_hal_setApMacAddressControlMode(uint32_t apIndex, uint32_t mac_filter_mode)
 {
     wifi_interface_info_t *interface = get_interface_by_vap_index(apIndex);
     if (interface == NULL) {
-        wifi_hal_error_print("%s:%d: WiFi interface not found for vap:%d\n", __func__, __LINE__, apIndex);
+        wifi_hal_error_print("%s:%d: WiFi interface not found for vap:%d\n", __func__, __LINE__,
+            apIndex);
         return RETURN_ERR;
     }
-    return (nl80211_set_acl_mode(interface, mac_filter_mode));
+
+    wifi_vap_info_t *vap;
+    vap = &interface->vap_info;
+    if (vap == NULL) {
+        wifi_hal_error_print("%s:%d: WiFi interface not found for vap:%d\n", __func__, __LINE__,
+            apIndex);
+        return RETURN_ERR;
+    }
+
+    if (vap->u.bss_info.enabled != true || vap->vap_mode != wifi_vap_mode_ap) {
+        wifi_hal_error_print(":%s:%d bss not enabled:%d for vap:%d\n", __func__, __LINE__,
+            vap->u.bss_info.enabled, vap->vap_index);
+        return RETURN_ERR;
+    }
+
+    switch (mac_filter_mode) {
+    case 2:
+        vap->u.bss_info.mac_filter_enable = true;
+        vap->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
+        break;
+
+    case 1:
+        vap->u.bss_info.mac_filter_enable = true;
+        vap->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_white_list;
+        break;
+
+    case 0:
+        vap->u.bss_info.mac_filter_enable = false;
+        break;
+
+    default:
+        wifi_hal_error_print(":%s:%d Wrong Mac mode %d\n", __func__, __LINE__, mac_filter_mode);
+        return RETURN_ERR;
+    }
+
+    return (nl80211_set_acl(interface));
 }
 
 int steering_set_acl_mode(uint32_t apIndex, uint32_t mac_filter_mode)
@@ -4192,5 +4228,6 @@ int steering_set_acl_mode(uint32_t apIndex, uint32_t mac_filter_mode)
         vap->u.bss_info.mac_filter_enable = true;
     }
 
-    return (nl80211_set_acl_mode(interface, mac_filter_mode));
+    vap->u.bss_info.mac_filter_mode = mac_filter_mode;
+    return (nl80211_set_acl(interface));
 }


### PR DESCRIPTION
Reason for change: HAL changes for setting mode.
Test Procedure: ACL set should work over Netlink.
Risks: Low
Priority:P0
