### PR TITLE
RDKBWIFI-31: Fixes segfault due to no hapd present for sta interfaces

### DIFF
--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -341,6 +341,28 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
         return;
     }
 
+    if (vap->vap_mode != wifi_vap_mode_ap) {
+        // If a station just sent a TX frame (and therefore here received a TX status as an ACK), 
+        // it doesn't need to do anything with that information. Action frames are not sent to the
+        // RX handler. Additionally, following commands depend on `hapd` which is not present for 
+        // non-AP modes.
+        // We'll debug out the info though, for programmer convenience.
+        
+        char tmp[256] = "";
+        sprintf(tmp, "%s:%d:", __func__, __LINE__);
+        if (addr) sprintf(tmp + strlen(tmp), " MAC: "MACSTR",", MAC2STR((u8*)nla_data(addr)));
+        if (cookie) sprintf(tmp + strlen(tmp), " cookie: %llu,", nla_get_u64(cookie));
+        if (ack) sprintf(tmp + strlen(tmp), " ack: %d,", nla_get_flag(ack));
+        
+        sprintf(tmp + strlen(tmp), " type: %d, stype: %d",
+                WLAN_FC_GET_TYPE(fc), WLAN_FC_GET_STYPE(fc));
+        
+        wifi_hal_dbg_print("%s\n", tmp);
+
+        wifi_hal_dbg_print("%s:%d: vap mode is not AP, dropping\n", __func__, __LINE__);
+        return;
+    }
+
     os_memset(&event, 0, sizeof(event));
     event.tx_status.type = WLAN_FC_GET_TYPE(fc);
     event.tx_status.stype = WLAN_FC_GET_STYPE(fc);


### PR DESCRIPTION
Reason for change: When sending management frames from a station interface, rdk-wifi-hal linked programs (like OneWifi) will SEGFAULT when a `tx_status` is received because only APs can have a `hapd` allocated.

Test procedure: Send a management frame from a STA interface and once the `tx_status` is returned (whether immediately or after the dwell time), a segfault will occur.
Priority: P1
Risks: Low