### PR TITLE
RDKB-58602: [rdk-wifi-hal] MultiVAP, WiFi backhaul as AL_MAC

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -38,7 +38,7 @@ Licensed under the BSD-3 License
 #define MAX_BUF_SIZE 128
 #define MAX_CMD_SIZE 1024
 #define RPI_LEN_32 32
-#define MAX_KEYPASSPHRASE_LEN 128
+#define MAX_KEYPASSPHRASE_LEN 129
 #define MAX_SSID_LEN 33
 #define INVALID_KEY                      "12345678"
 

--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -38,6 +38,8 @@ Licensed under the BSD-3 License
 #define MAX_BUF_SIZE 128
 #define MAX_CMD_SIZE 1024
 #define RPI_LEN_32 32
+#define MAX_KEYPASSPHRASE_LEN 128
+#define MAX_SSID_LEN 33
 #define INVALID_KEY                      "12345678"
 
 int wifi_nvram_defaultRead(char *in,char *out);
@@ -86,6 +88,17 @@ int wifi_nvram_defaultRead(char *in,char *out)
     position++;
     strncpy(out,position,strlen(position)+1);
     return 0; 
+}
+
+static int json_parse_backhaul_keypassphrase(char *backhaul_keypassphrase)
+{
+    return json_parse_string(EM_CFG_FILE, "Backhaul_KeyPassphrase", backhaul_keypassphrase,
+        MAX_KEYPASSPHRASE_LEN);
+}
+
+static int json_parse_backhaul_ssid(char *backhaul_ssid)
+{
+    return json_parse_string(EM_CFG_FILE, "Backhaul_SSID", backhaul_ssid, MAX_SSID_LEN);
 }
 
 int platform_pre_init()
@@ -158,21 +171,40 @@ int nvram_get_current_security_mode(wifi_security_modes_t *security_mode,int vap
 
 int platform_get_keypassphrase_default(char *password, int vap_index)
 {
-    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
-    /*password is not sensitive,won't grant access to real devices*/ 
-    wifi_nvram_defaultRead("rpi_wifi_password",password);
+    wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
+    /* if the vap_index is that of mesh STA then try to obtain the ssid from
+       /nvram/EasymeshCfg.json file */
+    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+        if (!json_parse_backhaul_keypassphrase(password)) {
+            wifi_hal_dbg_print("%s:%d, read password from jSON file\n", __func__, __LINE__);
+            return 0;
+        }
+    }
+    /*password is not sensitive,won't grant access to real devices*/
+    wifi_nvram_defaultRead("rpi_wifi_password", password);
     if (strlen(password) == 0) {
-       wifi_hal_error_print("%s:%d nvram default password not found, "
-           "enforced alternative default password\n", __func__, __LINE__);
-       strncpy(password, INVALID_KEY, strlen(INVALID_KEY) + 1);
+        wifi_hal_error_print("%s:%d nvram default password not found, "
+                             "enforced alternative default password\n",
+            __func__, __LINE__);
+        strncpy(password, INVALID_KEY, strlen(INVALID_KEY) + 1);
     }
     return 0;
 }
 
 int platform_get_ssid_default(char *ssid, int vap_index)
 {
-    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);   
-    sprintf(ssid,"RPI_RDKB-AP%d",vap_index);
+    int ret = 0;
+
+    wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
+    /* if the vap_index is that of mesh STA or mesh backhaul then try to obtain the ssid from
+       /nvram/EasymeshCfg.json file */
+    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+        if (!json_parse_backhaul_ssid(ssid)) {
+            wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
+            return 0;
+        }
+    }
+    sprintf(ssid, "RPI_RDKB-AP%d", vap_index);
     return 0;
 }
 
