### PR TITLE
RDKBWIFI-24: Add vendor_ies to beacons/probes on hostapd_init_bss

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -141,7 +141,7 @@ void set_interface_vendor_ies(wifi_interface_info_t* interface) {
         if (platform_get_vendor_oui_fn(vendor_oui, sizeof(vendor_oui)) == 0) {
             wifi_hal_dbg_print("%s:%d: vendor_oui = %s \n", __func__, __LINE__,vendor_oui);
             
-            if (elems = wpabuf_parse_bin(vendor_oui)) {
+            if ((elems = wpabuf_parse_bin(vendor_oui)) != NULL) {
                 conf->vendor_elements = elems;
             }
         }


### PR DESCRIPTION
Facing below build error while building Comcast images.

> 11:19:53  | ../git/src/wifi_hal_hostapd.c:144:17: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
> 11:19:53  |   144 |             if (elems = wpabuf_parse_bin(vendor_oui)) {
> 11:19:53  |       |                 ^~~~~
> 11:19:53  | libtool: compile:  arm-rdk-linux-gnueabi-gcc -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a15 --
> Reason for change: To fix build errors while building Comcast images
> Risks: Low
> Priority: P0

Reason for change: To fix build failure for Comcast image
Risks: Low
Priority: P0
Testing Procedure: Modify `bss_info.vendor_elements` with valid elements before calling
    `createVAP` "somewhere" and verify with monitor mode that the VAP beacon
    and probe responses contain those vendor_elements.

Signed-off-by:  Sathish Kumar Gnanasekaran <sathishkumar_gnanasekaran@comcast.com>