### PR TITLE
RDKB-59279: fixed capabilities for xb10 and xer10

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1407,6 +1407,11 @@ int update_hostap_iface(wifi_interface_info_t *interface)
 #ifdef CONFIG_IEEE80211AX
     struct he_capabilities *drv_he_cap;
 #endif
+#ifdef CONFIG_IEEE80211BE
+#if HOSTAPD_VERSION >= 211
+    struct eht_capabilities *drv_eht_cap;
+#endif // HOSTAPD_VERSION >= 211
+#endif // CONFIG_IEEE80211BE
 
     if (interface == NULL) {
         return RETURN_ERR;
@@ -1707,6 +1712,18 @@ int update_hostap_iface(wifi_interface_info_t *interface)
     }
 #endif
 #endif
+
+#ifdef CONFIG_IEEE80211BE
+#if HOSTAPD_VERSION >= 211
+    drv_eht_cap = &iface->current_mode->eht_capab[IEEE80211_MODE_AP];
+    iface->conf->eht_phy_capab.su_beamformer = !!(
+        drv_eht_cap->phy_cap[EHT_PHYCAP_SU_BEAMFORMER_IDX] & EHT_PHYCAP_SU_BEAMFORMER);
+    iface->conf->eht_phy_capab.su_beamformee = !!(
+        drv_eht_cap->phy_cap[EHT_PHYCAP_SU_BEAMFORMEE_IDX] & EHT_PHYCAP_SU_BEAMFORMEE);
+    iface->conf->eht_phy_capab.mu_beamformer = !!(
+        drv_eht_cap->phy_cap[EHT_PHYCAP_MU_BEAMFORMER_IDX] & EHT_PHYCAP_MU_BEAMFORMER_MASK);
+#endif // HOSTAPD_VERSION >= 211
+#endif // CONFIG_IEEE80211BE
 
     if(preassoc_supp_rates) {
       os_free(preassoc_supp_rates);


### PR DESCRIPTION
Reason for change: enable hostap mgt frame ctrl for xb10 and xer10 Test Procedure:
Risks: Low
Priority: P1