### PR TITLE
REFPLTB-3426: Porting kernel patches to support ACL for RPI

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13560,7 +13560,7 @@ int wifi_drv_set_ap(void *priv, struct wpa_driver_ap_params *params)
         }
     }
 
-#if defined(NL80211_ACL) && !defined(PLATFORM_LINUX) && !defined(_PLATFORM_RASPBERRYPI_)
+#if defined(NL80211_ACL) && !defined(PLATFORM_LINUX)
     //Raspberry Pi kernel requires patching to support ACL functionality.
     nl80211_put_acl(msg, interface);
 #endif


### PR DESCRIPTION
Reason for change:
     Reverting the work around change added for ACL support.
Test Procedure:
    1. Bring up the device and check for SSIDs are UP or not using "iw dev" command.
    2. SSIDs should be broadcasted. 
Risks: None