### PR TITLE
XER5-240 : Enable CFLAGS '-Werror' in rdk-wifi-hal.bbappend

### DIFF
--- a/platform/qualcomm/platform_xer5.c
+++ b/platform/qualcomm/platform_xer5.c
@@ -26,6 +26,7 @@
 #define MAX_BUF_SIZE 300
 #define VAP_PREFIX "ath"
 #define RADIO_PREFIX "wifi"
+#define IPQ_XER5_MAX_NUM_RADIOS 2
 #define OUI_QCA "0x001374"
 #define RETRY_LIMIT 7
 
@@ -391,12 +392,12 @@ int is_interface_exists(const char *fname)
 //check if radio  present in info map
 int check_radio_index(uint8_t radio_index)
 {
-    radio_interface_mapping_t platform_map_t[MAX_NUM_RADIOS];
+    radio_interface_mapping_t platform_map_t[IPQ_XER5_MAX_NUM_RADIOS];
     uint8_t i = 0;
 
     get_radio_interface_info_map(platform_map_t);
 
-    for (i = 0; i < MAX_NUM_RADIOS ; i++) {
+    for (i = 0; i < IPQ_XER5_MAX_NUM_RADIOS  ; i++) {
         if (platform_map_t[i].radio_index == radio_index) {
 
             return 0;
@@ -415,7 +416,7 @@ int platform_post_init(wifi_vap_info_map_t *vap_map)
 
     wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
 
-    for (i = 0; i < MAX_NUM_RADIOS; i++) {
+    for (i = 0; i < IPQ_XER5_MAX_NUM_RADIOS ; i++) {
         if(i == RDK_2G_RADIO) {
             for (apIndex = 0; apIndex < MAX_NUM_VAP_PER_RADIO; apIndex++) {
                 if (isValidAPIndex(VAP_RADIO_2G[apIndex])) {
@@ -456,7 +457,7 @@ int platform_post_init(wifi_vap_info_map_t *vap_map)
 void getprivatevap2G(unsigned int *index)
 {
     unsigned int idx = 0;
-    wifi_interface_name_idex_map_t interface_map[(MAX_NUM_RADIOS * MAX_NUM_VAP_PER_RADIO)];
+    wifi_interface_name_idex_map_t interface_map[(IPQ_XER5_MAX_NUM_RADIOS  * MAX_NUM_VAP_PER_RADIO)];
     if (index == NULL) {
         wifi_hal_error_print("%s: NULL param error\n", __FUNCTION__);
         return;
@@ -476,7 +477,7 @@ void getprivatevap2G(unsigned int *index)
 void getprivatevap5G(unsigned int *index)
 {
     unsigned int idx = 0;
-    wifi_interface_name_idex_map_t interface_map[(MAX_NUM_RADIOS * MAX_NUM_VAP_PER_RADIO)];
+    wifi_interface_name_idex_map_t interface_map[(IPQ_XER5_MAX_NUM_RADIOS  * MAX_NUM_VAP_PER_RADIO)];
     if (index == NULL) {
         wifi_hal_error_print("%s: NULL param error\n", __FUNCTION__);
         return;
@@ -507,7 +508,7 @@ void qca_setRadioMode(wifi_radio_index_t index, wifi_radio_operationParam_t *ope
 
     variant = operationParam->variant; channelWidth = operationParam->channelWidth;
     //wifi_interface_name_idex_map_t *interface_map;
-    wifi_interface_name_idex_map_t interface_map[(MAX_NUM_RADIOS * MAX_NUM_VAP_PER_RADIO)];
+    wifi_interface_name_idex_map_t interface_map[(IPQ_XER5_MAX_NUM_RADIOS  * MAX_NUM_VAP_PER_RADIO)];
 
     get_wifi_interface_info_map(interface_map);
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13226,16 +13226,22 @@ int wifi_drv_set_ap(void *priv, struct wpa_driver_ap_params *params)
     interface->u.ap.hapd.iconf->beacon_rate = vap->u.bss_info.beaconRate;
 
     // update beacon rate type
-    if ((radio_param->variant & WIFI_80211_VARIANT_AX) ||
-        (radio_param->variant & WIFI_80211_VARIANT_BE)) {
+#if HOSTAPD_VERSION >= 210
+    if ((radio_param->variant & WIFI_80211_VARIANT_AX)
+#if HOSTAPD_VERSION >= 211
+        || (radio_param->variant & WIFI_80211_VARIANT_BE)
+#endif // HOSTAPD_VERSION >= 211
+    ) {
         params->rate_type = BEACON_RATE_HE;
-    } else if (radio_param->variant & WIFI_80211_VARIANT_AC) {
-        params->rate_type = BEACON_RATE_VHT;
-    } else if (radio_param->variant & WIFI_80211_VARIANT_N) {
-        params->rate_type = BEACON_RATE_HT;
-    } else {
-        params->rate_type = BEACON_RATE_LEGACY;
-    }
+    } else
+#endif // HOSTAPD_VERSION >= 210
+        if (radio_param->variant & WIFI_80211_VARIANT_AC) {
+            params->rate_type = BEACON_RATE_VHT;
+        } else if (radio_param->variant & WIFI_80211_VARIANT_N) {
+            params->rate_type = BEACON_RATE_HT;
+        } else {
+            params->rate_type = BEACON_RATE_LEGACY;
+        }
 
     beacon_set = params->reenable ? 0 : interface->beacon_set;
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13226,22 +13226,19 @@ int wifi_drv_set_ap(void *priv, struct wpa_driver_ap_params *params)
     interface->u.ap.hapd.iconf->beacon_rate = vap->u.bss_info.beaconRate;
 
     // update beacon rate type
-#if HOSTAPD_VERSION >= 210
-    if ((radio_param->variant & WIFI_80211_VARIANT_AX)
-#if HOSTAPD_VERSION >= 211
-        || (radio_param->variant & WIFI_80211_VARIANT_BE)
-#endif // HOSTAPD_VERSION >= 211
-    ) {
+
+    if ((radio_param->variant & WIFI_80211_VARIANT_AX) ||
+        (radio_param->variant & WIFI_80211_VARIANT_BE)) {
+#if HOSTAPD_VERSION >= 210	    
         params->rate_type = BEACON_RATE_HE;
-    } else
-#endif // HOSTAPD_VERSION >= 210
-        if (radio_param->variant & WIFI_80211_VARIANT_AC) {
-            params->rate_type = BEACON_RATE_VHT;
-        } else if (radio_param->variant & WIFI_80211_VARIANT_N) {
-            params->rate_type = BEACON_RATE_HT;
-        } else {
-            params->rate_type = BEACON_RATE_LEGACY;
-        }
+#endif // HOSTAPD_VERSION >= 210	    
+    } else if (radio_param->variant & WIFI_80211_VARIANT_AC) {
+        params->rate_type = BEACON_RATE_VHT;
+    } else if (radio_param->variant & WIFI_80211_VARIANT_N) {
+        params->rate_type = BEACON_RATE_HT;
+    } else {
+        params->rate_type = BEACON_RATE_LEGACY;
+    }
 
     beacon_set = params->reenable ? 0 : interface->beacon_set;
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -139,9 +139,11 @@ void prepare_interface_fdset(wifi_hal_priv_t *priv)
 {
     wifi_radio_info_t *radio;
     wifi_interface_info_t *interface;
-    wifi_vap_info_t *vap;
     unsigned int i;
+#ifndef EAPOL_OVER_NL
+    wifi_vap_info_t *vap;
     int sock_fd;
+#endif
 
     FD_ZERO(&priv->drv_rfds);
     FD_SET(priv->nl_event_fd, &priv->drv_rfds);
@@ -153,8 +155,8 @@ void prepare_interface_fdset(wifi_hal_priv_t *priv)
 
         while (interface != NULL) {
             if (interface->vap_configured == true && interface->bridge_configured == true) {
-                vap = &interface->vap_info;
 #ifndef EAPOL_OVER_NL
+                vap = &interface->vap_info;
                 sock_fd = (vap->vap_mode == wifi_vap_mode_ap) ?
                                     interface->u.ap.br_sock_fd:interface->u.sta.sta_sock_fd;
                 FD_SET(sock_fd, &priv->drv_rfds);
@@ -13112,10 +13114,7 @@ int process_bss_frame(struct nl_msg *msg, void *arg)
 {
     wifi_interface_info_t *interface;
     struct genlmsghdr *gnlh;
-    struct nlattr *tb[NL80211_ATTR_MAX + 1], *attr;
-    unsigned int len;
-    unsigned char cat;
-    wifi_vap_info_t *vap;
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
 
     gnlh = nlmsg_data(nlmsg_hdr(msg));
     nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL);
@@ -13601,8 +13600,7 @@ static int spurious_frame_register_handler(struct nl_msg *msg, void *arg)
 #ifdef EAPOL_OVER_NL
 int nl80211_register_bss_frames(wifi_interface_info_t *interface)
 {
-    struct nl_msg *msg = NULL;
-    int ret = 0, err = 1;
+    int err = 1;
 
     if (interface->bss_frames_registered == 1) {
         wifi_hal_info_print("%s:%d: bss frames handler already registered for %s\n", __func__,
@@ -13637,14 +13635,14 @@ int nl80211_register_bss_frames(wifi_interface_info_t *interface)
      * operations are blocked. Try to increase the buffer to make
      * this less likely to occur.
      */
-    err = nl_socket_set_buffer_size(interface->bss_nl_connect_event, NL_SOCK_MAX_BUF_SIZE, 0);
+    err = nl_socket_set_buffer_size((struct nl_sock *)interface->bss_nl_connect_event, NL_SOCK_MAX_BUF_SIZE, 0);
     if (err < 0) {
         wifi_hal_error_print("nl80211: Could not set nl_socket RX buffer size: %s",
                 nl_geterror(err));
         /* continue anyway with the default (smaller) buffer */
     }
 
-    nl_socket_set_nonblocking(interface->bss_nl_connect_event);
+    nl_socket_set_nonblocking((struct nl_sock *)interface->bss_nl_connect_event);
 
     interface->bss_nl_connect_event_fd = nl_socket_get_fd((struct nl_sock *)
             interface->bss_nl_connect_event);
@@ -13745,10 +13743,12 @@ error:
 int wifi_drv_set_operstate(void *priv, int state)
 {
     wifi_interface_info_t *interface;
-    struct sockaddr_ll sockaddr;
     wifi_vap_info_t *vap;
+#ifndef EAPOL_OVER_NL
+    struct sockaddr_ll sockaddr;
     int sock_fd;
     const char *ifname;
+#endif
 
     interface = (wifi_interface_info_t *)priv;
     vap = &interface->vap_info;
@@ -14126,7 +14126,7 @@ void* wifi_drv_init(struct hostapd_data *hapd, struct wpa_init_params *params)
 #ifdef EAPOL_OVER_NL
     if (nl80211_register_bss_frames(interface) != 0) {
         wifi_hal_error_print("%s:%d: Failed to register for bss frames\n", __func__, __LINE__);
-        return -1;
+        return NULL;
     }
 #endif
 


### PR DESCRIPTION
Reason for change: Fix warnings
Test Procedure: Verify XER5 build
Risks: None
Priority: P1