### PR TITLE
RDKB-58414: Update the NAS IP dynamically depending on the RADIUS server IP famil…

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -664,13 +664,6 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
         }
 
         char output[256] = {0};
-        _syscmd("sh /usr/sbin/deviceinfo.sh -eip", output, sizeof(output));
-
-        //own_ip_addr
-        if (inet_aton(output, &conf->own_ip_addr.u.v4)) {
-            conf->own_ip_addr.af = AF_INET;
-        }
-
         // nas_identifier
         memset(output, '\0', sizeof(output));
         _syscmd("sh /usr/sbin/deviceinfo.sh -emac", output, sizeof(output));


### PR DESCRIPTION
…y configured as we support IPv4 and IPv6 (#92)

RDKB-58414: Dynamically update NAS

Impacted Platforms:
All OneWifi Platforms using hostapd 2.10 & 2.11

Reason for change:We must dynamically update NAS IP to be in accordance with RADIUS IP Family.

Test Procedure: Enable Hotspot VAPs and connect clients. Simultaneously take erouter0 PCAPs. Check if NAS IP is updated properly as per RADIUS IP Family.

Risks: Low

Signed-off-by:Srijeyarankesh_JS@comcast.com

---------