### PR TITLE
RDKB-58443 RDKB-58446 Add WPA3-Compatibility Configuration and Telemetry

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -2492,6 +2492,9 @@ static int decode_bss_info_to_neighbor_ap_info(wifi_neighbor_ap2_t *ap, const wi
         case wifi_security_mode_wpa3_enterprise:
             str = "WPA3-Enterprise";
             break;
+        case wifi_security_mode_wpa3_compatibility:
+            str = "WPA3-Compatibility";
+            break;
         default:
             str = "?";
     }
@@ -3849,6 +3852,20 @@ void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice
 
     callbacks->disassoc_cb[callbacks->num_disassoc_cbs] = func;
     callbacks->num_disassoc_cbs++;
+}
+
+void wifi_hal_stamode_callback_register(wifi_stamode_callback func)
+{
+    wifi_device_callbacks_t *callbacks;
+
+    callbacks = get_hal_device_callbacks();
+
+    if (callbacks == NULL || callbacks->num_stamode_cbs> MAX_REGISTERED_CB_NUM) {
+        return;
+    }
+
+    callbacks->stamode_cb[callbacks->num_stamode_cbs] = func;
+    callbacks->num_stamode_cbs++;
 }
 
 void wifi_hal_radius_eap_failure_callback_register(wifi_radiusEapFailure_callback func)

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -1785,6 +1785,8 @@ int get_security_mode_int_from_str(char *security_mode_str,char *mfp_str,wifi_se
         *security_mode = wifi_security_mode_wpa3_enterprise;
     } else if (strcmp(security_mode_str, "wpa wpa2") == 0) {
         *security_mode = wifi_security_mode_wpa_wpa2_enterprise;
+    } else if (strstr(security_mode_str, "psk2") && strstr(security_mode_str, "sae") && !strcmp(mfp_str, "0")) {
+        *security_mode = wifi_security_mode_wpa3_compatibility;
     } else {
         wifi_hal_error_print("%s:%d: wifi security mode not found:[%s:%s]\r\n",__func__, __LINE__, security_mode_str,mfp_str);
         return RETURN_ERR;
@@ -1875,6 +1877,10 @@ int get_security_mode_str_from_int(wifi_security_modes_t security_mode, unsigned
         strcpy(security_mode_str, "wpa wpa2");
         break;
 
+    case wifi_security_mode_wpa3_compatibility:
+        strcpy(security_mode_str, "psk2 sae");
+        break;
+
     default:
         wifi_hal_error_print("%s:%d: wifi security mode not found:[%d]\r\n",__func__, __LINE__, security_mode);
         return RETURN_ERR;
@@ -1907,6 +1913,7 @@ int get_security_encryption_mode_str_from_int(wifi_encryption_method_t encryptio
                 case wifi_security_mode_wpa3_personal:
                 case wifi_security_mode_wpa3_transition:
                 case wifi_security_mode_wpa3_enterprise:
+                case wifi_security_mode_wpa3_compatibility:
                     has_gcmp256 = !interface->u.ap.conf.disable_11be;
                     break;
                 default:

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -803,6 +803,7 @@ INT wifi_hal_configNeighborReports(UINT apIndex, bool enable, bool auto_resp);
 INT wifi_hal_setNeighborReports(UINT apIndex, UINT numNeighborReports, wifi_NeighborReport_t *neighborReports);
 void wifi_hal_newApAssociatedDevice_callback_register(wifi_newApAssociatedDevice_callback func);
 void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice_callback func);
+void wifi_hal_stamode_callback_register(wifi_stamode_callback func);
 void wifi_hal_radiusEapFailure_callback_register(wifi_radiusEapFailure_callback func);
 void wifi_hal_radiusFallback_failover_callback_register(wifi_radiusFallback_failover_callback func);
 void wifi_hal_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback func);

--- a/src/wifi_hal_rdk_framework.h
+++ b/src/wifi_hal_rdk_framework.h
@@ -133,6 +133,8 @@ typedef struct {
     unsigned int                            num_radius_fallback_failover_cbs;
     wifi_radiusFallback_failover_callback   radius_failover_fallback_cbs[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_vapstatus_cbs;
+    unsigned int                            num_stamode_cbs;
+    wifi_stamode_callback                   stamode_cb[MAX_REGISTERED_CB_NUM];
     queue_t                                 *queue;
     wifi_RMBeaconReport_callback            bcnrpt_callback[MAX_AP_INDEX];
     wifi_BTM_callbacks_t                    btm_callback[MAX_AP_INDEX];

--- a/src/wifi_hal_rdk_util.c
+++ b/src/wifi_hal_rdk_util.c
@@ -363,7 +363,7 @@ int validate_wifi_interface_vap_info_params(wifi_vap_info_t *vap_info, char *msg
     }
 
     // security parameter values
-    if (bss_info->security.mode <= 0 || bss_info->security.mode > wifi_security_mode_enhanced_open ||
+    if (bss_info->security.mode <= 0 || bss_info->security.mode >  wifi_security_mode_wpa3_compatibility ||
             (bss_info->security.mode &(bss_info->security.mode - 1)) != 0) {
         ret = RETURN_ERR;
         snprintf(msg + strlen(msg), len - strlen(msg), " security mode: %d", bss_info->security.mode);


### PR DESCRIPTION
Impacted Platforms:
Tech-XB7, Tech-XB8, CBRv2

Reason for change: To add WPA3-Personal-Compatibility mode in onewifi and rdk-wifi-hal

Test Procedure: Enable WPA3-Compatibility RFC and set security mode as
                WPA3-Personal-Compatibility.
                Check Client connectivity and internet

Risks: Medium
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com
Signed-off-by:Harshavardhan_Pulluru@comcast.com