### PR TITLE
RDKBACCL-673 : Observing runtime errors in EM Agent

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -15,6 +15,14 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
+*
+* Some material is:
+* Copyright (c) 2002-2015, Jouni Malinen j@w1.fi
+* Copyright (c) 2003-2004, Instant802 Networks, Inc.
+* Copyright (c) 2005-2006, Devicescape Software, Inc.
+* Copyright (c) 2007, Johannes Berg johannes@sipsolutions.net
+* Copyright (c) 2009-2010, Atheros Communications
+* Licensed under the BSD-3 License
 **************************************************************************/
 
 #include <stddef.h>
@@ -29,9 +37,17 @@
 #define MAX_CMD_SIZE 1024
 #define BPI_LEN_32 32
 #define BPI_LEN_16 16
+#define MAX_KEYPASSPHRASE_LEN 129
+#define MAX_SSID_LEN 33
+#define INVALID_KEY  "12345678"
 
 int wifi_nvram_defaultRead(char *in,char *out);
 int _syscmd(char *cmd, char *retBuf, int retBufSize);
+
+typedef struct {
+    mac_address_t *macs;
+    unsigned int num;
+} sta_list_t;
 
 int wifi_nvram_defaultRead(char *in,char *out)
 {
@@ -68,6 +84,17 @@ int wifi_nvram_defaultRead(char *in,char *out)
     position++;
     strncpy(out,position,strlen(position)+1);
     return 0; 
+}
+
+static int json_parse_backhaul_keypassphrase(char *backhaul_keypassphrase)
+{
+    return json_parse_string(EM_CFG_FILE, "Backhaul_KeyPassphrase", backhaul_keypassphrase,
+        MAX_KEYPASSPHRASE_LEN);
+}
+
+static int json_parse_backhaul_ssid(char *backhaul_ssid)
+{
+    return json_parse_string(EM_CFG_FILE, "Backhaul_SSID", backhaul_ssid, MAX_SSID_LEN);
 }
 
 int platform_pre_init()
@@ -142,14 +169,36 @@ int nvram_get_current_security_mode(wifi_security_modes_t *security_mode,int vap
 int platform_get_keypassphrase_default(char *password, int vap_index)
 {
     wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
+    /* if the vap_index is that of mesh STA then try to obtain the ssid from
+       /nvram/EasymeshCfg.json file */
+    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+        if (!json_parse_backhaul_keypassphrase(password)) {
+            wifi_hal_dbg_print("%s:%d, read password from jSON file\n", __func__, __LINE__);
+            return 0;
+        }
+    }
     /*password is not sensitive,won't grant access to real devices*/ 
     wifi_nvram_defaultRead("bpi_wifi_password",password);
+    if (strlen(password) == 0) {
+        wifi_hal_error_print("%s:%d nvram default password not found, "
+                             "enforced alternative default password\n",
+            __func__, __LINE__);
+        strncpy(password, INVALID_KEY, strlen(INVALID_KEY) + 1);
+    }
     return 0;
 }
 
 int platform_get_ssid_default(char *ssid, int vap_index)
 {
-    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);   
+    wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
+    /* if the vap_index is that of mesh STA or mesh backhaul then try to obtain the ssid from
+       /nvram/EasymeshCfg.json file */
+    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+        if (!json_parse_backhaul_ssid(ssid)) {
+            wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
+            return 0;
+        }
+    }
     snprintf(ssid,BPI_LEN_16,"BPI_RDKB-AP%d",vap_index);
     return 0;
 }
@@ -331,3 +380,338 @@ INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCH
 {
     return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
 }
