### PR TITLE
RDKB-59304: set hostap auth configuration

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -1292,6 +1292,12 @@ static int platform_set_hostap_ctrl(wifi_radio_info_t *radio, uint vap_index, in
         }
     }
 
+    if (wl_iovar_set(interface_name, "usr_auth", &enable, sizeof(enable)) < 0) {
+        wifi_hal_error_print("%s:%d failed to set usr_auth %d for %s, err: %d (%s)\n", __func__,
+            __LINE__, enable, interface_name, errno, strerror(errno));
+        return RETURN_ERR;
+    }
+
     if (enable) {
         assoc_ctrl = ASSOC_HOSTAP_FULL_CTRL;
     } else if (is_wifi_hal_vap_hotspot_open(vap_index) ||

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -1796,20 +1796,6 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
 #ifdef WIFI_EMULATOR_CHANGE
         send_mgmt_to_char_dev = true;
 #endif
-
-#if !defined(WIFI_EMULATOR_CHANGE)
-#if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || \
-		defined(SKYSR213_PORT) || defined(SKYSR300_PORT) || defined(TCHCBRV2_PORT)
-		/* Authentication done in driver except SAE */
-		if (len >= IEEE80211_HDRLEN + sizeof(mgmt->u.auth) &&
-				le_to_host16(mgmt->u.auth.auth_alg) != WLAN_AUTH_SAE) {
-			forward_frame = false;
-		}
-#endif /* defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) ||
-		 defined(SCXER10_PORT) || defined(SKYSR213_PORT) || defined(SKYSR300_PORT) ||
-		 defined(TCHCBRV2_PORT) */
-#endif //WIFI_EMULATOR_CHANGE
-
         break;
 
     case WLAN_FC_STYPE_ASSOC_REQ:


### PR DESCRIPTION
Reason for change:
 - enable hostap auth reply
 - revert woraround to block hostap auth reply 
Test Procedure:
Risks: Low
Priority: P1