### PR TITLE
RDKBWIFI-31: Added off-channel mgmt frame sending + wait parameter

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -320,3 +320,14 @@ int platform_get_radio_caps(wifi_radio_index_t index)
     return 0;
 }
 
+
+INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
+{
+    int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);
+    return (res == 0) ? WIFI_HAL_SUCCESS : WIFI_HAL_ERROR;
+}
+
+INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
+{
+    return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
+}

--- a/platform/intel/platform.c
+++ b/platform/intel/platform.c
@@ -1580,9 +1580,15 @@ INT wifi_getApInterworkingServiceEnable(INT apIndex, BOOL *output_bool)
 }
 
 //--------------------------------------------------------------------------------------------------
-INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
+INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
 {
     return RETURN_ERR;
+}
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
+{
+    return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -766,10 +766,15 @@ INT wifi_getApInterworkingServiceEnable(INT apIndex, BOOL *output_bool)
     return 0;
 }
 
+INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
+{
+    int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);
+    return (res == 0) ? WIFI_HAL_SUCCESS : WIFI_HAL_ERROR;
+}
+
 INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
 {
-    wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency);
-    return RETURN_OK;
+    return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
 }
 
 INT wifi_setDownStreamGroupAddress(INT apIndex, BOOL disabled)

--- a/platform/wifi-emulator/platform_emulator.c
+++ b/platform/wifi-emulator/platform_emulator.c
@@ -711,10 +711,15 @@ INT wifi_getApInterworkingServiceEnable(INT apIndex, BOOL *output_bool)
     return 0;
 }
 
+INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
+{
+    int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);
+    return (res == 0) ? WIFI_HAL_SUCCESS : WIFI_HAL_ERROR;
+}
+
 INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
 {
-    wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency);
-    return RETURN_OK;
+    return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
 }
 
 INT wifi_setDownStreamGroupAddress(INT apIndex, BOOL disabled)

