### PR TITLE
RDKB-59089 : network connection between pi and gateway

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1323,7 +1323,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             memcpy(vap->u.bss_info.bssid, interface->mac, sizeof(vap->u.bss_info.bssid));
         } else {
             wifi_hal_info_print("%s:%d: vap_enable_status:%d\n", __func__, __LINE__, vap->u.sta_info.enabled);
-#ifndef CONFIG_WIFI_EMULATOR
+#if  !defined(CONFIG_WIFI_EMULATOR) && !defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
             memcpy(vap->u.sta_info.mac, interface->mac, sizeof(vap->u.sta_info.mac));
 #else
             mac_addr_str_t sta_mac_str;
@@ -1332,7 +1332,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             memcpy(interface->vap_info.u.sta_info.mac, vap->u.sta_info.mac, sizeof(mac_address_t));
             key = to_mac_str(interface->vap_info.u.sta_info.mac, sta_mac_str);
             wifi_hal_dbg_print("%s:%d: sta mac is : %s\n", __func__, __LINE__, key);
-#endif
+#endif //!defined(CONFIG_WIFI_EMULATOR) || !defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
         }
         memcpy((unsigned char *)&interface->vap_info, (unsigned char *)vap, sizeof(wifi_vap_info_t));
 
@@ -1508,7 +1508,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             }
 
         } else if (vap->vap_mode == wifi_vap_mode_sta) {
-#ifdef CONFIG_WIFI_EMULATOR
+#if defined(CONFIG_WIFI_EMULATOR) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
             if (nl80211_create_bridge(interface->name, vap->bridge_name) != 0) {
                 wifi_hal_error_print("%s:%d: interface:%s failed to create bridge:%s\n",
                         __func__, __LINE__, interface->name, vap->bridge_name);
@@ -1536,7 +1536,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                     interface->name);
                 nl80211_interface_enable(interface->name, false);
             }
