### PR TITLE
Add kernel patches for Raspberry Pi

### DIFF
--- a/platform/raspberry-pi/kernel-patches/0001-BSS-Tx-Action-frame-support-RPI.patch
+++ b/platform/raspberry-pi/kernel-patches/0001-BSS-Tx-Action-frame-support-RPI.patch
@@ -1,0 +1,152 @@
+From 7816e08ccdd7606bfd9e8138ad2ac70bda5be85a Mon Sep 17 00:00:00 2001
+From: Rakhil P E <rakhilpe001@gmail.com>
+Date: Mon, 23 Dec 2024 15:42:21 +0530
+Subject: [PATCH] Address the crash seen while sending action frame
+
+When an action frame was transmitted from a non-P2P interface,
+it resulted in a crash in kernel. This patch fixes the crash and
+sends out the action frame. Since there is lot of dependency on
+P2P interface while sending action frame in this driver, this patch
+only addresses sending of action frame but is not able to notify
+the TX status of frame sent.
+
+Signed-off-by: Amarnath Hullur Subramanyam <amarnath.hs@gmail.com>
+
+Added support for sending BSS Transition action frame
+
+Current RPI Kernel doesnt support sending BSS Transition action frame.
+Modified the code to add support for sending BSS Transition action
+frames as well.
+
+Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>
+---
+ .../broadcom/brcm80211/brcmfmac/p2p.c         | 71 ++++++++++++++++++-
+ 1 file changed, 68 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
+index 7376f9f37..c2dc274aa 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
+@@ -93,6 +93,10 @@
+ #define P2PSD_ACTION_ID_GAS_CREQ	0x0c	/* GAS Comeback Request AF */
+ #define P2PSD_ACTION_ID_GAS_CRESP	0x0d	/* GAS Comeback Response AF */
+ 
++/* P2P BSS Transition related  */
++#define P2P_WNM_TRANS_AF_CATEGORY       0x0a   /* WNM Action Frame */
++#define P2P_BSS_TR_MGMT_RQ_ACTION       0x07   /* BSS Transition Management Request */
++
+ #define BRCMF_P2P_DISABLE_TIMEOUT	msecs_to_jiffies(500)
+ 
+ /* Mask for retry counter of custom dwell time */
+@@ -195,6 +199,28 @@ struct brcmf_p2psd_gas_pub_act_frame {
+ 	u8	query_data[];
+ };
+ 
++/**
++ * struct brcmf_p2p_bss_transition_action_frame - WiFi P2P BSS Transition Management Frame
++ *
++ * @category: P2P_WNM_TRANS_AF_CATEGORY
++ * @action: P2P_BSS_TR_MGMT_RQ_ACTION
++ * @dialog_token: nonzero, identifies req/rsp transaction
++ * @req_mode: indicating the type of transition request
++ * @disassoc_timer: time until disassociation
++ * @validity_interval:  transition request validity interval
++ * @elts: Variable length information elements.
++ */
++
++struct brcmf_p2p_bss_transition_action_frame {
++	u8	category;
++	u8	action;
++	u8	dialog_token;
++	u8	req_mode;
++	u8	disassoc_timer[2];
++	u8	validity_interval;
++	u8	elts[];
++};
++
+ /**
+  * struct brcmf_config_af_params - Action Frame Parameters for tx.
+  *
+@@ -264,6 +290,26 @@ static bool brcmf_p2p_is_p2p_action(void *frame, u32 frame_len)
+ 	return false;
+ }
+ 
++static bool brcmf_p2p_is_bss_transition_action(void *frame, u32 frame_len)
++{
++	struct brcmf_p2p_bss_transition_action_frame *pbss_tr_frm;
++
++	if (frame == NULL)
++		return false;
++
++	pbss_tr_frm = (struct brcmf_p2p_bss_transition_action_frame *)frame;
++	if (frame_len < sizeof(*pbss_tr_frm))
++	{
++		return false;
++	}
++
++	if (pbss_tr_frm->category == P2P_WNM_TRANS_AF_CATEGORY &&
++	    pbss_tr_frm->action == P2P_BSS_TR_MGMT_RQ_ACTION)
++		return true;
++
++	return false;
++}
++
+ /**
+  * brcmf_p2p_is_gas_action() - true if p2p gas action type frame.
+  *
+@@ -1563,6 +1609,11 @@ static s32 brcmf_p2p_tx_action_frame(struct brcmf_p2p_info *p2p,
+ 	else
+ 		vif = p2p->bss_idx[P2PAPI_BSSCFG_DEVICE].vif;
+ 
++	if (vif == NULL) {
++		vif = p2p->bss_idx[P2PAPI_BSSCFG_PRIMARY].vif;
++		bphy_err(drvr, "%s:%d Using Primary Interface Vif:%p\n", __func__,__LINE__,vif);
++	}
++
+ 	err = brcmf_fil_bsscfg_data_set(vif->ifp, "actframe", af_params,
+ 					sizeof(*af_params));
+ 	if (err) {
+@@ -1584,7 +1635,17 @@ static s32 brcmf_p2p_tx_action_frame(struct brcmf_p2p_info *p2p,
+ 		  (p2p->wait_for_offchan_complete) ?
+ 		   "off-channel" : "on-channel");
+ 
+-	wait_for_completion_timeout(&p2p->send_af_done, P2P_AF_MAX_WAIT_TIME);
++	/* Wait for completion timeout only if vif used is not primary BSSCFG vif.
++           A crash is seen if wait for completion is invoked when action frame is
++           sent on primary BSSCFG Vif. */
++	if (vif != p2p->bss_idx[P2PAPI_BSSCFG_PRIMARY].vif) {
++		wait_for_completion_timeout(&p2p->send_af_done,
++					    P2P_AF_MAX_WAIT_TIME);
++	} else {
++		set_bit(BRCMF_P2P_STATUS_ACTION_TX_COMPLETED, &p2p->status);
++		if (!p2p->wait_for_offchan_complete)
++			complete(&p2p->send_af_done);
++	}
+ 
+ 	if (test_bit(BRCMF_P2P_STATUS_ACTION_TX_COMPLETED, &p2p->status)) {
+ 		brcmf_dbg(TRACE, "TX action frame operation is success\n");
+@@ -1796,6 +1857,10 @@ bool brcmf_p2p_send_action_frame(struct brcmf_cfg80211_info *cfg,
+ 					   action_frame_len)) {
+ 		/* do not configure anything. it will be */
+ 		/* sent with a default configuration     */
++	} else if (brcmf_p2p_is_bss_transition_action(action_frame->data,
++					   action_frame_len)) {
++		/* do not configure anything. it will be */
++		/* sent with a default configuration     */
+ 	} else {
+ 		bphy_err(drvr, "Unknown Frame: category 0x%x, action 0x%x\n",
+ 			 category, action);
+@@ -1805,8 +1870,8 @@ bool brcmf_p2p_send_action_frame(struct brcmf_cfg80211_info *cfg,
+ 	/* if connecting on primary iface, sleep for a while before sending
+ 	 * af tx for VSDB
+ 	 */
+-	if (test_bit(BRCMF_VIF_STATUS_CONNECTING,
+-		     &p2p->bss_idx[P2PAPI_BSSCFG_PRIMARY].vif->sme_state))
++	if (p2p->bss_idx[P2PAPI_BSSCFG_PRIMARY].vif && test_bit(BRCMF_VIF_STATUS_CONNECTING,
++			&p2p->bss_idx[P2PAPI_BSSCFG_PRIMARY].vif->sme_state))
+ 		msleep(50);
+ 
+ 	/* if scan is ongoing, abort current scan. */
+-- 
+2.25.1
+

--- a/platform/raspberry-pi/kernel-patches/0002-MAC-ACL-support-for-RPI.patch
+++ b/platform/raspberry-pi/kernel-patches/0002-MAC-ACL-support-for-RPI.patch
@@ -1,0 +1,190 @@
+From 7882aa931dec93a21c5a8853f4ef552bbda7b2d5 Mon Sep 17 00:00:00 2001
+From: Rakhil P E <Rakhil_PuthiyaveettilEdachena@comcast.com>
+Date: Thu, 6 Feb 2025 12:33:21 +0530
+Subject: [PATCH] Added MAC ACL support for RPI by modifying kernel and driver
+ code
+
+- Due to lack of access to RPI firmware and its lack of support for MAC mode, the implementation is done at the kernel level.
+- Modified relevant kernel modules and driver files to handle MAC ACL functionality.
+
+Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>
+---
+ .../broadcom/brcm80211/brcmfmac/cfg80211.c    | 76 +++++++++++++++++++
+ .../broadcom/brcm80211/brcmfmac/cfg80211.h    | 25 ++++++
+ 2 files changed, 101 insertions(+)
+
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
+index e19c14ba3..171dd236e 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
+@@ -5930,6 +5930,48 @@ static int brcmf_cfg80211_tdls_oper(struct wiphy *wiphy,
+ 	return ret;
+ }
+ 
++static int
++brcmf_cfg80211_set_mac_acl(struct wiphy *wiphy, struct net_device *ndev,
++                           const struct cfg80211_acl_data *acl)
++{
++    struct brcmf_cfg80211_info *cfg = wiphy_to_cfg(wiphy);
++    int i;
++    int macnum = 0;
++    int macmode = MACLIST_MODE_DISABLED;
++
++    /* if acl == NULL, macmode is still disabled.. */
++    if (!acl) {
++        brcmf_err("Null MAC ACL\n");
++        goto exit;
++    }
++
++    macnum = acl->n_acl_entries;
++    if (macnum < 0 || macnum > MAX_NUM_MAC_FILT) {
++        brcmf_err("invalid number of MAC address entries %d\n", macnum);
++        goto exit;
++    }
++
++    /* get the MAC filter mode */
++    if (acl && acl->acl_policy == NL80211_ACL_POLICY_DENY_UNLESS_LISTED) {
++        macmode = MACLIST_MODE_ALLOW;
++    } else if (acl && acl->acl_policy == NL80211_ACL_POLICY_ACCEPT_UNLESS_LISTED &&
++        acl->n_acl_entries) {
++        macmode = MACLIST_MODE_DENY;
++    }
++
++    cfg->mac_acl.acl_count = acl->n_acl_entries;
++    for (i = 0; i < acl->n_acl_entries; i++) {
++        brcmf_dbg(TRACE, "ACL-MAC : %pM\n", acl->mac_addrs[i].addr);
++        memcpy(cfg->mac_acl.acl_list[i], acl->mac_addrs[i].addr, ETH_ALEN);
++    }
++
++exit:
++    cfg->mac_acl.acl_mode = macmode;
++    brcmf_dbg(TRACE, "Updated ACL Data: mode=%d, count=%d\n", cfg->mac_acl.acl_mode,
++            cfg->mac_acl.acl_count);
++    return 0;
++}
++
+ static int
+ brcmf_cfg80211_update_conn_params(struct wiphy *wiphy,
+ 				  struct net_device *ndev,
+@@ -6091,6 +6133,7 @@ static struct cfg80211_ops brcmf_cfg80211_ops = {
+ 	.crit_proto_start = brcmf_cfg80211_crit_proto_start,
+ 	.crit_proto_stop = brcmf_cfg80211_crit_proto_stop,
+ 	.tdls_oper = brcmf_cfg80211_tdls_oper,
++	.set_mac_acl = brcmf_cfg80211_set_mac_acl,
+ 	.update_connect_params = brcmf_cfg80211_update_conn_params,
+ 	.set_pmk = brcmf_cfg80211_set_pmk,
+ 	.del_pmk = brcmf_cfg80211_del_pmk,
+@@ -6583,6 +6626,30 @@ brcmf_bss_connect_done(struct brcmf_cfg80211_info *cfg,
+ 	return 0;
+ }
+ 
++static bool brcmf_check_acl_cfg(struct brcmf_cfg80211_info *cfg, const u8 *mac_addr) {
++    int i;
++
++    if (cfg->mac_acl.acl_mode == MACLIST_MODE_DISABLED) {
++        return true;
++    }
++
++    for (i = 0; i < cfg->mac_acl.acl_count; i++) {
++        if (memcmp(cfg->mac_acl.acl_list[i], mac_addr, ETH_ALEN) == 0) {
++            if (cfg->mac_acl.acl_mode == MACLIST_MODE_ALLOW) {
++                return true;
++            } else {
++                return false;
++            }
++        }
++    }
++
++    if (cfg->mac_acl.acl_mode == MACLIST_MODE_ALLOW) {
++        return false;
++    } else {
++        return true;
++    }
++}
++
+ static s32
+ brcmf_notify_connect_status_ap(struct brcmf_cfg80211_info *cfg,
+ 			       struct net_device *ndev,
+@@ -6603,6 +6670,13 @@ brcmf_notify_connect_status_ap(struct brcmf_cfg80211_info *cfg,
+ 		return 0;
+ 	}
+ 
++	if ((event == BRCMF_E_ASSOC_IND) || (event == BRCMF_E_REASSOC_IND)) {
++		if (!brcmf_check_acl_cfg(cfg, e->addr)) {
++			brcmf_err("Connection denied for MAC: %pM\n", e->addr);
++			return 0;
++		}
++	}
++
+ 	if (((event == BRCMF_E_ASSOC_IND) || (event == BRCMF_E_REASSOC_IND)) &&
+ 	    (reason == BRCMF_E_STATUS_SUCCESS)) {
+ 		if (!data) {
+@@ -8575,6 +8649,8 @@ struct brcmf_cfg80211_info *brcmf_cfg80211_attach(struct brcmf_pub *drvr,
+ 	 */
+ 	drvr->config = cfg;
+ 
++	wiphy->max_acl_mac_addrs = MAX_NUM_MAC_FILT;
++
+ 	err = brcmf_setup_wiphy(wiphy, ifp);
+ 	if (err < 0)
+ 		goto priv_out;
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h
+index f6573da57..a37afbb32 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.h
+@@ -92,6 +92,16 @@
+ 
+ #define BRCMF_VIF_EVENT_TIMEOUT		msecs_to_jiffies(1500)
+ 
++/* hostap mac mode */
++#define MACLIST_MODE_DISABLED   0
++#define MACLIST_MODE_DENY       1
++#define MACLIST_MODE_ALLOW      2
++
++/* max number of mac filter list
++ * restrict max number to 10 as maximum cmd string size is 255
++ */
++#define MAX_NUM_MAC_FILT        10
++
+ /**
+  * enum brcmf_scan_status - scan engine status
+  *
+@@ -322,6 +332,19 @@ struct brcmf_cfg80211_wowl {
+ 	bool nd_enabled;
+ };
+ 
++/**
++ * struct brcmf_cfg80211_acl - acl related information.
++ *
++ * @acl_list: list of mac addresses
++ * @acl_count: current number of mac addresses
++ * @acl_mode: acl policy mode
++ */
++struct brcmf_cfg80211_acl {
++    u8 acl_list[MAX_NUM_MAC_FILT][ETH_ALEN];
++    int acl_count;
++    int acl_mode;
++};
++
+ /**
+  * struct brcmf_cfg80211_info - dongle private data of cfg80211 interface
+  *
+@@ -356,6 +379,7 @@ struct brcmf_cfg80211_wowl {
+  * @vif_event: vif event signalling.
+  * @wowl: wowl related information.
+  * @pno: information of pno module.
++ * @mac_acl: acl related information
+  */
+ struct brcmf_cfg80211_info {
+ 	struct wiphy *wiphy;
+@@ -389,6 +413,7 @@ struct brcmf_cfg80211_info {
+ 	struct brcmf_cfg80211_wowl wowl;
+ 	struct brcmf_pno_info *pno;
+ 	u8 ac_priority[MAX_8021D_PRIO];
++	struct brcmf_cfg80211_acl mac_acl;
+ };
+ 
+ /**
+-- 
+2.25.1
+

--- a/platform/raspberry-pi/kernel-patches/0003-Modified-the-code-to-support-sending-all-kind-of-act.patch
+++ b/platform/raspberry-pi/kernel-patches/0003-Modified-the-code-to-support-sending-all-kind-of-act.patch
@@ -1,0 +1,55 @@
+From a6a13b2ba2e5715e278049ab77b2c93b5872843a Mon Sep 17 00:00:00 2001
+From: Rakhil P E <Rakhil_PuthiyaveettilEdachena@comcast.com>
+Date: Thu, 27 Feb 2025 19:10:08 +0530
+Subject: [PATCH] Modified the code to support sending all kind of action
+ frames. Current code was patches earlier to support only BSS Tx action
+ frames.
+
+Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>
+---
+ .../wireless/broadcom/brcm80211/brcmfmac/p2p.c | 18 +++---------------
+ 1 file changed, 3 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
+index c2dc274aa..574059fa1 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/p2p.c
+@@ -290,24 +290,12 @@ static bool brcmf_p2p_is_p2p_action(void *frame, u32 frame_len)
+ 	return false;
+ }
+ 
+-static bool brcmf_p2p_is_bss_transition_action(void *frame, u32 frame_len)
++static bool brcmf_p2p_is_action_frame(void *frame, u32 frame_len)
+ {
+-	struct brcmf_p2p_bss_transition_action_frame *pbss_tr_frm;
+-
+ 	if (frame == NULL)
+ 		return false;
+ 
+-	pbss_tr_frm = (struct brcmf_p2p_bss_transition_action_frame *)frame;
+-	if (frame_len < sizeof(*pbss_tr_frm))
+-	{
+-		return false;
+-	}
+-
+-	if (pbss_tr_frm->category == P2P_WNM_TRANS_AF_CATEGORY &&
+-	    pbss_tr_frm->action == P2P_BSS_TR_MGMT_RQ_ACTION)
+-		return true;
+-
+-	return false;
++	return true;
+ }
+ 
+ /**
+@@ -1857,7 +1845,7 @@ bool brcmf_p2p_send_action_frame(struct brcmf_cfg80211_info *cfg,
+ 					   action_frame_len)) {
+ 		/* do not configure anything. it will be */
+ 		/* sent with a default configuration     */
+-	} else if (brcmf_p2p_is_bss_transition_action(action_frame->data,
++	} else if (brcmf_p2p_is_action_frame(action_frame->data,
+ 					   action_frame_len)) {
+ 		/* do not configure anything. it will be */
+ 		/* sent with a default configuration     */
+-- 
+2.25.1
+


### PR DESCRIPTION
Add kernel patches for Raspberry Pi

Patch 1 - Address-the-crash-seen-while-sending-action-frame
Patch 2  - Added-MAC-ACL-support-for-RPI-by-modifying-kernel
Patch 3 - Modified-the-code-to-support-sending-all-kind-of-action-frame