### PR TITLE
XER5-1607: Revert g mode support change

### DIFF
--- a/platform/qualcomm/platform_xer5.c
+++ b/platform/qualcomm/platform_xer5.c
@@ -493,7 +493,6 @@ void getprivatevap5G(unsigned int *index)
 void qca_setRadioMode(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
 {
     unsigned int apindex = 0, i = 0; int band = -1;
-    size_t len = 0;
     char cmd[DEFAULT_CMD_SIZE] = {0};
     char tmp[DEFAULT_CMD_SIZE] = {0};
     char command[DEFAULT_CMD_SIZE] = {0};
@@ -625,12 +624,10 @@ void qca_setRadioMode(wifi_radio_index_t index, wifi_radio_operationParam_t *ope
     }
     while (fgets(buffer, sizeof(buffer), fp) != NULL) {
         strncpy(output, buffer, DEFAULT_CMD_SIZE);
-        output[strcspn(output, "\n")] = '\0';
     }
     pclose(fp);
 
-    len = strlen(output) > strlen(cmd) ? strlen(output) : strlen(cmd);
-    if (strncmp(output, cmd, len) != 0 ) {
+    if (strncmp(output, cmd, strlen(cmd)) != 0 ) {
         snprintf(tmp, DEFAULT_CMD_SIZE, "cfg80211tool %s%d mode %s",VAP_PREFIX,apindex,cmd);
         system(tmp);
     }


### PR DESCRIPTION
Reason for change: revert XER5-1348
Test Procedure: No issues with other builds
Risks: Medium
Priority: P1