-#endif
+#endif //CONFIG_WIFI_EMULATOR || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
         }
 
         if (vap->vap_mode == wifi_vap_mode_ap) {

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -75,11 +75,11 @@
 #define KEY_MGMT_SAE_EXT 67108864
 #define MAX_MBSSID_INTERFACES 8
 
-#ifdef WIFI_EMULATOR_CHANGE
+#if defined(WIFI_EMULATOR_CHANGE) ||  defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 static unsigned char eapol_qos_info[] = {0x88,0x02,0x3c,0x00,0x04,0xf0,0x21,0x5f,0x03,0x7c,0xe2,0xdb,0xd1,0xe4,0xdf,0x53,0xe2,0xdb,0xd1,0xe4,0xdf,0x53,0x10,0x00,0x05,0x00};
 
 static unsigned char llc_info[] = {0xaa, 0xaa, 0x03, 0x00,0x00,0x00,0x88,0x8e};
-#endif
+#endif // defined(WIFI_EMULATOR_CHANGE) ||  defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 
 static int scan_info_handler(struct nl_msg *msg, void *arg);
 static int nl80211_register_mgmt_frames(wifi_interface_info_t *interface);
@@ -124,7 +124,7 @@ struct sock_filter bpf_filter[6] = {
 
 struct sock_fprog bpf = { 6, bpf_filter };
 
-#ifdef WIFI_EMULATOR_CHANGE
+#if defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 typedef enum {
     wlan_emu_msg_type_none,
     wlan_emu_msg_type_emu80211,
@@ -133,7 +133,7 @@ typedef enum {
     wlan_emu_msg_type_frm80211,
     wlan_emu_msg_type_webconfig
 } wlan_emu_msg_type_t;
-#endif
+#endif //defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 
 void prepare_interface_fdset(wifi_hal_priv_t *priv)
 {
@@ -2283,6 +2283,64 @@ static int get_eapol_reply_counter(uint8_t *data, size_t data_len)
     return eapol_key->replay_counter[WPA_REPLAY_COUNTER_LEN - 1];
 }
 
+#if defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
+static void push_eapol_to_char_dev(char *buff, int buflen, struct ieee8023_hdr *eth_hdr)
+{
+    int fd_c = -1;
+    unsigned char c_buff[2048];
+    unsigned char *t_buff = c_buff;
+    unsigned int type = wlan_emu_msg_type_frm80211, ops_type = 0;
+#ifdef WIFI_EMULATOR_CHANGE
+    if ((access(ONEWIFI_TESTSUITE_TMPFILE, R_OK)) == 0)
+#endif
+    {
+        fd_c = open("/dev/rdkfmac_dev", O_RDWR);
+        if (fd_c < 0) {
+            wifi_hal_info_print("%s:%d: failed to open to char dev\n", __func__, __LINE__);
+            return;
+        }
+        memset(t_buff, 0, 2048);
+        memcpy(t_buff, &type, sizeof(unsigned int));
+        t_buff += sizeof(unsigned int);
+
+        memcpy(t_buff, &ops_type, sizeof(unsigned int));
+        t_buff += sizeof(unsigned int);
+
+        unsigned int len = buflen + sizeof(eapol_qos_info) + sizeof(llc_info);
+        memcpy(t_buff, &len, sizeof(unsigned int));
+        t_buff += sizeof(unsigned int);
+
+        memcpy(t_buff, eth_hdr->src, ETH_ALEN);
+        t_buff += ETH_ALEN;
+
+        memcpy(t_buff, eth_hdr->dest, ETH_ALEN);
+        t_buff += ETH_ALEN;
+
+        memcpy(eapol_qos_info + 4, eth_hdr->dest, ETH_ALEN);
+        memcpy(eapol_qos_info + 10, eth_hdr->src, ETH_ALEN);
+        memcpy(eapol_qos_info + 10 + ETH_ALEN, eth_hdr->src, ETH_ALEN);
+        memcpy(t_buff, eapol_qos_info, sizeof(eapol_qos_info));
+        t_buff += sizeof(eapol_qos_info);
+
+        memcpy(t_buff, llc_info, sizeof(llc_info));
+        t_buff += sizeof(llc_info);
+
+        unsigned char *eapol_tmp_buff = NULL;
+
+        eapol_tmp_buff = buff + 14;
+
+        memcpy(t_buff, eapol_tmp_buff, len);
+
+        if (write(fd_c, c_buff, 2048) < 0) {
+            wifi_hal_error_print("%s:%d: failed to write to char dev\n", __func__, __LINE__);
+        }
+
+        close(fd_c);
+    }
+    return;
+}
+#endif //defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
+
 void recv_data_frame(wifi_interface_info_t *interface)
 {
     unsigned char buff[2048];
@@ -2295,9 +2353,6 @@ void recv_data_frame(wifi_interface_info_t *interface)
     union wpa_event_data event;
     struct ieee802_1x_hdr *hdr;
     mac_addr_str_t src_mac_str, dst_mac_str;
-#ifdef WIFI_EMULATOR_CHANGE
-    static int fd_c = -1;
-#endif
 
     vap = &interface->vap_info;
     saddr_len = sizeof(saddr);
@@ -2510,60 +2565,11 @@ void recv_data_frame(wifi_interface_info_t *interface)
 #if HOSTAPD_VERSION >= 211
         event.eapol_rx.link_id = NL80211_DRV_LINK_ID_NA;
 #endif /* HOSTAPD_VERSION >= 211 */
-        //Capture the EAPOL frames 2 and 4 on AP
-#ifdef WIFI_EMULATOR_CHANGE
-        if ((access(ONEWIFI_TESTSUITE_TMPFILE, R_OK)) == 0) {
-            if (fd_c < 0) {
-                fd_c = open("/dev/rdkfmac_dev", O_RDWR);
-                if (fd_c < 0) {
-                    wifi_hal_info_print("%s:%d: failed to open to char dev\n", __func__, __LINE__);
-                }
-            }
-            if (fd_c > 0) {
-                unsigned char c_buff[2048];
-                unsigned char *t_buff = c_buff;
-                unsigned int type = wlan_emu_msg_type_frm80211, ops_type = 0;
-                memset(t_buff, 0, 2048);
-                memcpy(t_buff, &type, sizeof(unsigned int));
-                t_buff += sizeof(unsigned int);
 
-                memcpy(t_buff, &ops_type, sizeof(unsigned int));
-                t_buff += sizeof(unsigned int);
-
-                unsigned int len = buflen + sizeof(eapol_qos_info) + sizeof(llc_info);
-                memcpy(t_buff, &len, sizeof(unsigned int));
-                t_buff += sizeof(unsigned int);
-
-                memcpy(t_buff, eth_hdr->src, ETH_ALEN);
-                t_buff += ETH_ALEN;
-
-                memcpy(t_buff, eth_hdr->dest, ETH_ALEN);
-                t_buff += ETH_ALEN;
-
-                memcpy(eapol_qos_info+4, eth_hdr->dest, ETH_ALEN);
-                memcpy(eapol_qos_info+10, eth_hdr->src, ETH_ALEN);
-                memcpy(eapol_qos_info+10+ETH_ALEN, eth_hdr->src, ETH_ALEN);
-                memcpy(t_buff, eapol_qos_info, sizeof(eapol_qos_info));
-                t_buff += sizeof(eapol_qos_info);
-
-                memcpy(t_buff, llc_info, sizeof(llc_info));
-                t_buff += sizeof(llc_info);
-
-                unsigned char *eapol_tmp_buff = NULL;
-
-                eapol_tmp_buff = buff + 14;
-
-                memcpy(t_buff, eapol_tmp_buff, len);
-
-                if (write(fd_c, c_buff, 2048) > 0) {
-//                    wifi_hal_dbg_print("%s:%d: write succesful bytes written : %d for EAPOL data\n", __func__, __LINE__, len);
-                }
-
-                close(fd_c);
-                fd_c = -1;
-            }
-        }
-#endif
+#if defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
+        //Capture the EAPOL frames.
+        push_eapol_to_char_dev(buff, buflen, eth_hdr);
+#endif //defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 
         buflen -= sizeof(struct ieee8023_hdr);
         wifi_hal_info_print("%s:%d: interface:%s received eapol m%d from:%s to:%s "
@@ -2576,6 +2582,10 @@ void recv_data_frame(wifi_interface_info_t *interface)
         wpa_supplicant_event(&interface->u.ap.hapd, EVENT_EAPOL_RX, &event);
         pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
     } else if (vap->vap_mode == wifi_vap_mode_sta) {
+#if defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
+        //Capture the EAPOL frames.
+        push_eapol_to_char_dev(buff, buflen, eth_hdr);
+#endif //defined(WIFI_EMULATOR_CHANGE) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
         if (interface->u.sta.wpa_sm) {
 #if HOSTAPD_VERSION >= 211 //2.11
             if (!interface->u.sta.wpa_sm->eapol || !eapol_sm_rx_eapol(interface->u.sta.wpa_sm->eapol,(unsigned char *)&sta,


### PR DESCRIPTION
Reason for change: Changes for getting EAPOL pcaps for external client. Test Procedure: On Ext client connection we should see eapol pcaps on cci. Risks: Low
Priority:P0