### PR TITLE
RDKB-58696: hal_cap.wifi_prop.numRadios is out of range

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -983,8 +983,6 @@ int nvram_get_current_ssid(char *l_ssid, int vap_index)
         }
     }
     strncpy(l_ssid, ssid, (len + 1));
-    wifi_hal_dbg_print("%s:%d vap[%d] ssid:%s nvram name:%s\r\n", __func__, __LINE__, vap_index,
-        l_ssid, nvram_name);
     return 0;
 }
 

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -971,11 +971,20 @@ int nvram_get_current_ssid(char *l_ssid, int vap_index)
     }
     len = strlen(ssid);
     if (len < 0 || len > 63) {
-        wifi_hal_error_print("%s:%d invalid ssid length [%d], expected length is [0..63]\r\n", __func__, __LINE__, len);
+        wifi_hal_error_print("%s:%d invalid ssid length [%d], expected length is [0..63]\r\n",
+            __func__, __LINE__, len);
         return -1;
     }
+    for (int i = 0; i < len; i++) {
+        if (!((ssid[i] >= ' ') && (ssid[i] <= '~'))) {
+            wifi_hal_error_print("%s:%d: Invalid character %c in SSID\r\n", __func__, __LINE__,
+                ssid[i]);
+            return -1;
+        }
+    }
     strncpy(l_ssid, ssid, (len + 1));
-    wifi_hal_dbg_print("%s:%d vap[%d] ssid:%s nvram name:%s\r\n", __func__, __LINE__, vap_index, l_ssid, nvram_name);
+    wifi_hal_dbg_print("%s:%d vap[%d] ssid:%s nvram name:%s\r\n", __func__, __LINE__, vap_index,
+        l_ssid, nvram_name);
     return 0;
 }
 


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms

Reason for change: During Ccsp to OneWifi migration, there's no validation for the invalid characters in SSID.

Test Procedure:
1. Load the device with CGA4332COM_6.7p11s1_PROD_sey.
2. And CDL the device to CGA4332COM_7.6p6s1_PROD_sey
3. And check for the log print hal_cap.wifi_prop.numRadios is out of range is flooding in /rdklogs/logs/wifiDMCLI.txt.

Risks: Medium

Priority: P1

Signed-off-by: sanjayvenkatesan1902@gmail.com