--- a/src/wifi_hal_anqp.c
+++ b/src/wifi_hal_anqp.c
@@ -656,7 +656,7 @@ INT wifi_anqpSendResponse(UINT apIndex, mac_address_t sta, unsigned char token, 
 
     wifi_sendActionFrame(apIndex, sta, freq, (unsigned char *)anqp_gas_initial_response_frame, sizeof(wifi_anqpResponseFrame_t) + total_length);
 #else
-    wifi_hal_send_mgmt_frame(apIndex,  sta,(unsigned char *)anqp_gas_initial_response_frame,(sizeof(wifi_anqpResponseFrame_t) + total_length),0);
+    wifi_hal_send_mgmt_frame(apIndex,  sta,(unsigned char *)anqp_gas_initial_response_frame,(sizeof(wifi_anqpResponseFrame_t) + total_length),0, 0);
 #endif
     wifi_anqp_dbg_print(1, "%s:%d: wifi_anqpSendResponse exit\n", __func__, __LINE__);
     return RETURN_OK;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9785,7 +9785,7 @@ int nl80211_update_beacon_params(wifi_interface_info_t *interface)
 }
 
 static int nl80211_send_frame_cmd(wifi_interface_info_t *interface,
-                                  unsigned int freq,
+                                  unsigned int freq, unsigned int wait,
                                   const u8 *buf, size_t buf_len,
                                   int save_cookie, int no_ack,
                                   const u16 *csa_offs,
@@ -9800,6 +9800,8 @@ static int nl80211_send_frame_cmd(wifi_interface_info_t *interface,
 
     if (!(msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_FRAME)) ||
         (freq && nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, freq)) ||
+	    (wait && nla_put_u32(msg, NL80211_ATTR_DURATION, wait)) ||
+	    ((freq != 0) && nla_put_flag(msg, NL80211_ATTR_OFFCHANNEL_TX_OK)) ||
         (no_ack && nla_put_flag(msg, NL80211_ATTR_DONT_WAIT_FOR_ACK)) ||
         (csa_offs && nla_put(msg, NL80211_ATTR_CSA_C_OFFSETS_TX,
                              csa_offs_len * sizeof(u16), csa_offs)) ||
@@ -10579,7 +10581,7 @@ int wifi_drv_send_action(void *priv,
         // *csa_offs = <csa offset data>
     }
 
-    ret = nl80211_send_frame_cmd(interface, freq, buf, 24 + data_len,
+    ret = nl80211_send_frame_cmd(interface, freq, wait_time, buf, 24 + data_len,
             use_cookie, no_ack, csa_offs, csa_offs_len);
 
     free(csa_offs);
@@ -10760,7 +10762,7 @@ int wifi_drv_send_mlme(void *priv, const u8 *data,
 send_frame_cmd:
 
     //wifi_hal_dbg_print("nl80211: send_mlme -> send_frame_cmd\n");
-    res = nl80211_send_frame_cmd(interface, freq, data, data_len,
+    res = nl80211_send_frame_cmd(interface, freq, wait, data, data_len,
               use_cookie, noack, csa_offs, csa_offs_len);
 
     return res;

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -1007,7 +1007,7 @@ int get_bw160_center_freq(wifi_radio_operationParam_t *param, const char *countr
 int get_bw320_center_freq(wifi_radio_operationParam_t *param, const char *country);
 #endif /* CONFIG_IEEE80211BE */
 int pick_akm_suite(int sel);
-void wifi_hal_send_mgmt_frame(int apIndex,mac_address_t sta, const u8 *data,size_t data_len,unsigned int freq);
+int wifi_hal_send_mgmt_frame(int apIndex,mac_address_t sta, const u8 *data,size_t data_len,unsigned int freq, unsigned int wait);
 int wifi_drv_sta_disassoc(void *priv, const u8 *own_addr, const u8 *addr, u16 reason);
 void wifi_hal_disassoc(int vap_index, int status, uint8_t *mac);
 #if HOSTAPD_VERSION >= 211 //2.11


### PR DESCRIPTION
**Depends on `halinterface` [PR #33](https://github.com/rdkcentral/rdkb-halif-wifi/pull/33)**

Reason for change: To allow for off-channel action-frame sending with an optionally provided time for the channel to wait/dwell/remain on.

Test procedure: 

For off channel scanning: Call the `wifi_sendActionFrame` with a `freq != 0` and observe the call in the `cfg_80211:rdev_mgmt_tx` and `cfg_80211:rdev_return_int_cookie` ftrace (example below) or in a monitor mode capture on that channel.
```shell
         OneWifi-68665   [003] ..... 123730.013302: rdev_mgmt_tx: phy1, wdev(1), band: 0, freq: 2437.000, offchan: true, wait: 0, no cck: false, dont wait for ack: true
         OneWifi-68665   [003] ..... 123730.013311: rdev_return_int_cookie: phy1, returned 0, cookie: 4294967295
```

For off-channel scanning + wait: Call the `wifi_sendActionFrameExt`  with `freq != 0` and `wait > 0` and observe the call in the `cfg_80211:rdev_mgmt_tx`, `cfg_80211:rdev_return_int_cookie`, and `cfg80211_tx_mgmt_expired` ftrace (example below).

```shell
         OneWifi-68665   [000] ..... 123676.248523: rdev_mgmt_tx: phy1, wdev(1), band: 1, freq: 5220.000, offchan: true, wait: 1000, no cck: false, dont wait for ack: true
         OneWifi-68665   [000] ..... 123676.248534: drv_remain_on_channel: phy1 vif:wlan1(2) freq:5220.000MHz duration:1000ms type=1
         OneWifi-68665   [000] ..... 123676.259291: drv_return_int: phy1 - 0
         OneWifi-68665   [000] ..... 123676.259295: rdev_return_int_cookie: phy1, returned 0, cookie: 4294967295
    kworker/u8:0-62116   [001] ..... 123677.276361: api_remain_on_channel_expired: phy1
   kworker/u10:0-62747   [001] ..... 123677.276384: cfg80211_tx_mgmt_expired: wdev(1), cookie: 4294967295, band: 1, freq: 5220.000
```

Priority: P1
Risks: Low

Addendum:
The risks are low because any existing code inside rdk-wifi-hal, OneWifi, and unified-wifi-mesh that uses `wifi_sendActionFrame` or `wifi_hal_send_mgmt_frame` that already passes `freq != 0` has the assumption that it will be sent on that frequency, despite what the current frequency of the device is. In the current version of the code, that assumption is false. This makes that assumption true. 