+
+INT wifi_getApManagementFramePowerControl(INT apIndex, INT *output_dBm)
+{
+    return 0;
+}
+
+INT wifi_getRadioChannelStats(INT radioIndex, wifi_channelStats_t *input_output_channelStats_array,
+    INT array_size)
+{
+    return RETURN_OK;
+}
+
+static int get_sta_list_handler(struct nl_msg *msg, void *arg)
+{
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    sta_list_t *sta_list = (sta_list_t *)arg;
+
+    if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0),
+        NULL) < 0) {
+        wifi_hal_stats_error_print("%s:%d Failed to parse sta data\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (tb[NL80211_ATTR_MAC]) {
+        sta_list->macs = realloc(sta_list->macs, (sta_list->num + 1) * sizeof(mac_address_t));
+        if (sta_list->macs) {
+            memcpy(sta_list->macs[sta_list->num], nla_data(tb[NL80211_ATTR_MAC]), sizeof(mac_address_t));
+            sta_list->num++;
+        }
+    }
+
+    return NL_OK;
+}
+
+static int get_sta_list(wifi_interface_info_t *interface, sta_list_t *sta_list)
+{
+    int ret;
+    struct nl_msg *msg = NULL;
+
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, NLM_F_DUMP, NL80211_CMD_GET_STATION);
+    if (msg == NULL) {
+        wifi_hal_stats_error_print("%s:%d Failed to create NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    ret = nl80211_send_and_recv(msg, get_sta_list_handler, sta_list, NULL, NULL);
+    if (ret < 0) {
+        wifi_hal_stats_error_print("%s:%d Failed to execute NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
+{
+    wifi_associated_dev3_t *dev = (wifi_associated_dev3_t *)arg;
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
+    struct nlattr *stats[NL80211_STA_INFO_MAX + 1];
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1] = {
+                [NL80211_STA_INFO_INACTIVE_TIME] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_RX_BYTES] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_BYTES] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_RX_PACKETS] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_PACKETS] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_FAILED] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_CONNECTED_TIME] = { .type = NLA_U32 },
+    };
+    struct nlattr *rate[NL80211_RATE_INFO_MAX + 1];
+    static struct nla_policy rate_policy[NL80211_RATE_INFO_MAX + 1] = {
+                [NL80211_RATE_INFO_BITRATE32] = { .type = NLA_U32 },
+    };
+    struct nl80211_sta_flag_update *sta_flags;
+
+    if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),genlmsg_attrlen(gnlh, 0),
+        NULL) < 0) {
+        wifi_hal_error_print("%s:%d Failed to parse sta data\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (!tb[NL80211_ATTR_STA_INFO]) {
+        wifi_hal_error_print("%s:%d Failed to get sta info attribute\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (tb[NL80211_ATTR_MAC]) {
+        memcpy(dev->cli_MACAddress, nla_data(tb[NL80211_ATTR_MAC]), sizeof(mac_address_t));
+    }
+
+    if (nla_parse_nested(stats, NL80211_STA_INFO_MAX, tb[NL80211_ATTR_STA_INFO], stats_policy)) {
+	wifi_hal_error_print("%s:%d Failed to parse nested attributes\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (stats[NL80211_STA_INFO_RX_BYTES]) {
+        dev->cli_BytesReceived = nla_get_u32(stats[NL80211_STA_INFO_RX_BYTES]);
+    }
+    if (stats[NL80211_STA_INFO_TX_BYTES]) {
+        dev->cli_BytesSent = nla_get_u32(stats[NL80211_STA_INFO_TX_BYTES]);
+    }
+    if (stats[NL80211_STA_INFO_RX_PACKETS]) {
+        dev->cli_PacketsReceived = nla_get_u32(stats[NL80211_STA_INFO_RX_PACKETS]);
+    }
+    if (stats[NL80211_STA_INFO_TX_PACKETS]) {
+        dev->cli_PacketsSent = nla_get_u32(stats[NL80211_STA_INFO_TX_PACKETS]);
+    }
+    if (stats[NL80211_STA_INFO_TX_FAILED]) {
+        dev->cli_ErrorsSent = nla_get_u32(stats[NL80211_STA_INFO_TX_FAILED]);
+    }
+
+    if (stats[NL80211_STA_INFO_TX_BITRATE] &&
+        nla_parse_nested(rate, NL80211_RATE_INFO_MAX, stats[NL80211_STA_INFO_TX_BITRATE], rate_policy) == 0) {
+        if (rate[NL80211_RATE_INFO_BITRATE32]){
+            dev->cli_LastDataDownlinkRate = nla_get_u32(rate[NL80211_RATE_INFO_BITRATE32]) * 100;
+        }
+    }
+    if (stats[NL80211_STA_INFO_RX_BITRATE] &&
+        nla_parse_nested(rate, NL80211_RATE_INFO_MAX, stats[NL80211_STA_INFO_RX_BITRATE], rate_policy) == 0) {
+        if (rate[NL80211_RATE_INFO_BITRATE32]) {
+                dev->cli_LastDataUplinkRate = nla_get_u32(rate[NL80211_RATE_INFO_BITRATE32]) * 100;
+        }
+    }
+
+    if (stats[NL80211_STA_INFO_STA_FLAGS]) {
+        sta_flags = nla_data(stats[NL80211_STA_INFO_STA_FLAGS]);
+        dev->cli_AuthenticationState = sta_flags->mask & (1 << NL80211_STA_FLAG_AUTHORIZED) &&
+            sta_flags->set & (1 << NL80211_STA_FLAG_AUTHORIZED);
+    }
+
+    return NL_OK;
+}
+
+static int get_sta_stats(wifi_interface_info_t *interface, mac_address_t mac, wifi_associated_dev3_t *dev)
+{
+    int ret;
+    struct nl_msg *msg = NULL;
+
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_GET_STATION);
+    if (msg == NULL) {
+        wifi_hal_error_print("%s:%d Failed to create NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    nla_put(msg, NL80211_ATTR_MAC, sizeof(mac_address_t), mac);
+
+    ret = nl80211_send_and_recv(msg, get_sta_stats_handler, dev, NULL, NULL);
+    if (ret < 0) {
+        wifi_hal_error_print("%s:%d Failed to execute NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    return 0;
+}
+
+INT wifi_getApAssociatedDeviceDiagnosticResult3(INT apIndex,
+    wifi_associated_dev3_t **associated_dev_array, UINT *output_array_size)
+{
+    int ret;
+    unsigned int i;
+    sta_list_t sta_list = {};
+    wifi_interface_info_t *interface;
+
+    interface = get_interface_by_vap_index(apIndex);
+    if (interface == NULL) {
+        wifi_hal_stats_error_print("%s:%d Failed to get interface for index %d\n", __func__, __LINE__, apIndex);
+        return -1;
+    }
+
+    ret = get_sta_list(interface, &sta_list);
+    if (ret < 0) {
+        wifi_hal_stats_error_print("%s:%d Failed to get sta list\n", __func__, __LINE__);
+        goto exit;
+    }
+
+    *associated_dev_array = sta_list.num ?
+        calloc(sta_list.num, sizeof(wifi_associated_dev3_t)) : NULL;
+    *output_array_size = sta_list.num;
+
+    for (i = 0; i < sta_list.num; i++) {
+        ret = get_sta_stats(interface, sta_list.macs[i], &(*associated_dev_array)[i]);
+        if (ret < 0) {
+            wifi_hal_stats_error_print("%s:%d Failed to get sta stats\n", __func__, __LINE__);
+            free(*associated_dev_array);
+            *associated_dev_array = NULL;
+            *output_array_size = 0;
+            goto exit;
+        }
+    }
+
+exit:
+    free(sta_list.macs);
+    return ret;
+}
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_getApEnable(INT apIndex, BOOL *output_bool)
+{
+    return RETURN_OK;
+}
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_setApIsolationEnable(INT apIndex, BOOL enable)
+{
+    return RETURN_ERR;
+}
+
+UINT wifi_freq_to_op_class(UINT freq)
+{
+    u8 op_class, channel;
+
+    if (ieee80211_freq_to_channel_ext(freq, 0, 0, &op_class, &channel) == NUM_HOSTAPD_MODES){
+        wifi_hal_error_print("%s:%d Failed to get op class for freq : %d\n", __func__, __LINE__, freq);
+        return RETURN_ERR;
+    }
+
+    return op_class;
+}
+
+INT wifi_setProxyArp(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_setCountryIe(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_getLayer2TrafficInspectionFiltering(INT apIndex, BOOL *enabled)
+{
+    return 0;
+}
+
+INT wifi_getCountryIe(INT apIndex, BOOL *enabled)
+{
+    return 0;
+}
+
+INT wifi_getDownStreamGroupAddress(INT apIndex, BOOL *disabled)
+{
+    return 0;
+}
+
+INT wifi_getProxyArp(INT apIndex, BOOL *enabled)
+{
+    return 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_getBssLoad(INT apIndex, BOOL *enabled)
+{
+    return RETURN_ERR;
+}
+
+INT wifi_setDownStreamGroupAddress(INT apIndex, BOOL disabled)
+{
+    return 0;
+}
+
+INT wifi_setBssLoad(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_getApAssociatedClientDiagnosticResult(INT ap_index, char *key,wifi_associated_dev3_t *assoc)
+{
+    return RETURN_ERR;
+}
+
+INT wifi_setP2PCrossConnect(INT apIndex, BOOL disabled)
+{
+    return 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_setLayer2TrafficInspectionFiltering(INT apIndex, BOOL enabled)
+{
+    return RETURN_ERR;
+}
+
+INT wifi_pushApHotspotElement(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_applyGASConfiguration(wifi_GASConfiguration_t *input_struct)
+{
+    return 0;
+}
+
+INT wifi_steering_eventRegister(wifi_steering_eventCB_t event_cb)
+{
+    return RETURN_OK;
+}
+
+INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
+{
+    return 0;
+}
+
+#ifdef CONFIG_IEEE80211BE
+int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
+    struct wpa_driver_ap_params *params)
+{
+    (void)msg;
+    (void)msg_mlo;
+    (void)priv;
+    (void)params;
+
+    return 0;
+}
+
+int nl80211_send_mlo_msg(struct nl_msg *msg)
+{
+    (void)msg;
+
+    return 0;
+}
+
+void wifi_drv_get_phy_eht_cap_mac(struct eht_capabilities *eht_capab, struct nlattr **tb)
+{
+    (void)eht_capab;
+    (void)tb;
+}
+
+int update_hostap_mlo(wifi_interface_info_t *interface)
+{
+    (void)interface;
+
+    return 0;
+}
+#endif /* CONFIG_IEEE80211BE */
+

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -162,14 +162,22 @@ INT wifi_hal_getHalCapability(wifi_hal_capability_t *hal)
 #if !defined(_PLATFORM_RASPBERRYPI_)
     /* Copy device manufacturer,model,serial no and software version to here */
     memset(output, '\0', sizeof(output));
+#if defined (_PLATFORM_BANANAPI_R4_)
+    _syscmd("cat /etc/machine-id", output, sizeof(output));
+#else
     _syscmd("grep -a 'Serial' /tmp/factory_nvram.data | cut -d ' ' -f2", output, sizeof(output));
+#endif
     if (output[strlen(output) - 1] == '\n') {
         output[strlen(output) - 1] = '\0';
     }
     strcpy(hal->wifi_prop.serialNo,output);
 
     memset(output, '\0', sizeof(output));
+#if defined (_PLATFORM_BANANAPI_R4_)
+    _syscmd("cat /proc/device-tree/model | tr -d ' '", output, sizeof(output));
+#else
     _syscmd("grep -a 'MODEL' /tmp/factory_nvram.data | cut -d ' ' -f2", output, sizeof(output));
+#endif 
     if (output[strlen(output) - 1] == '\n') {
         output[strlen(output) - 1] = '\0';
     }
@@ -185,14 +193,22 @@ INT wifi_hal_getHalCapability(wifi_hal_capability_t *hal)
 
     // CM mac
     memset(output, '\0', sizeof(output));
+#if defined (_PLATFORM_BANANAPI_R4_)
+    _syscmd("ifconfig erouter0 | grep -oE 'HWaddr [[:alnum:]:]+' | awk '{print $2}'", output, sizeof(output));
+#else
     _syscmd("grep -a 'CM' /tmp/factory_nvram.data | cut -d ' ' -f2", output, sizeof(output));
+#endif
     if (output[strlen(output) - 1] == '\n') {
         output[strlen(output) - 1] = '\0';
     }
     to_mac_bytes(output,hal->wifi_prop.cm_mac);
 
     memset(output, '\0', sizeof(output));
+#if defined (_PLATFORM_BANANAPI_R4_)
+    _syscmd("ifconfig erouter0 | grep -oE 'HWaddr [[:alnum:]:]+' | awk '{print $2}'", output, sizeof(output));
+#else
     _syscmd("ifconfig eth0 | grep -oE 'HWaddr [[:alnum:]:]+' | awk '{print $2}'", output, sizeof(output));
+#endif
     if (output[strlen(output) - 1] == '\n') { 
         output[strlen(output) - 1] = '\0';
     }


### PR DESCRIPTION
Reason for change:  Errors are below,
translate_onewifi_dml_data:202 Dev-Init decode fail print_config:1907:Network:
print_config:1908:Controller MAC:00:00:00:00:00:00	Controller AL MAC:00:00:00:00:00:00	Agent AL MAC:00:00:00:00:00:00 print_config:1910:Manufacturer:	Manufacturere Model:	SoftwareVersion: Test Procedure: Able to run local em_agent
Risks: Low