### PR TITLE
RDKB-59404: OpenWRT related rdk-wifi-hal change

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -682,6 +682,36 @@ INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
     return 0;
 }
 
+int wifi_rrm_send_beacon_req(struct wifi_interface_info_t *interface, const u8 *addr,
+    u16 num_of_repetitions, u8 measurement_request_mode, u8 oper_class, u8 channel,
+    u16 random_interval, u16 measurement_duration, u8 mode, const u8 *bssid,
+    struct wpa_ssid_value *ssid, u8 *rep_cond, u8 *rep_cond_threshold, u8 *rep_detail,
+    const u8 *ap_ch_rep, unsigned int ap_ch_rep_len, const u8 *req_elem, unsigned int req_elem_len,
+    u8 *ch_width, u8 *ch_center_freq0, u8 *ch_center_freq1, u8 last_indication)
+{
+    return 0;
+}
+
+/* called by BTM API */
+int wifi_wnm_send_bss_tm_req(struct wifi_interface_info_t *interface, struct sta_info *sta,
+    u8 dialog_token, u8 req_mode, int disassoc_timer, u8 valid_int, const u8 *bss_term_dur,
+    const char *url, const u8 *nei_rep, size_t nei_rep_len, const u8 *mbo_attrs, size_t mbo_len)
+{
+    return 0;
+}
+
+int handle_wnm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    struct ieee80211_mgmt *mgmt, size_t len)
+{
+    return 0;
+}
+
+int handle_rrm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    const struct ieee80211_mgmt *mgmt, size_t len, int ssi_signal)
+{
+    return 0;
+}
+
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
     struct wpa_driver_ap_params *params)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -49,7 +49,9 @@
 #include "ap/wmm.h"
 #include <sys/wait.h>
 #include <linux/if_ether.h>
+#ifdef __GLIBC__
 #include <netinet/ether.h>
+#endif
 #include <linux/filter.h>
 #include <fcntl.h>
 
@@ -2794,6 +2796,15 @@ void *nl_recv_func(void *arg)
     wifi_hal_priv_t *priv = (wifi_hal_priv_t *)arg;
     wifi_interface_info_t *interface;
     int eloop_timeout_ms;
+#if defined (_PLATFORM_BANANAPI_R4_)
+    size_t stack_size2;
+    pthread_attr_t attr;
+
+    pthread_attr_init(&attr);
+    pthread_attr_getstacksize(&attr, &stack_size2);
+    wifi_hal_dbg_print("%s:%d Thread stack size = %ld bytes \n", __func__, __LINE__, stack_size2);
+    pthread_attr_destroy(&attr);
+#endif
 
     prctl(PR_SET_NAME,  __func__, 0, 0, 0);
 

--- a/src/wifi_hal_wnm_rrm.c
+++ b/src/wifi_hal_wnm_rrm.c
@@ -47,7 +47,9 @@
 #include "ap/dfs.h"
 #include <sys/wait.h>
 #include <linux/if_ether.h>
+#ifdef __GLIBC__
 #include <netinet/ether.h>
+#endif
 #include <linux/filter.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
Reason for change: Fixing build and runtime issue on OpenWRT platform.
Risks: Low
Test Procedure: Tested on BPI openWRT with agent, RPI collocated mode.