### PR TITLE
RDKB-59179:Porting 6G keep Out Channels list to stable2(main)

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -1,5 +1,9 @@
 #include <stddef.h>
 #include "wifi_hal.h"
+#if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)
+#include "typedefs.h"
+#include "bcmwifi_channels.h"
+#endif
 #include "wifi_hal_priv.h"
 #if defined(WLDM_21_2)
 #include "wlcsm_lib_api.h"
@@ -139,6 +143,61 @@ static int get_ccspwifiagent_interface_name_from_vap_index(unsigned int vap_inde
         return RETURN_ERR;
     }
     return RETURN_OK;
+}
+#endif
+
+#if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)
+unsigned int convert_channelBandwidth_to_bcmwifibandwidth(wifi_channelBandwidth_t chanWidth)
+{
+    switch(chanWidth)
+    {
+        case WIFI_CHANNELBANDWIDTH_20MHZ:
+            return WL_CHANSPEC_BW_20;
+        case WIFI_CHANNELBANDWIDTH_40MHZ:
+            return WL_CHANSPEC_BW_40;
+        case WIFI_CHANNELBANDWIDTH_80MHZ:
+            return WL_CHANSPEC_BW_80;
+        case WIFI_CHANNELBANDWIDTH_160MHZ:
+            return WL_CHANSPEC_BW_160;
+        case WIFI_CHANNELBANDWIDTH_80_80MHZ: //Made obselete by Broadcom
+            return WL_CHANSPEC_BW_8080;
+#ifdef CONFIG_IEEE80211BE
+        case WIFI_CHANNELBANDWIDTH_320MHZ:
+            return WL_CHANSPEC_BW_320;
+#endif
+        default:
+            wifi_hal_error_print("%s:%d Unable to find matching Broadcom bandwidth for incoming bandwidth = 0x%x\n",__func__,__LINE__,chanWidth);
+    }
+    return UINT_MAX;
+}
+
+unsigned int convert_radioindex_to_bcmband(unsigned int radioIndex)
+{
+    switch(radioIndex)
+    {
+        case 0:
+            return WL_CHANSPEC_BAND_2G;
+        case 1:
+            return WL_CHANSPEC_BAND_5G;
+        case 2:
+            return WL_CHANSPEC_BAND_6G;
+        default:
+            wifi_hal_info_print("%s:%d There is no matching Broadcom Band for radioIndex %u\n",__func__,__LINE__,radioIndex);
+    }
+    return UINT_MAX;
+}
+
+void convert_from_channellist_to_chspeclist(unsigned int bw, unsigned int band,wifi_channels_list_t chanlist, char* output_chanlist)
+{
+    int channel_list[chanlist.num_channels];
+    memcpy(channel_list,chanlist.channels_list,sizeof(channel_list));
+    for(int i=0;i<chanlist.num_channels;i++)
+    {
+        char buff[8];
+        chanspec_t chspec = wf_channel2chspec(channel_list[i],bw,band);
+        snprintf(buff,sizeof(buff),"0x%x,",chspec);
+        strcat(output_chanlist, buff);
+    }
 }
 #endif
 
@@ -402,6 +461,42 @@ static int enable_spect_management(int radio_index, int enable)
     return 0;
 }
 
