### PR TITLE
RDKB-59179:Resolving XLE Build failure(6G Keep-Out)

### DIFF
--- a/platform/xle/platform_xle.c
+++ b/platform/xle/platform_xle.c
@@ -365,6 +365,18 @@ int platform_update_radio_presence(void)
     return 0;
 }
 
+int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    return 0;
+}
+
+int platform_set_acs_exclusion_list(wifi_radio_index_t index,char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    return 0;
+}
+
 int nvram_get_mgmt_frame_power_control(int vap_index, int* output_dbm)
 {
     return 0;


### PR DESCRIPTION
MIssing platform callback inside platform_xle.c caused build to fail
Signed-off-by:RaviShankar.R_Rangaraj@comcast.com