### PR TITLE
RDKB-59277: Fixing OneWifi build failure

### DIFF
--- a/src/wifi_hal_wnm_rrm.c
+++ b/src/wifi_hal_wnm_rrm.c
@@ -1147,7 +1147,7 @@ static int wifi_hal_parse_rrm_beacon_req(wifi_interface_info_t *interface,
     int op_class;
 
     if (len < sizeof(*req)) {
-        wifi_hal_error_print("%s:%d RRM: request element too short, len: %d\n", __func__, __LINE__,
+        wifi_hal_error_print("%s:%d RRM: request element too short, len: %zu\n", __func__, __LINE__,
             len);
         return RETURN_ERR;
     }
@@ -1342,7 +1342,7 @@ int wifi_hal_parse_rm_beacon_request(unsigned int apIndex, char *buff, size_t le
     }
 
     if (len < IEEE80211_HDRLEN + sizeof(mgmt->u.action.u.rrm)) {
-        wifi_hal_error_print("%s:%d too short measurement request, len: %d\n", __func__, __LINE__,
+        wifi_hal_error_print("%s:%d too short measurement request, len: %zu\n", __func__, __LINE__,
             len);
         return RETURN_ERR;
     }
@@ -1375,7 +1375,7 @@ int wifi_hal_parse_rm_beacon_request(unsigned int apIndex, char *buff, size_t le
     // len -= IEEE80211_HDRLEN + sizeof(mgmt->u.action.u.rrm);
 
     if (len < 2) {
-        wifi_hal_error_print("%s:%d too short measurement request, len: %d\n", __func__, __LINE__,
+        wifi_hal_error_print("%s:%d too short measurement request, len: %zu\n", __func__, __LINE__,
             len);
         return -1;
     }


### PR DESCRIPTION
Reason for change: Fixing build failure, incorrect format specifier for size_t variable
Test Procedure: OneWifi image should build successfully Risks: Low
Priority: P1
Signed-off-by: Sathish Kumar Gnanasekaran <sathishkumar_gnanasekaran@comcast.com>