+int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t chanlist, char* buff)
+{
+#if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)
+    unsigned int bw = convert_channelBandwidth_to_bcmwifibandwidth(bandwidth);
+    unsigned int band = convert_radioindex_to_bcmband(radioIndex);
+    if(bw != UINT_MAX && band != UINT_MAX)
+    {
+        convert_from_channellist_to_chspeclist(bw,band,chanlist,buff);
+    }
+    else
+    {
+        return RETURN_ERR;
+    }
+#endif
+    return RETURN_OK;
+}
+
+int platform_set_acs_exclusion_list(unsigned int radioIndex, char* str)
+{
+#if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)
+    char excl_chan_string[20];
+    snprintf(excl_chan_string,sizeof(excl_chan_string),"wl%u_acs_excl_chans",radioIndex);
+    if(str != NULL)
+    {
+        set_string_nvram_param(excl_chan_string,str);
+        nvram_commit();
+    }
+    else
+    {
+        nvram_unset(excl_chan_string);
+        nvram_commit();
+    }
+#endif
+    return RETURN_OK;
+}
+
 int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
 {
     if ((index < 0) || (operationParam == NULL)) {
@@ -494,6 +589,17 @@ int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationPa
             wifi_hal_dbg_print("%s():%d Enabling autoChannel in radio index %d\n", __FUNCTION__, __LINE__, index);
             sprintf(cmd, "acs_cli2 -i wl%d mode 2 &", index);
             system(cmd);
+
+            memset(cmd, 0 ,sizeof(cmd));
+            sprintf(cmd, "wl%d_acs_excl_chans", index);
+            char chanbuff[ACS_MAX_VECTOR_LEN];
+	        memset(chanbuff,0,sizeof(chanbuff));
+	        char *buff = nvram_get(cmd);
+            if(buff != NULL && (strcmp(buff,"") != 0))
+            {
+                sprintf(chanbuff, "acs_cli2 -i wl%d set acs_excl_chans %s &", index, buff);
+                system(chanbuff);
+            }
 
             /* Run acsd2 autochannel */
             memset(cmd, 0 ,sizeof(cmd));

--- a/platform/qualcomm/platform_xer5.c
+++ b/platform/qualcomm/platform_xer5.c
@@ -408,6 +408,18 @@ int check_radio_index(uint8_t radio_index)
     return -1;
 }
 
+int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_set_acs_exclusion_list(wifi_radio_index_t index,char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
 int platform_post_init(wifi_vap_info_map_t *vap_map)
 {
     char cmd[DEFAULT_CMD_SIZE];

--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -280,6 +280,18 @@ int platform_get_acl_num(int vap_index, uint *acl_count)
     return 0;
 }
 
+int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_set_acs_exclusion_list(wifi_radio_index_t index,char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
 int platform_get_vendor_oui(char *vendor_oui, int vendor_oui_len)
 {
     return -1;

--- a/platform/xle/platform_xle.c
+++ b/platform/xle/platform_xle.c
@@ -386,6 +386,18 @@ int platform_get_acl_num(int vap_index, uint *acl_count)
     return 0;
 }
 
+int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_set_acs_exclusion_list(wifi_radio_index_t index,char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
 int platform_get_vendor_oui(char *vendor_oui, int vendor_oui_len)
 {
     return -1;

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1563,6 +1563,41 @@ INT wifi_hal_getRadioVapInfoMap(wifi_radio_index_t index, wifi_vap_info_map_t *m
     return RETURN_OK;
 }
 
+INT wifi_hal_set_acs_keep_out_chans(wifi_radio_operationParam_t *wifi_radio_oper_param,
+    int radioIndex)
+{
+    char buff[ACS_MAX_VECTOR_LEN + 2];
+    char excl_chan_string[20];
+    memset(buff, 0, sizeof(buff));
+    snprintf(excl_chan_string, sizeof(excl_chan_string), "wl%u_acs_excl_chans", radioIndex);
+    if (!wifi_radio_oper_param) {
+        wifi_hal_error_print("%s:%d Null radio operation parameter, hence clearing entries\n", __func__, __LINE__);
+        return wifi_drv_set_acs_exclusion_list(radioIndex, NULL);
+    }
+    for (size_t i = 0; i < MAX_NUM_CHANNELBANDWIDTH_SUPPORTED; i++) {
+        wifi_channels_list_per_bandwidth_t *chans_per_band = 
+            &wifi_radio_oper_param->channels_per_bandwidth[i];
+        if (chans_per_band->num_channels_list == 0) {
+            continue;
+        }
+        wifi_channelBandwidth_t bandwidth = chans_per_band->chanwidth;
+        for (int j = 0; j < chans_per_band->num_channels_list; j++) {
+            wifi_channels_list_t chanlist = chans_per_band->channels_list[j];
+            if (wifi_drv_get_chspc_configs(radioIndex, bandwidth, 
+                                         chanlist, buff) != 0) {
+                wifi_hal_error_print("%s:%d Failed for radio %u bandwidth 0x%x\n",
+                                   __func__, __LINE__, radioIndex, bandwidth);
+                return RETURN_ERR;
+            }
+        }
+    }
+    size_t len = strlen(buff);
+    if (len > 0) {
+        buff[len - 1] = '\0';
+    }
+    return wifi_drv_set_acs_exclusion_list(radioIndex, buff);
+}
+
 INT wifi_hal_getScanResults(wifi_radio_index_t index, wifi_channel_t *channel, wifi_bss_info_t **bss, UINT *num_bss)
 {
     wifi_radio_info_t *radio;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13955,6 +13955,29 @@ int wifi_drv_set_offload_mode(void *priv, enum offload_mode offload_mode)
 #endif
 }
 
+int wifi_drv_set_acs_exclusion_list(unsigned int radioIndex, char* str)
+{
+    wifi_hal_dbg_print("%s:%d Enter\n",__func__,__LINE__);
+    platform_set_acs_exclusion_list_t platform_set_acs_exclusion_list_fn = get_platform_acs_exclusion_list_fn();
+    if (platform_set_acs_exclusion_list_fn != NULL){
+       return platform_set_acs_exclusion_list_fn(radioIndex, str);
+    } else {
+        return 0;
+    }
+}
+
+int wifi_drv_get_chspc_configs(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t chanlist, char* buff)
+{
+    wifi_hal_dbg_print("%s:%d Enter\n",__func__,__LINE__);
+    platform_get_chanspec_list_t platform_get_chanspec_list_fn = get_platform_chanspec_list_fn();
+    if(platform_get_chanspec_list_fn != NULL)
+    {
+        return platform_get_chanspec_list_fn(radioIndex,bandwidth,chanlist,buff);
+    } else {
+        return 0;
+    }
+}
+
 int wifi_drv_getApAclDeviceNum(int vap_index, uint *acl_count)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -378,6 +378,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -409,6 +411,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -440,6 +444,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -471,6 +477,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -503,6 +511,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -539,6 +549,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -570,6 +582,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -632,6 +646,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -663,6 +679,8 @@ const wifi_driver_info_t  driver_info = {
     platform_set_txpower,
     platform_set_offload_mode,
     platform_get_acl_num,
+    platform_get_chanspec_list,
+    platform_set_acs_exclusion_list,
     platform_get_vendor_oui,
     platform_set_neighbor_report,
     platform_get_radio_phytemperature,
@@ -2983,6 +3001,16 @@ platform_set_txpower_t get_platform_set_txpower_fn()
     return driver_info.platform_set_txpower_fn;
 }
 
+platform_set_acs_exclusion_list_t get_platform_acs_exclusion_list_fn()
+{
+    return driver_info.platform_set_acs_exclusion_list_fn;
+}
+
+platform_get_chanspec_list_t get_platform_chanspec_list_fn()
+{
+    return driver_info.platform_get_chanspec_list_fn;
+}
+
 platform_get_ApAclDeviceNum_t get_platform_ApAclDeviceNum_fn()
 {
     return driver_info.platform_get_ApAclDeviceNum_fn;
@@ -3469,6 +3497,17 @@ int wifi_bitrate_to_str(char *dest, size_t dest_size, wifi_bitrate_t bitrate)
     return wifi_enum_bitmap_to_str(dest, dest_size,
         wifi_bitrate_Map, ARRAY_SIZE(wifi_bitrate_Map),
         "", (int)bitrate);
+}
+
+int wifi_channelBandwidth_from_str(const char *str, wifi_channelBandwidth_t *bandwidth)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(wifi_bandwidth_Map); i++) {
+        if (strcasecmp(str, wifi_bandwidth_Map[i].str_val) == 0) {
+            *bandwidth = (wifi_channelBandwidth_t)wifi_bandwidth_Map[i].enum_val;
+            return 0;
+        }
+    }
+    return -1; 
 }
 
 #ifdef CONFIG_WIFI_EMULATOR

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -204,6 +204,7 @@ extern "C" {
 #define MAX_APPS 12
 
 #define SSID_MAX_LEN                32
+#define ACS_MAX_VECTOR_LEN  (256 * 7) /* Max Possible non operable (Exclude) chanspecs in a radio is 256*/
 
 #if HOSTAPD_VERSION >= 211
 #define CHANWIDTH_320MHZ CONF_OPER_CHWIDTH_320MHZ
@@ -587,6 +588,8 @@ typedef int    (* platform_update_radio_presence_t)();
 typedef int    (* platform_set_txpower_t)(void* priv, uint txpower);
 typedef int    (* platform_set_offload_mode_t)(void* priv, uint offload_mode);
 typedef int    (* platform_get_ApAclDeviceNum_t)(int vap_index, uint *acl_count);
+typedef int    (* platform_get_chanspec_list_t)(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char *buff);
+typedef int    (* platform_set_acs_exclusion_list_t)(unsigned int radioIndex, char* str);
 typedef int    (* platform_get_vendor_oui_t)(char* vendor_oui, int vendor_oui_len);
 typedef int    (* platform_set_neighbor_report_t)(uint apIndex, uint add, mac_address_t mac);
 typedef int    (* platform_get_radio_phytemperature_t)(wifi_radio_index_t index, wifi_radioTemperature_t *radioPhyTemperature);
@@ -654,6 +657,8 @@ typedef struct {
     platform_set_txpower_t            platform_set_txpower_fn;
     platform_set_offload_mode_t       platform_set_offload_mode_fn;
     platform_get_ApAclDeviceNum_t     platform_get_ApAclDeviceNum_fn;
+    platform_get_chanspec_list_t      platform_get_chanspec_list_fn;
+    platform_set_acs_exclusion_list_t platform_set_acs_exclusion_list_fn;
     platform_get_vendor_oui_t         platform_get_vendor_oui_fn;
     platform_set_neighbor_report_t    platform_set_neighbor_report_fn;
     platform_get_radio_phytemperature_t platform_get_radio_phytemperature_fn;
@@ -685,6 +690,7 @@ INT wifi_hal_getRadioVapInfoMap(wifi_radio_index_t index, wifi_vap_info_map_t *m
 INT wifi_hal_setApWpsButtonPush(INT apIndex);
 INT wifi_hal_setApWpsPin(INT ap_index, char *wps_pin);
 INT wifi_hal_setApWpsCancel(INT ap_index);
+INT wifi_hal_set_acs_keep_out_chans(wifi_radio_operationParam_t *wifi_radio_oper_param, int radioIndex);
 INT wifi_hal_sendDataFrame(int vap_id, unsigned char *dmac, unsigned char *data_buff, int data_len, BOOL insert_llc, int protocal, int priority);
 #ifdef WIFI_HAL_VERSION_3_PHASE2
 INT wifi_hal_addApAclDevice(INT apIndex, mac_address_t DeviceMacAddress);
@@ -741,6 +747,7 @@ int create_ecomode_interfaces(void);
 void update_ecomode_radio_capabilities(wifi_radio_info_t *radio);
 int convert_string_to_int(int **int_list, char *val);
 int print_rate_list(int *list);
+int wifi_channelBandwidth_from_str(const char *str, wifi_channelBandwidth_t *bandwidth);
 int convert_string_mcs_to_int(char *string_mcs);
 int init_nl80211();
 void wifi_hal_nl80211_wps_pbc(unsigned int ap_index);
@@ -943,6 +950,8 @@ int nvram_get_mgmt_frame_power_control(int vap_index, int* output_dbm);
 int nl80211_set_regulatory_domain(wifi_countrycode_type_t country_code);
 int platform_get_channel_bandwidth(wifi_radio_index_t index, wifi_channelBandwidth_t *channelWidth);
 int wifi_drv_getApAclDeviceNum(int vap_index, uint *acl_count);
+int wifi_drv_get_chspc_configs(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char* buff);
+int wifi_drv_set_acs_exclusion_list(unsigned int radioIndex, char* str);
 int platform_get_acl_num(int vap_index, uint *acl_hal_count);
 
 int get_total_num_of_vaps(void);
@@ -1003,6 +1012,8 @@ extern int platform_free_aid(void* priv, u16* aid);
 extern int platform_sync_done(void* priv);
 extern int platform_update_radio_presence(void);
 extern int platform_set_txpower(void* priv, uint txpower);
+extern int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char *buff);
+extern int platform_set_acs_exclusion_list(unsigned int radioIndex, char* str);
 extern int platform_get_vendor_oui(char* vendor_oui, int vendor_oui_len);
 extern int platform_set_neighbor_report(uint apIndex, uint add, mac_address_t mac);
 extern int platform_get_radio_phytemperature(wifi_radio_index_t index, wifi_radioTemperature_t *radioPhyTemperature);
@@ -1056,6 +1067,8 @@ platform_sync_done_t                get_platform_sync_done_fn();
 platform_update_radio_presence_t    get_platform_update_radio_presence_fn();
 platform_set_txpower_t              get_platform_set_txpower_fn();
 platform_get_ApAclDeviceNum_t get_platform_ApAclDeviceNum_fn();
+platform_get_chanspec_list_t        get_platform_chanspec_list_fn();
+platform_set_acs_exclusion_list_t   get_platform_acs_exclusion_list_fn();
 platform_get_vendor_oui_t           get_platform_vendor_oui_fn();
 platform_set_neighbor_report_t      get_platform_set_neighbor_report_fn();
 platform_get_radio_phytemperature_t get_platform_get_radio_phytemperature_fn();


### PR DESCRIPTION
RDKB-59179:6G Keep Out Channels list

Impacted Platforms:
OneWifi platforms

Reason for change: OneWifi platforms with 6G Radios must be able to exclude specific channels which are sent by MeshAgent

Test Procedure: Send the configuration via blob/multipartRoot and try to see if the excluded channels are not selected by giving a reboot/OneWifi restart.

Risks: Low

Signed-off-by:Srijeyarankesh_JS@comcast.com1