### PR TITLE
RDKBWIFI-31: Fixed: Compile error lack of `wifi_sendActionFrameExt` support

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -507,10 +507,15 @@ int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t 
     return RETURN_OK;
 }
 
-int wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
+INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
 {
     int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);
-    return (res == 0) ? RETURN_OK : RETURN_ERR;
+    return (res == 0) ? WIFI_HAL_SUCCESS : WIFI_HAL_ERROR;
+}
+
+INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
+{
+    return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
 }
 
 int platform_set_acs_exclusion_list(unsigned int radioIndex, char* str)

--- a/platform/qualcomm/platform_xer5.c
+++ b/platform/qualcomm/platform_xer5.c
@@ -1713,3 +1713,14 @@ INT platform_create_interface_attributes(struct nl_msg **msg_ptr, wifi_radio_inf
     }
     return RETURN_OK;
 }
+
+INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
+{
+    int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);
+    return (res == 0) ? WIFI_HAL_SUCCESS : WIFI_HAL_ERROR;
+}
+
+INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
+{
+    return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
+}

--- a/platform/xle/platform_xle.c
+++ b/platform/xle/platform_xle.c
@@ -493,3 +493,14 @@ int platform_get_radio_caps(wifi_radio_index_t index)
 {
     return 0;
 }
+
+INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
+{
+    int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);
+    return (res == 0) ? WIFI_HAL_SUCCESS : WIFI_HAL_ERROR;
+}
+
+INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
+{
+    return wifi_sendActionFrameExt(apIndex, MacAddr, frequency, 0, frame, len);
+}

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -351,7 +351,7 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
         char tmp[256] = "";
         sprintf(tmp, "%s:%d:", __func__, __LINE__);
         if (addr) sprintf(tmp + strlen(tmp), " MAC: "MACSTR",", MAC2STR((u8*)nla_data(addr)));
-        if (cookie) sprintf(tmp + strlen(tmp), " cookie: %lu,", nla_get_u64(cookie));
+        if (cookie) sprintf(tmp + strlen(tmp), " cookie: %llu,", (unsigned long long)nla_get_u64(cookie));
         if (ack) sprintf(tmp + strlen(tmp), " ack: %d,", nla_get_flag(ack));
         
         sprintf(tmp + strlen(tmp), " type: %d, stype: %d",


### PR DESCRIPTION
Reason for change : To fix OneWifi build error due to lack of `wifi_sendActionFrameExt` implementation. Also to fix build error because of cookie `snprintf` format for different architectures

@amarnathhullur 