### PR TITLE
RDKB-58819: Sim client not connecting to AP with WPA2

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -1794,16 +1794,20 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
 #ifdef WIFI_EMULATOR_CHANGE
         send_mgmt_to_char_dev = true;
 #endif
+
+#if !defined(WIFI_EMULATOR_CHANGE)
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || \
-    defined(SKYSR213_PORT) || defined(SKYSR300_PORT) || defined(TCHCBRV2_PORT)
-        /* Authentication done in driver except SAE */
-        if (len >= IEEE80211_HDRLEN + sizeof(mgmt->u.auth) &&
-            le_to_host16(mgmt->u.auth.auth_alg) != WLAN_AUTH_SAE) {
-            forward_frame = false;
-        }
+		defined(SKYSR213_PORT) || defined(SKYSR300_PORT) || defined(TCHCBRV2_PORT)
+		/* Authentication done in driver except SAE */
+		if (len >= IEEE80211_HDRLEN + sizeof(mgmt->u.auth) &&
+				le_to_host16(mgmt->u.auth.auth_alg) != WLAN_AUTH_SAE) {
+			forward_frame = false;
+		}
 #endif /* defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) ||
-          defined(SCXER10_PORT) || defined(SKYSR213_PORT) || defined(SKYSR300_PORT) ||
-          defined(TCHCBRV2_PORT) */
+		 defined(SCXER10_PORT) || defined(SKYSR213_PORT) || defined(SKYSR300_PORT) ||
+		 defined(TCHCBRV2_PORT) */
+#endif //WIFI_EMULATOR_CHANGE
+
         break;
 
     case WLAN_FC_STYPE_ASSOC_REQ:


### PR DESCRIPTION
Reason for change:  enabled hostap authentication for rdk-wifi-emulator hal. so that WPA2 auth events will be forwarded and responded.
Test Procedure: Simulated client with WPA2 security should connect to AP in onewifitest suite
Risks: Low
Priority: P1