### PR TITLE
RDKB-59259: Change to use operatingClass variable of wifi_radio_operation_t

### DIFF
--- a/hal_ipc/server/hal_ipc_processors.c
+++ b/hal_ipc/server/hal_ipc_processors.c
@@ -42,7 +42,7 @@ int sync_hostapd_freq_param(unsigned int apIndex)
 
     get_coutry_str_from_code(radio_param->countryCode, country);
 
-    freq = ieee80211_chan_to_freq(country, radio_param->op_class, radio_param->channel);
+    freq = ieee80211_chan_to_freq(country, radio_param->operatingClass, radio_param->channel);
     if (interface->u.ap.hapd.iface->freq != freq) {
         wifi_hal_info_print("%s:%d: ap index:%u existing freq:%d curr freq:%d\n", __func__, __LINE__, apIndex, interface->u.ap.hapd.iface->freq, freq);
         interface->u.ap.hapd.iface->freq = freq;

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -1127,7 +1127,7 @@ static int get_control_side_band(wifi_radio_index_t index, wifi_radio_operationP
     radio = get_radio_by_rdk_index(index);
     get_coutry_str_from_code(operationParam->countryCode, country);
 
-    freq = ieee80211_chan_to_freq(country, operationParam->op_class, operationParam->channel);
+    freq = ieee80211_chan_to_freq(country, operationParam->operatingClass, operationParam->channel);
     sec_chan_offset = get_sec_channel_offset(radio, freq);
 
     return sec_chan_offset;


### PR DESCRIPTION
Address missing changes related to removal of op_class usage and instead use operatingClass variable of wifi_radio_operation_t structure seen as part of compilation.

Test Procedure: ssid change, radio info change tested with Easymesh agent and controller.