### PR TITLE
REFPLTB-3409: New NL80211 for ACL import changes causing AP issues in RPI

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13554,7 +13554,7 @@ int wifi_drv_set_ap(void *priv, struct wpa_driver_ap_params *params)
         }
     }
 
-#if defined(NL80211_ACL) && !defined(PLATFORM_LINUX)
+#if defined(NL80211_ACL) && !defined(PLATFORM_LINUX) && !defined(_PLATFORM_RASPBERRYPI_)
     //Raspberry Pi kernel requires patching to support ACL functionality.
     nl80211_put_acl(msg, interface);
 #endif


### PR DESCRIPTION
Reason for change:
    Added work around change for RPI.
Test Procedure:
    1. Bring up the device and check for SSIDs are UP or not using "iw dev" command.
    2. SSIDs should be broadcasted. Risks: None