### PR TITLE
RDKB-59259: Change to use operatingClass variable of wifi_radio_operation_t

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -698,10 +698,10 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
         return WIFI_HAL_INVALID_ARGUMENTS;
     }
 
-    operationParam->op_class = op_class;
+    operationParam->operatingClass = op_class;
 
     wifi_hal_info_print("%s:%d:Index:%d Country: %d, Channel: %d, Op Class:%d\n",
-        __func__, __LINE__, index, operationParam->countryCode, operationParam->channel, operationParam->op_class);
+        __func__, __LINE__, index, operationParam->countryCode, operationParam->channel, operationParam->operatingClass);
 
     radio = get_radio_by_rdk_index(index);
     if (radio == NULL) {
@@ -849,7 +849,7 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
         radio->oper_param.channelWidth != operationParam->channelWidth;
     if (radio->configured && radio->oper_param.enable && is_channel_changed) {
         radio->oper_param.channel = operationParam->channel;
-        radio->oper_param.op_class = operationParam->op_class;
+        radio->oper_param.operatingClass = operationParam->operatingClass;
         radio->oper_param.channelWidth = operationParam->channelWidth;
         radio->oper_param.autoChannelEnabled = operationParam->autoChannelEnabled;
         radio->oper_param.DfsEnabledBootup = operationParam->DfsEnabledBootup;
@@ -1772,7 +1772,7 @@ INT wifi_hal_getScanResults(wifi_radio_index_t index, wifi_channel_t *channel, w
         if (radio_param->band != channel->band) {
             wifi_hal_error_print("%s:%d: Channel not valid on radio index: %d band : 0x%x\n", __func__, __LINE__, index, channel->band);
             return RETURN_ERR;
-        } else if ((freq = ieee80211_chan_to_freq(country, radio_param->op_class, channel->channel)) == -1) {
+        } else if ((freq = ieee80211_chan_to_freq(country, radio_param->operatingClass, channel->channel)) == -1) {
             wifi_hal_error_print("%s:%d: Channel argument error for index : %d channel : %d\n", __func__, __LINE__, index, channel->channel);
             return RETURN_ERR;
         }
@@ -2836,7 +2836,7 @@ INT wifi_hal_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, I
         return RETURN_ERR;
     }
 
-    op_class = radio->oper_param.op_class;
+    op_class = radio->oper_param.operatingClass;
     {
         unsigned global_op_class = country_to_global_op_class(country, op_class);
         wifi_hal_stats_dbg_print("%s:%d: [SCAN] country code: %s, op_class:%d, global_op_class:%d\n",
@@ -2937,7 +2937,7 @@ INT wifi_hal_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, I
     }
 
     wifi_hal_stats_dbg_print("%s:%d: [SCAN] oper_param.opclass:%d, oper_param.channel:%d\n", __func__,
-        __LINE__, radio->oper_param.op_class, radio->oper_param.channel);
+        __LINE__, radio->oper_param.operatingClass, radio->oper_param.channel);
     switch (scan_mode) {
     case WIFI_RADIO_SCAN_MODE_ONCHAN: {
         // - get the current channel

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1470,7 +1470,7 @@ int update_hostap_iface(wifi_interface_info_t *interface)
     iface->basic_rates = radio->basic_rates[band];
 
     get_coutry_str_from_code(param->countryCode, country);
-    iface->freq = ieee80211_chan_to_freq(country, param->op_class, param->channel);
+    iface->freq = ieee80211_chan_to_freq(country, param->operatingClass, param->channel);
 
 #if defined(CONFIG_HW_CAPABILITIES)
     iface->current_mode = get_hw_mode(iface);
@@ -1614,9 +1614,9 @@ int update_hostap_iface(wifi_interface_info_t *interface)
 
     hostapd_set_oper_centr_freq_seg0_idx(interface->u.ap.hapd.iconf, seg0);
 
-    global_op_class = (unsigned int) country_to_global_op_class(country, (unsigned char)param->op_class);
+    global_op_class = (unsigned int) country_to_global_op_class(country, (unsigned char)param->operatingClass);
     wifi_hal_info_print("%s:%d:interface name:%s country:%s op class:%d global op class:%d channel:%d frequency:%d center_freq1:%d\n", __func__, __LINE__, 
-        interface->name, country, param->op_class, global_op_class, param->channel, iface->freq, cf1);
+        interface->name, country, param->operatingClass, global_op_class, param->channel, iface->freq, cf1);
     if (interface->u.ap.iface_initialized == false) {
         dl_list_init(&iface->sta_seen);
         interface->u.ap.iface_initialized = true;
@@ -1982,7 +1982,7 @@ int update_hostap_config_params(wifi_radio_info_t *radio)
     iconf->acs = param->autoChannelEnabled;
     iconf->channel = param->channel;
 #if HOSTAPD_VERSION >= 210
-    iconf->op_class = param->op_class;
+    iconf->op_class = param->operatingClass;
 #endif
 
     get_coutry_str_from_oper_params(param, iconf->country);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -6824,9 +6824,9 @@ static int nl80211_fill_chandef(struct nl_msg *msg, wifi_radio_info_t *radio, wi
     param = &radio->oper_param;
 
     get_coutry_str_from_code(param->countryCode, country);
-    freq = ieee80211_chan_to_freq(country, param->op_class, param->channel);
+    freq = ieee80211_chan_to_freq(country, param->operatingClass, param->channel);
     freq1 = freq;
-    wifi_hal_dbg_print("%s:%d: index= %d Country = %s, country code = %d, channel = :%d op_class = %d \n", __func__, __LINE__, radio->index, country, param->countryCode, param->channel, param->op_class);
+    wifi_hal_dbg_print("%s:%d: index= %d Country = %s, country code = %d, channel = :%d op_class = %d \n", __func__, __LINE__, radio->index, country, param->countryCode, param->channel, param->operatingClass);
     switch (param->channelWidth) {
         case WIFI_CHANNELBANDWIDTH_20MHZ:
             width = NL80211_CHAN_WIDTH_20;
@@ -6891,7 +6891,7 @@ int nl80211_switch_channel(wifi_radio_info_t *radio)
 
     param = &radio->oper_param;
     get_coutry_str_from_code(param->countryCode, country);
-    freq = ieee80211_chan_to_freq(country, param->op_class, param->channel);
+    freq = ieee80211_chan_to_freq(country, param->operatingClass, param->channel);
     freq1 = freq;
     sec_chan_offset = get_sec_channel_offset(radio, freq);
 
@@ -6949,7 +6949,7 @@ int nl80211_switch_channel(wifi_radio_info_t *radio)
     os_memset(&csa_settings.freq_params, 0, sizeof(struct hostapd_freq_params));
 
     csa_settings.freq_params.mode = radio->iconf.hw_mode;
-    csa_settings.freq_params.freq = ieee80211_chan_to_freq(country, param->op_class, param->channel);
+    csa_settings.freq_params.freq = ieee80211_chan_to_freq(country, param->operatingClass, param->channel);
     csa_settings.freq_params.channel = param->channel;
     csa_settings.freq_params.ht_enabled = radio->iconf.ieee80211n;
     csa_settings.freq_params.vht_enabled = radio->iconf.ieee80211ac;
@@ -10686,7 +10686,7 @@ int wifi_drv_send_mlme(void *priv, const u8 *data,
 
     get_coutry_str_from_code(radio_param->countryCode, country);
 
-    interface_freq = ieee80211_chan_to_freq(country, radio_param->op_class,
+    interface_freq = ieee80211_chan_to_freq(country, radio_param->operatingClass,
           radio_param->channel);
 
 
@@ -10962,7 +10962,7 @@ int wifi_drv_sta_deauth(void *priv, const u8 *own_addr, const u8 *addr, u16 reas
 
     get_coutry_str_from_code(radio_param->countryCode, country);
 
-    freq = ieee80211_chan_to_freq(country, radio_param->op_class, radio_param->channel);
+    freq = ieee80211_chan_to_freq(country, radio_param->operatingClass, radio_param->channel);
 
     if (ieee80211_freq_to_chan(freq, &channel) ==
           HOSTAPD_MODE_IEEE80211AD) {
@@ -14809,7 +14809,7 @@ int nl80211_start_dfs_cac(wifi_radio_info_t *radio)
 
     param = &radio->oper_param;
     get_coutry_str_from_code(radio->oper_param.countryCode, country);
-    freq = ieee80211_chan_to_freq(country, radio->oper_param.op_class, radio->oper_param.channel);
+    freq = ieee80211_chan_to_freq(country, radio->oper_param.operatingClass, radio->oper_param.channel);
     freq1 = freq;
     sec_chan_offset = get_sec_channel_offset(radio, freq);
 
@@ -14866,7 +14866,7 @@ int nl80211_start_dfs_cac(wifi_radio_info_t *radio)
     pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
 
     wifi_hal_info_print("%s:%d iface_freq:%d freq:%d freq1:%d chan:%u seg0:%u sec_chan_offset:%d opclass:%u \n",__FUNCTION__, __LINE__, interface->u.ap.iface.freq, freq, freq1,
-                         radio->oper_param.channel, seg0, sec_chan_offset, radio->oper_param.op_class);
+                         radio->oper_param.channel, seg0, sec_chan_offset, radio->oper_param.operatingClass);
 
     update_hostap_iface(interface);
 
@@ -14902,7 +14902,7 @@ int nl80211_start_dfs_cac(wifi_radio_info_t *radio)
 
     if(res == 0) {
         wifi_hal_info_print("nl80211-%s:%d hostapd_handle_dfs success \n", __func__, __LINE__);
-        dfs_chan_change_event(interface->vap_info.radio_index, radio->oper_param.channel, radio->oper_param.channelWidth, radio->oper_param.op_class);
+        dfs_chan_change_event(interface->vap_info.radio_index, radio->oper_param.channel, radio->oper_param.channelWidth, radio->oper_param.operatingClass);
         nl80211_dfs_cac_started(interface, freq, radio->iconf.ieee80211n, sec_chan_offset, radio->oper_param.channelWidth,
                                 hostapd_get_oper_chwidth(interface->u.ap.hapd.iconf), freq1, 0);
         return RETURN_OK;
@@ -14933,7 +14933,7 @@ int set_freq_and_interface_enable(wifi_interface_info_t *interface, wifi_radio_i
     char country[8];
 
     get_coutry_str_from_code(radio->oper_param.countryCode, country);
-    freq = ieee80211_chan_to_freq(country, radio->oper_param.op_class, radio->oper_param.channel);
+    freq = ieee80211_chan_to_freq(country, radio->oper_param.operatingClass, radio->oper_param.channel);
     sec_chan_offset = get_sec_channel_offset(radio, freq);
 
     ht_enabled = radio->iconf.ieee80211n;
@@ -14954,7 +14954,7 @@ int set_freq_and_interface_enable(wifi_interface_info_t *interface, wifi_radio_i
         return RETURN_ERR;
     }
 
-    dfs_chan_change_event(interface->vap_info.radio_index, radio->oper_param.channel, radio->oper_param.channelWidth, radio->oper_param.op_class);
+    dfs_chan_change_event(interface->vap_info.radio_index, radio->oper_param.channel, radio->oper_param.channelWidth, radio->oper_param.operatingClass);
 #endif
     return RETURN_OK;
 }
@@ -14986,7 +14986,7 @@ int nl80211_dfs_cac_started(wifi_interface_info_t *interface, int freq, int ht_e
        radio_channel_param.sub_event = WIFI_EVENT_RADAR_CAC_STARTED;
        radio_channel_param.channel = radio->oper_param.channel;
        radio_channel_param.channelWidth = radio->oper_param.channelWidth;
-       radio_channel_param.op_class = radio->oper_param.op_class;
+       radio_channel_param.op_class = radio->oper_param.operatingClass;
        callbacks->channel_change_event_callback(radio_channel_param);
     }
 
@@ -15177,7 +15177,7 @@ int nl80211_dfs_radar_detected (wifi_interface_info_t *interface, int freq, int 
         wifi_hal_error_print("%s:%d update_channel_flags failed \n", __func__, __LINE__);
     }
 
-    dfs_chan_change_event(interface->vap_info.radio_index, radio->oper_param.channel, radio->oper_param.channelWidth, radio->oper_param.op_class);
+    dfs_chan_change_event(interface->vap_info.radio_index, radio->oper_param.channel, radio->oper_param.channelWidth, radio->oper_param.operatingClass);
 #endif /* defined(CMXB7_PORT) || defined(TCXB7_PORT) || defined(TCXB8_PORT) */
     return RETURN_OK;
 }
@@ -15458,7 +15458,7 @@ static u8* wifi_drv_get_rnr_colocation_ie(void *priv, u8 *eid, size_t *current_l
 
         tbtt_count_pos = eid++;
         *eid++ = RNR_TBTT_INFO_LEN;
-        *eid++ = radio->oper_param.op_class;
+        *eid++ = radio->oper_param.operatingClass;
         *eid++ = radio->oper_param.channel;
         len += RNR_TBTT_HEADER_LEN;
 

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -912,7 +912,7 @@ static void nl80211_ch_switch_notify_event(wifi_interface_info_t *interface, str
     if (wifi_chan_event_type == WIFI_EVENT_CHANNELS_CHANGED) {
         radio_param->channel = channel;
         radio_param->channelWidth = l_channel_width;
-        radio_param->op_class = op_class;
+        radio_param->operatingClass = op_class;
 
         ch_switch_update_hostap_config(radio, channel, op_class, freq, cf1, cf2,
             hostap_channel_width, l_channel_width);

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -2234,7 +2234,7 @@ int get_bw80_center_freq(wifi_radio_operationParam_t *param, const char *country
 
     for (i = 0; i < num_channels; i++) {
         if (param->channel <= (channels[i]+6)) {
-            freq = ieee80211_chan_to_freq(country, param->op_class, channels[i]);
+            freq = ieee80211_chan_to_freq(country, param->operatingClass, channels[i]);
             break;
         }
     }
@@ -2263,7 +2263,7 @@ int get_bw160_center_freq(wifi_radio_operationParam_t *param, const char *countr
 
     for (i = 0; i < num_channels; i++) {
         if (param->channel <= (channels[i]+14)) {
-            freq = ieee80211_chan_to_freq(country, param->op_class, channels[i]);
+            freq = ieee80211_chan_to_freq(country, param->operatingClass, channels[i]);
             break;
         }
     }
@@ -2288,7 +2288,7 @@ int get_bw320_center_freq(wifi_radio_operationParam_t *param, const char *countr
 
     for (i = 0; i < num_channels; i++) {
         if (param->channel <= (channels[i] + next_channel_start)) {
-            freq = ieee80211_chan_to_freq(country, param->op_class, channels[i]);
+            freq = ieee80211_chan_to_freq(country, param->operatingClass, channels[i]);
             break;
         }
     }


### PR DESCRIPTION
wifi_radio_operation_t structure has duplicate operating class variables op_class and operatingClass. Modify to use operatingClass and remove usage of op_class variable in rdk-wifi-hal.

Test Procedure: ssid change, radio info change tested with Easymesh agent and controller.