### PR TITLE
Add MAC ACL Support for RPI4 device

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -340,9 +340,32 @@ INT wifi_getApEnable(INT apIndex, BOOL *output_bool)
 //--------------------------------------------------------------------------------------------------
 INT wifi_setApMacAddressControlMode(INT apIndex, INT filterMode)
 {
+    wifi_vap_info_t *vap_info = NULL;
+    wifi_interface_info_t *interface = NULL;
+
+    interface = get_interface_by_vap_index(apIndex);
+    if (interface == NULL) {
+        wifi_hal_error_print("%s:%d: interface for ap index:%d not found\n", __func__, __LINE__, apIndex);
+        return RETURN_ERR;
+    }
+
+    vap_info = &interface->vap_info;
+
+    if (vap_info->vap_mode == wifi_vap_mode_ap) {
+        if (filterMode == 0) {
+               vap_info->u.bss_info.mac_filter_enable = FALSE;
+               vap_info->u.bss_info.mac_filter_mode  = wifi_mac_filter_mode_black_list;
+        } else if(filterMode == 1) {
+               vap_info->u.bss_info.mac_filter_enable = TRUE;
+               vap_info->u.bss_info.mac_filter_mode  = wifi_mac_filter_mode_white_list;
+        } else if(filterMode == 2) {
+               vap_info->u.bss_info.mac_filter_enable = TRUE;
+               vap_info->u.bss_info.mac_filter_mode  = wifi_mac_filter_mode_black_list;
+        }
+    }
+
     return RETURN_OK;
 }
-
 
 //--------------------------------------------------------------------------------------------------
 INT wifi_getBssLoad(INT apIndex, BOOL *enabled)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13135,8 +13135,7 @@ int wifi_drv_set_ap(void *priv, struct wpa_driver_ap_params *params)
     }
 
 #if defined(NL80211_ACL) && !defined(PLATFORM_LINUX)
-    //TODO: Remove/Refine the check of !defined(PLATFORM_LINUX) based on
-    //support for ACL in latest versions of Raspberry PI driver.
+    //Raspberry Pi kernel requires patching to support ACL functionality.
     nl80211_put_acl(msg, interface);
 #endif
 


### PR DESCRIPTION
Add MAC ACL Support for RPI4 device

Reason for change: Added MAC ACL Support for Raspberry-Pi device by patching RPI kernel
                   Defined wifi_setApMacAddressControlMode function for setting the MAC address filter control
                   mode for the specified AP. The valid values are:
                         * 0: Filter disabled
                         * 1: Filter as whitelist
                         * 2: Filter as blacklist
Test Procedure: Ensure MAC ACL support is working as expected Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>