### PR TITLE
RDKBDEV-3009 : Fix memory leaks in "rdk-wifi-hal"

### DIFF
--- a/src/wifi_hal_dpp.c
+++ b/src/wifi_hal_dpp.c
@@ -716,11 +716,9 @@ void dpp_build_config(wifi_device_dpp_context_t *ctx, char* str)
         if (out)
         {
             printf("%s\n",out);
-
             /*let input string have json */
             strcpy(str, out);
             free(out);
-            out = NULL;
         }
 	
 	return;

--- a/src/wifi_hal_dpp.c
+++ b/src/wifi_hal_dpp.c
@@ -492,6 +492,8 @@ EC_POINT *dpp_build_point_from_connector_string(wifi_device_dpp_context_t *ctx, 
 
 	printf("%s:%d: point built\n", __func__, __LINE__);
 
+       cJSON_Delete(connector_json);
+
 	return instance->responder_connector;
 }
 
@@ -711,10 +713,15 @@ void dpp_build_config(wifi_device_dpp_context_t *ctx, char* str)
 	}
 
 	out = cJSON_Print(root);
-    printf("%s\n",out);
+        if (out)
+        {
+            printf("%s\n",out);
 
-	/*let input string have json */
-	strcpy(str, out);
+            /*let input string have json */
+            strcpy(str, out);
+            free(out);
+            out = NULL;
+        }
 	
 	return;
 }


### PR DESCRIPTION
Reason for change: Fix memory leaks related to the usage of cJSON_Parse and cJSONPrint.
Test Procedure: Expected result - No memory leaks
Risks: None

Signed-off-by: venkatakrishna.vanga@cognizant.com