### PR TITLE
RDKB-58713: enable MBSSID feature only for XB7 and XB8

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -2023,9 +2023,11 @@ int update_hostap_config_params(wifi_radio_info_t *radio)
         iconf->vht_capab |= VHT_CAP_SUPP_CHAN_WIDTH_160MHZ;
     }
 
+#if defined(TCXB7_PORT) || defined(TCXB8_PORT)
 #if HOSTAPD_VERSION >= 210
     iconf->mbssid = param->band == WIFI_FREQUENCY_6_BAND ? MBSSID_ENABLED : MBSSID_DISABLED;
-#endif
+#endif /* HOSTAPD_VERSION >= 210 */
+#endif /* defined(TCXB7_PORT) || defined(TCXB8_PORT) */
 
     //validate_config_params
     if (hostapd_config_check(iconf, 1) < 0) {


### PR DESCRIPTION
Reason for change: VAP configuration issue on XB10
Test Procedure: check XB10 6GHz VAP is up
Risks: Low
Priority: P1