### PR TITLE
RDKB-58446 Update sae_pwe for hostap-2.10 and above

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -483,7 +483,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
     conf->wpa_key_mgmt = 0;
 #if HOSTAPD_VERSION >= 210
     conf->wpa_key_mgmt_rsno = 0;
-#endif
+#endif /* HOSTAPD_VERSION >= 210 */
     conf->wpa = 0;
     memset(&test_ip, 0, sizeof(test_ip));
 
@@ -547,14 +547,14 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
 #else
             conf->sae_pwe = 0;
 #endif /* CONFIG_IEEE80211BE*/
-#endif
+#endif /* HOSTAPD_VERSION >= 210 */
             break;
         case wifi_security_mode_wpa3_compatibility:
             conf->wpa_key_mgmt = WPA_KEY_MGMT_PSK;
-            conf->sae_pwe = 1;
 #if HOSTAPD_VERSION >= 210
             conf->wpa_key_mgmt_rsno = WPA_KEY_MGMT_SAE;
-#endif
+            conf->sae_pwe = 1;
+#endif /* HOSTAPD_VERSION >= 210 */
             conf->auth_algs = WPA_AUTH_ALG_SAE | WPA_AUTH_ALG_SHARED | WPA_AUTH_ALG_OPEN;
             break;
         default:
@@ -610,7 +610,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
         conf->ieee80211w = (enum mfp_options) NO_MGMT_FRAME_PROTECTION;
 #if HOSTAPD_VERSION >= 210
         conf->ieee80211w_rsno = (enum mfp_options) MGMT_FRAME_PROTECTION_REQUIRED;
-#endif
+#endif /* HOSTAPD_VERSION >= 210 */
         conf->sae_require_mfp = 1;
     }
 #endif

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8395,7 +8395,7 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
                     wpa_conf.wpa_key_mgmt = WPA_KEY_MGMT_PSK;
 #if HOSTAPD_VERSION >= 210
                     wpa_conf.wpa_key_mgmt_rsno = WPA_KEY_MGMT_SAE;
-#endif
+#endif /* HOSTAPD_VERSION >= 210 */
                     break;
                 default:
                     wifi_hal_info_print("%s:%d:Invalid security mode: %d in wifi_hal_connect\r\n", __func__, __LINE__, security->mode);
@@ -16286,7 +16286,7 @@ const struct wpa_driver_ops g_wpa_driver_nl80211_ops = {
     .get_mbssid_ie = wifi_drv_get_mbssid_ie,
     .get_mbssid_config = wifi_drv_get_mbssid_config,
     .get_sta_auth_type = wifi_drv_get_sta_auth_type,
-#endif
+#endif /* HOSTAPD_VERSION >= 210 */
 };
 
 #ifdef CONFIG_WIFI_EMULATOR
@@ -16444,6 +16444,6 @@ const struct wpa_driver_ops g_wpa_supplicant_driver_nl80211_ops = {
 #endif
 #if HOSTAPD_VERSION >= 210
     .get_sta_auth_type = wifi_drv_get_sta_auth_type,
-#endif
+#endif /* HOSTAPD_VERSION >= 210 */
 };
 #endif //CONFIG_WIFI_EMULATOR


### PR DESCRIPTION
Impacted Platforms:
Tech-XB7, Tech-XB8, CBRv2, XB10

Reason for change: Update sae_pwe for hostap-2.10 and above

Test Procedure: Enable WPA3-Compatibility RFC and set security mode as
                Check Client connectivity and internet

Risks: Low
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com