@@ -219,7 +251,7 @@ int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
 
 int platform_flags_init(int *flags)
 {
-    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
     *flags = PLATFORM_FLAGS_STA_INACTIVITY_TIMER;
     return 0;
 }

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -740,9 +740,7 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
                     interface->vap_info.u.bss_info.enabled, radio->configured,
                     radio->oper_param.enable);
                 if (radio->oper_param.enable && interface->vap_info.u.bss_info.enabled) {
-                    if (nl80211_interface_enable(interface->name, true) != 0 ||
-                    is_wifi_hal_vap_xhs(interface->vap_info.vap_index) ||
-                    is_wifi_hal_vap_lnf(interface->vap_info.vap_index)) {
+                    if (nl80211_interface_enable(interface->name, true) != 0) {
                         ret = nl80211_retry_interface_enable(interface, true);
                         if (ret != 0) {
                             wifi_hal_error_print("%s:%d: Retry of interface enable failed:%d\n",
@@ -1344,9 +1342,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
         if (radio->configured && radio->oper_param.enable) {
             wifi_hal_info_print("%s:%d: interface:%s set up\n", __func__, __LINE__,
                 interface->name);
-            if (nl80211_interface_enable(interface->name, true) != 0 ||
-                    is_wifi_hal_vap_xhs(interface->vap_info.vap_index) ||
-                    is_wifi_hal_vap_lnf(interface->vap_info.vap_index)) {
+            if (nl80211_interface_enable(interface->name, true) != 0) {
                 ret = nl80211_retry_interface_enable(interface, true);
                 if (ret != 0) {
                     wifi_hal_error_print("%s:%d: Retry of interface enable failed:%d\n", __func__,

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -141,7 +141,7 @@ void set_interface_vendor_ies(wifi_interface_info_t* interface) {
         if (platform_get_vendor_oui_fn(vendor_oui, sizeof(vendor_oui)) == 0) {
             wifi_hal_dbg_print("%s:%d: vendor_oui = %s \n", __func__, __LINE__,vendor_oui);
             
-            if (elems = wpabuf_parse_bin(vendor_oui)) {
+            if ((elems = wpabuf_parse_bin(vendor_oui)) != NULL) {
                 conf->vendor_elements = elems;
             }
         }
@@ -2562,7 +2562,8 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
             wpa_sm_set_param(sm, WPA_PARAM_PAIRWISE, WPA_CIPHER_NONE);
             wpa_sm_set_param(sm, WPA_PARAM_GROUP, WPA_CIPHER_NONE);
         } else {
-            sel = (WPA_KEY_MGMT_IEEE8021X | WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_PSK_SHA256 | wpa_key_mgmt_11w) & data.key_mgmt;
+            sel = (WPA_KEY_MGMT_SAE | WPA_KEY_MGMT_IEEE8021X | WPA_KEY_MGMT_PSK |
+                WPA_KEY_MGMT_PSK_SHA256 | wpa_key_mgmt_11w) & data.key_mgmt;
             key_mgmt = pick_akm_suite(sel); 
 
             if (key_mgmt == -1) {

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -394,6 +394,12 @@ int update_hostap_data(wifi_interface_info_t *interface)
 
     vap = &interface->vap_info;
 
+    if (vap->vap_mode != wifi_vap_mode_ap || is_wifi_hal_vap_mesh_sta(vap->vap_index)) {
+        wifi_hal_error_print("%s:%d: Not an AP based VAP. Returning error\n", __func__,
+            __LINE__);
+        return RETURN_ERR;
+    }
+
     radio = get_radio_by_rdk_index(vap->radio_index);
     iconf = &radio->iconf;
 
@@ -2567,8 +2573,8 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
             wpa_sm_set_param(sm, WPA_PARAM_KEY_MGMT, key_mgmt);
         }
 
-        wifi_hal_dbg_print("update_wpa_sm_params%x %x %x\n", data.group_cipher, data.pairwise_cipher,
-            key_mgmt);
+        wifi_hal_dbg_print("%s:%d:%x %x %x\n", __func__, __LINE__, data.group_cipher,
+            data.pairwise_cipher, key_mgmt);
     } else {
         if (sec->mode == wifi_security_mode_none) {
             wpa_sm_set_param(sm, WPA_PARAM_KEY_MGMT, WPA_KEY_MGMT_NONE);

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -107,6 +107,74 @@ void init_radius_config(wifi_interface_info_t *interface)
     }
 }
 
+void set_interface_vendor_ies(wifi_interface_info_t* interface) {
+
+
+    struct hostapd_bss_config *conf = NULL;
+    wifi_vap_info_t* vap_info = NULL;
+    USHORT ves_len = 0;
+    struct wpabuf* ve_wpabuf = NULL;
+
+    if (interface == NULL) {
+        wifi_hal_dbg_print("%s:%d: interface is NULL\n", __func__, __LINE__);
+        return;
+    }
+    if (interface->vap_info.vap_mode != wifi_vap_mode_ap) {
+        wifi_hal_dbg_print("%s:%d: interface is not AP mode\n", __func__, __LINE__);
+        return;
+    }
+    
+    conf = &interface->u.ap.conf;
+
+    if (conf->vendor_elements) {
+        // Free previously allocated vendor elements
+        wpabuf_free(conf->vendor_elements);
+        conf->vendor_elements = NULL;
+    }
+
+    /* Vendor OUI IEs */
+    platform_get_vendor_oui_t platform_get_vendor_oui_fn = get_platform_vendor_oui_fn();
+    if (platform_get_vendor_oui_fn != NULL) {
+        char vendor_oui[128] = {0};
+        struct wpabuf *elems = NULL;
+
+        if (platform_get_vendor_oui_fn(vendor_oui, sizeof(vendor_oui)) == 0) {
+            wifi_hal_dbg_print("%s:%d: vendor_oui = %s \n", __func__, __LINE__,vendor_oui);
+            
+            if (elems = wpabuf_parse_bin(vendor_oui)) {
+                conf->vendor_elements = elems;
+            }
+        }
+    }
+
+    // At this point, conf->vendor_elements is either NULL or allocated with 
+
+    // Add custom added vendor elements if allocated
+    vap_info = &interface->vap_info;
+    ves_len = vap_info->u.bss_info.vendor_elements_len;
+
+    wifi_hal_dbg_print("%s:%d: ves_len = %d\n", __func__, __LINE__, ves_len);
+
+    if (vap_info->vap_mode == wifi_vap_mode_ap && ves_len > 0
+                                               && (ve_wpabuf = wpabuf_alloc(ves_len))) {
+        UCHAR* ve_s = vap_info->u.bss_info.vendor_elements;
+
+        wpabuf_put_data(ve_wpabuf, (void*) ve_s, ves_len);
+        wifi_hal_info_print("%s:%d: Adding %d vendor elements\n", __func__, __LINE__, ves_len);
+        if (conf->vendor_elements) {
+            // Add custom vendor elements to vendor elements defined above (suchh as OUI, if any)
+            // The first conf->vendor_elements and ve_wpabuf are freed in the wpabuf_concat func
+            conf->vendor_elements = wpabuf_concat(conf->vendor_elements, ve_wpabuf);
+        } else {
+            // Set custom vendor IEs as vendor elements since no vendor IEs are defined previously
+            // Lifetime will be handled by hostapd 
+            conf->vendor_elements = ve_wpabuf;
+        }
+        wpa_hexdump_buf(MSG_DEBUG, "Created vendor elements:", conf->vendor_elements);
+    }
+}
+
+
 void init_hostap_bss(wifi_interface_info_t *interface)
 {
     struct hostapd_bss_config *conf;
@@ -250,22 +318,10 @@ void init_hostap_bss(wifi_interface_info_t *interface)
     conf->bss_load_update_period = 360000;
 #endif
 
-    /* Vendor Specific IE */
-    platform_get_vendor_oui_t platform_get_vendor_oui_fn = get_platform_vendor_oui_fn();
-    if (platform_get_vendor_oui_fn != NULL) {
-        char vendor_oui[128] = {0};
-        struct wpabuf *elems = NULL;
+    set_interface_vendor_ies(interface);
 
-        if (platform_get_vendor_oui_fn(vendor_oui, sizeof(vendor_oui)) == 0) {
-            wifi_hal_dbg_print("%s:%d: vendor_oui = %s \n", __func__, __LINE__,vendor_oui);
-            elems = wpabuf_parse_bin(vendor_oui);
-
-            if (elems) {
-                conf->vendor_elements = elems;
-            }
-        }
-    }
 }
+
 
 void init_oem_config(wifi_interface_info_t *interface)
 {

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -1794,16 +1794,20 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
 #ifdef WIFI_EMULATOR_CHANGE
         send_mgmt_to_char_dev = true;
 #endif
+
+#if !defined(WIFI_EMULATOR_CHANGE)
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || \
-    defined(SKYSR213_PORT) || defined(SKYSR300_PORT) || defined(TCHCBRV2_PORT)
-        /* Authentication done in driver except SAE */
-        if (len >= IEEE80211_HDRLEN + sizeof(mgmt->u.auth) &&
-            le_to_host16(mgmt->u.auth.auth_alg) != WLAN_AUTH_SAE) {
-            forward_frame = false;
-        }
+		defined(SKYSR213_PORT) || defined(SKYSR300_PORT) || defined(TCHCBRV2_PORT)
+		/* Authentication done in driver except SAE */
+		if (len >= IEEE80211_HDRLEN + sizeof(mgmt->u.auth) &&
+				le_to_host16(mgmt->u.auth.auth_alg) != WLAN_AUTH_SAE) {
+			forward_frame = false;
+		}
 #endif /* defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) ||
-          defined(SCXER10_PORT) || defined(SKYSR213_PORT) || defined(SKYSR300_PORT) ||
-          defined(TCHCBRV2_PORT) */
+		 defined(SCXER10_PORT) || defined(SKYSR213_PORT) || defined(SKYSR300_PORT) ||
+		 defined(TCHCBRV2_PORT) */
+#endif //WIFI_EMULATOR_CHANGE
+
         break;
 
     case WLAN_FC_STYPE_ASSOC_REQ:
@@ -7075,9 +7079,7 @@ Exit:
         interface = hash_map_get_first(radio->interface_map);
         while (interface != NULL) {
             if (interface->bss_started) {
-                if (nl80211_interface_enable(interface->name, true) != 0 ||
-                    is_wifi_hal_vap_xhs(interface->vap_info.vap_index) ||
-                    is_wifi_hal_vap_lnf(interface->vap_info.vap_index)) {
+                if (nl80211_interface_enable(interface->name, true) != 0) {
                     ret = nl80211_retry_interface_enable(interface, true);
                     if (ret != 0) {
                         wifi_hal_error_print("%s:%d: Retry of interface enable failed:%d\n",

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -571,7 +571,7 @@ static void nl80211_connect_event(wifi_interface_info_t *interface, struct nlatt
     }
 
     if (status != WLAN_STATUS_SUCCESS) {
-        wifi_hal_error_print("%s:%d: status code unsuccessful, returning\n", __func__, __LINE__);
+        wifi_hal_error_print("%s:%d: status code %d unsuccessful, returning\n", __func__, __LINE__, status);
         send_sta_connection_status_to_cb(backhaul->bssid, interface->vap_info.vap_index, wifi_connection_status_ap_not_found);
         return;    
     }

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -102,6 +102,8 @@ extern "C" {
     #define HOSTAPD_VERSION 209
 #endif
 
+#define EM_CFG_FILE "/nvram/EasymeshCfg.json"
+
 #ifdef CONFIG_WIFI_EMULATOR
 #define MAX_NUM_SIMULATED_CLIENT (MAX_NUM_RADIOS*100)
 #endif
@@ -850,6 +852,7 @@ int     nl80211_create_bridge(const char *if_name, const char *br_name);
 int     nl80211_remove_from_bridge(const char *if_name);
 int     nl80211_update_interface(wifi_interface_info_t *interface);
 int     nl80211_interface_enable(const char *ifname, bool enable);
+int     nl80211_retry_interface_enable(wifi_interface_info_t *interface, bool enable);
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
@@ -1062,6 +1065,10 @@ time_t get_boot_time_in_sec(void);
 int get_total_num_of_vaps(void);
 int wifi_setQamPlus(void *priv);
 int wifi_setApRetrylimit(void *priv);
+int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode);
+int json_parse_string(const char* file_name, const char *item_name, char *val, size_t len);
+int json_parse_integer(const char* file_name, const char *item_name, int *val);
+bool get_ifname_from_mac(const mac_address_t *mac, char *ifname);
 
 #ifdef CONFIG_IEEE80211BE
 int wifi_drv_set_ap_mlo(struct nl_msg *msg, void *priv, struct wpa_driver_ap_params *params);


### PR DESCRIPTION
Reason for change: Changes in wifi-hal to support MultiVAP configuration
and to support wlan interface as AL_MAC.

Change in platform_pi to read backhaul sta configuration
Change in other files to support backhaul sta connection in EM mode.
Change to read and update almac_address and colocated mode from
EasymeshCfg.json to OneWifi.
Change to retry enabling secondary interface when it fails for first
time by bringing down the primary interface, required for Canakit adapter