### PR TITLE
RDKBWIFI-31: Adding new sendAction frame api to Broadcom platform file

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -507,6 +507,12 @@ int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t 
     return RETURN_OK;
 }
 
+int wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
+{
+    int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);
+    return (res == 0) ? RETURN_OK : RETURN_ERR;
+}
+
 int platform_set_acs_exclusion_list(unsigned int radioIndex, char* str)
 {
 #if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)


### PR DESCRIPTION
Reason for change : To fix onewifi build failure on Broadcom platform

> 15:19:04  | ../../../git/source/core/wifi_ctrl_queue_handlers.c:3117: error: undefined reference to 'wifi_sendActionFrameExt'
> 15:19:04  | collect2: error: ld returned 1 exit status
> 15:19:04  | make[3]: *** [Makefile:1492: OneWifi] Error 1

added new api wifi_sendActionFrameExt definition to Broadcom platform file.