### PR TITLE
RDKBACCL-668 : Jumping Hostapd 2.11 to 2.12 for wifi 7 MLO

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -682,6 +682,36 @@ INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
     return 0;
 }
 
+int wifi_rrm_send_beacon_req(struct wifi_interface_info_t *interface, const u8 *addr,
+    u16 num_of_repetitions, u8 measurement_request_mode, u8 oper_class, u8 channel,
+    u16 random_interval, u16 measurement_duration, u8 mode, const u8 *bssid,
+    struct wpa_ssid_value *ssid, u8 *rep_cond, u8 *rep_cond_threshold, u8 *rep_detail,
+    const u8 *ap_ch_rep, unsigned int ap_ch_rep_len, const u8 *req_elem, unsigned int req_elem_len,
+    u8 *ch_width, u8 *ch_center_freq0, u8 *ch_center_freq1, u8 last_indication)
+{
+    return 0;
+}
+
+/* called by BTM API */
+int wifi_wnm_send_bss_tm_req(struct wifi_interface_info_t *interface, struct sta_info *sta,
+    u8 dialog_token, u8 req_mode, int disassoc_timer, u8 valid_int, const u8 *bss_term_dur,
+    const char *url, const u8 *nei_rep, size_t nei_rep_len, const u8 *mbo_attrs, size_t mbo_len)
+{
+    return 0;
+}
+
+int handle_wnm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    struct ieee80211_mgmt *mgmt, size_t len)
+{
+    return 0;
+}
+
+int handle_rrm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    const struct ieee80211_mgmt *mgmt, size_t len, int ssi_signal)
+{
+    return 0;
+}
+
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
     struct wpa_driver_ap_params *params)

--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -366,9 +366,38 @@ int wifi_setApRetrylimit(void *priv)
 
 int platform_get_radio_caps(wifi_radio_index_t index)
 {
-    return 0;
-}
+#ifdef CONFIG_IEEE80211BE
+#if HOSTAPD_VERSION >= 211
+    wifi_radio_info_t *radio;
+    wifi_interface_info_t *interface;
+    radio = get_radio_by_rdk_index(index);
+    if (radio == NULL) {
+        wifi_hal_dbg_print("%s:%d failed to get radio for index\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
 
+    for (interface = hash_map_get_first(radio->interface_map); interface != NULL;
+        interface = hash_map_get_next(radio->interface_map, interface)) {
+
+        if (interface->vap_info.vap_mode == wifi_vap_mode_sta) {
+            continue;
+        }
+
+	struct hostapd_iface *iface = &interface->u.ap.iface;
+        if (strstr(interface->vap_info.vap_name, "private_ssid_5g")) {
+	    for (int i = 0; i < iface->num_hw_features; i++) {
+                iface->hw_features[i].eht_capab[IEEE80211_MODE_AP].eht_supported = true;
+	    }
+        } else if (strstr(interface->vap_info.vap_name, "private_ssid_6g")) {
+	    for (int i = 0; i < iface->num_hw_features; i++) {
+                iface->hw_features[i].eht_capab[IEEE80211_MODE_AP].eht_supported = true;
+	    }
+        }
+    }
+#endif /* HOSTAPD_VERSION >= 211 */
+#endif /* CONFIG_IEEE80211BE */
+    return RETURN_OK;
+}
 
 INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
 {

--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -682,6 +682,7 @@ INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
     return 0;
 }
 
+#ifdef PLATFORM_LINUX
 int wifi_rrm_send_beacon_req(struct wifi_interface_info_t *interface, const u8 *addr,
     u16 num_of_repetitions, u8 measurement_request_mode, u8 oper_class, u8 channel,
     u16 random_interval, u16 measurement_duration, u8 mode, const u8 *bssid,
@@ -711,6 +712,7 @@ int handle_rrm_action_frame(struct wifi_interface_info_t *interface, const mac_a
 {
     return 0;
 }
+#endif
 
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1252,6 +1252,11 @@ int init_wpa_supplicant(wifi_interface_info_t *interface)
 }
 #endif
 
+int get_sta_4addr_status(bool *sta_4addr)
+{
+    return json_parse_boolean(EM_CFG_FILE, "sta_4addr_mode_enabled", sta_4addr);
+}
+
 #if defined(SCXER10_PORT) && defined(CONFIG_IEEE80211BE) && defined(KERNEL_NO_320MHZ_SUPPORT)
 INT _wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map);
 
@@ -1395,9 +1400,13 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
         nl80211_interface_enable(interface->name, false);
 #ifndef CONFIG_WIFI_EMULATOR
         if (vap->vap_mode == wifi_vap_mode_sta) {
+            bool sta_4addr = 0;
             wifi_hal_info_print("%s:%d: interface:%s remove from bridge\n", __func__, __LINE__,
                 interface->name);
             nl80211_remove_from_bridge(interface->name);
+            if (get_sta_4addr_status(&sta_4addr) == RETURN_OK) {
+                interface->u.sta.sta_4addr = (int)sta_4addr;
+            }
         }
 #endif
         wifi_hal_info_print("%s:%d: interface:%s set mode:%d\n", __func__, __LINE__,

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -547,6 +547,14 @@ INT wifi_hal_pre_init()
         wifi_hal_info_print("%s:%d: platfrom pre init\n", __func__, __LINE__);
         pre_init_fn();
     }
+
+#ifdef CONFIG_IEEE80211BE
+void hostapd_wpa_event(void *ctx, enum wpa_event_type event,
+                       union wpa_event_data *data);
+
+     wpa_supplicant_event = hostapd_wpa_event;
+#endif
+
     return RETURN_OK;
 }
 

--- a/src/wifi_hal_dpp.c
+++ b/src/wifi_hal_dpp.c
@@ -2499,7 +2499,7 @@ INT wifi_dppProcessAuthResponse(wifi_device_dpp_context_t *dpp_ctx)
         return RETURN_ERR;
     }
 
-    if (status != STATUS_OK) {
+    if (status != WIFI_STATUS_OK) {
         // return authentication failure for now
 		dpp_ctx->enrollee_status = RESPONDER_STATUS_AUTH_FAILURE;
         return RETURN_ERR;
@@ -2731,7 +2731,7 @@ INT wifi_dppSendConfigResponse(wifi_device_dpp_context_t *ctx)
     wifi_dppConfigResponseFrame_t    *config_response_frame;
     wifi_dpp_session_data_t *data = NULL;
 	wifi_dpp_instance_t *instance;
-    unsigned char buff[2048], dpp_status = STATUS_OK;
+    unsigned char buff[2048], dpp_status = WIFI_STATUS_OK;
     wifi_tlv_t *tlv;
     unsigned int tlv_len = 0, wrapped_len = 0;
 
@@ -2902,7 +2902,7 @@ wifi_dppSendAuthCnf(wifi_device_dpp_context_t *ctx)
     unsigned char keyasn1[1024];
     unsigned char keyhash[SHA512_DIGEST_LENGTH];
     const unsigned char *key;
-    unsigned char buff[2048], dpp_status = STATUS_OK;
+    unsigned char buff[2048], dpp_status = WIFI_STATUS_OK;
     unsigned int asn1len, tlv_len = 0, wrapped_len = 0;
     wifi_dppPublicActionFrame_t    *public_action_frame;
     wifi_dpp_session_data_t *data = NULL;

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -2229,9 +2229,11 @@ static void wpa_sm_sta_set_state(void *ctx, enum wpa_states state)
 
     if (state == WPA_COMPLETED) {
         nl80211_get_channel_bw_conn(interface);
+        wifi_hal_configure_sta_4addr_to_bridge(interface, 1);
     } else if (state == WPA_DISCONNECTED) {
         callbacks = get_hal_device_callbacks();
         
+        wifi_hal_configure_sta_4addr_to_bridge(interface, 0);
         if (callbacks->sta_conn_status_callback) {
             memcpy(&bss, &interface->u.sta.backhaul, sizeof(wifi_bss_info_t));
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -5108,7 +5108,7 @@ static void wiphy_info_mbssid(struct wpa_driver_capa *cap, struct nlattr *attr)
         return;
     }
 
-    if (config[NL80211_MBSSID_CONFIG_ATTR_MAX_INTERFACES] != NULL) {
+    if (config[NL80211_MBSSID_CONFIG_ATTR_MAX_INTERFACES] == NULL) {
         return;
     }
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -49,7 +49,9 @@
 #include "ap/wmm.h"
 #include <sys/wait.h>
 #include <linux/if_ether.h>
+#ifdef __GLIBC__
 #include <netinet/ether.h>
+#endif
 #include <linux/filter.h>
 #include <fcntl.h>
 
@@ -2794,6 +2796,15 @@ void *nl_recv_func(void *arg)
     wifi_hal_priv_t *priv = (wifi_hal_priv_t *)arg;
     wifi_interface_info_t *interface;
     int eloop_timeout_ms;
+#if defined (_PLATFORM_BANANAPI_R4_)
+    size_t stack_size2;
+    pthread_attr_t attr;
+
+    pthread_attr_init(&attr);
+    pthread_attr_getstacksize(&attr, &stack_size2);
+    wifi_hal_dbg_print("%s:%d Thread stack size = %ld bytes \n", __func__, __LINE__, stack_size2);
+    pthread_attr_destroy(&attr);
+#endif
 
     prctl(PR_SET_NAME,  __func__, 0, 0, 0);
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -13591,7 +13591,7 @@ int wifi_drv_set_ap(void *priv, struct wpa_driver_ap_params *params)
         }
     }
 
-#if defined(NL80211_ACL) && !defined(PLATFORM_LINUX) && !defined(_PLATFORM_RASPBERRYPI_)
+#if defined(NL80211_ACL) && !defined(PLATFORM_LINUX)
     //Raspberry Pi kernel requires patching to support ACL functionality.
     nl80211_put_acl(msg, interface);
 #endif

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -10115,7 +10115,7 @@ int wifi_drv_add_ts(void *priv, u8 tsid, const u8 *addr, u8 user_priority, u16 a
     return 0;
 }
 
-int wifi_drv_br_set_net_param(void *priv, enum drv_br_net_param param, unsigned int val)
+int wifi_drv_br_set_net_param(void *priv, enum drv_br_net_param param, const char *ifname, unsigned int val)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
     return 0;
@@ -10455,7 +10455,7 @@ int wifi_drv_status(void *priv, char *buf, size_t buflen)
     return 0;
 }
 
-int wifi_drv_get_survey(void *priv, unsigned int freq)
+int wifi_drv_get_survey(void *priv, unsigned int freq, int link_id)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
     return 0;
@@ -10638,7 +10638,7 @@ int wifi_drv_send_action(void *priv,
                       const u8 *dst, const u8 *src,
                       const u8 *bssid,
                       const u8 *data, size_t data_len,
-                      int no_cck)
+                      int no_cck, int link_id)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
 
@@ -11419,7 +11419,7 @@ fail:
 }
 
 int wifi_drv_set_wds_sta(void *priv, const u8 *addr, int aid, int val,
-                const char *bridge_ifname, char *ifname_wds)
+                const char *bridge_ifname, const char *ifname_wds)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
 
@@ -12982,7 +12982,7 @@ int wifi_drv_if_add(void *priv, enum wpa_driver_if_type type,
                      void *bss_ctx, void **drv_priv,
                      char *force_ifname, u8 *if_addr,
                      const char *bridge, int use_existing,
-                     int setup_ap)
+                     int setup_ap, int freq, u32 radio_mask)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
     return 0;

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -174,6 +174,8 @@ static void nl80211_del_station_event(wifi_interface_info_t *interface, struct n
     os_memset(&event, 0, sizeof(event));
     event.disassoc_info.addr = mac;
     wpa_supplicant_event(&interface->u.ap.hapd, EVENT_DISASSOC, &event);
+    //Remove the station from the bridge, if present
+    wifi_hal_configure_sta_4addr_to_bridge(interface, 0);
 }
 #endif //_PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
 

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -4295,8 +4295,9 @@ void concat_band_to_vap_name(wifi_vap_name_t vap_name, unsigned int rdk_radio_in
 
 int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode)
 {
-    unsigned int index = 0;
+    unsigned int index = 0, i = 0;
     wifi_interface_info_t *interface = NULL;
+    int vap_count = 0;
     for (index = 0; index < get_sizeof_interfaces_index_map(); index++) {
         if (strncmp(interface_index_map[index].interface_name, ifname, strlen(ifname)) == 0) {
             switch (colocated_mode) {
@@ -4306,6 +4307,18 @@ int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode)
                     interface_index_map[index].rdk_radio_index);
                 break;
             case 1:
+                for (i = 0; i < interface_index_map_size; i++) {
+                    if (interface_index_map[i].rdk_radio_index ==
+                        interface_index_map[index].rdk_radio_index) {
+                        vap_count++;
+                    }
+                }
+                /* If only one VAP in collocated mode, configure it as mesh_back_haul */
+                if (vap_count == 1) {
+                    strcpy((char *)interface_index_map[index].vap_name, "mesh_backhaul_");
+                    concat_band_to_vap_name((char *)interface_index_map[index].vap_name,
+                        interface_index_map[index].rdk_radio_index);
+                }
                 /* Check the interface should be either fronthaul or backhaul */
                 if (is_wifi_hal_vap_private(interface_index_map[index].index) == false &&
                     is_wifi_hal_vap_mesh_backhaul(interface_index_map[index].index) == false) {

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -4298,7 +4298,8 @@ int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode)
     unsigned int index = 0, i = 0;
     wifi_interface_info_t *interface = NULL;
     int vap_count = 0;
-    for (index = 0; index < get_sizeof_interfaces_index_map(); index++) {
+    int index_map_size = get_sizeof_interfaces_index_map();
+    for (index = 0; index < index_map_size; index++) {
         if (strncmp(interface_index_map[index].interface_name, ifname, strlen(ifname)) == 0) {
             switch (colocated_mode) {
             case 0:
@@ -4307,7 +4308,7 @@ int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode)
                     interface_index_map[index].rdk_radio_index);
                 break;
             case 1:
-                for (i = 0; i < interface_index_map_size; i++) {
+                for (i = 0; i < index_map_size; i++) {
                     if (interface_index_map[i].rdk_radio_index ==
                         interface_index_map[index].rdk_radio_index) {
                         vap_count++;

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -366,6 +366,7 @@ typedef struct {
     unsigned char rx_eapol_buff[2048];
     mac_address_t src_addr;
     int buff_len;
+    int sta_4addr;
 } wifi_sta_priv_t;
 
 typedef struct {
@@ -1100,7 +1101,9 @@ int wifi_setApRetrylimit(void *priv);
 int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode);
 int json_parse_string(const char* file_name, const char *item_name, char *val, size_t len);
 int json_parse_integer(const char* file_name, const char *item_name, int *val);
+int json_parse_boolean(const char* file_name, const char *item_name, bool *val);
 bool get_ifname_from_mac(const mac_address_t *mac, char *ifname);
+int wifi_hal_configure_sta_4addr_to_bridge(wifi_interface_info_t *interface, int add);
 
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,

--- a/src/wifi_hal_rdk.h
+++ b/src/wifi_hal_rdk.h
@@ -177,7 +177,7 @@ typedef struct _wifi_EapStats_t{    // Passpoint stats defined rdkb-1317
 #endif
 #define DPP_CONFPROTO 0x01 // denoting the DPP Configuration protocol
 
-#define STATUS_OK 0
+#define WIFI_STATUS_OK 0
 #define STATUS_NOT_COMPATIBLE 1
 #define STATUS_AUTH_FAILURE 2
 #define STATUS_DECRYPT_FAILURE 3

--- a/src/wifi_hal_rdk_util.c
+++ b/src/wifi_hal_rdk_util.c
@@ -535,6 +535,32 @@ int json_parse_integer(const char* file_name, const char *item_name, int *val)
     return 0;
 }
 
+int json_parse_boolean(const char* file_name, const char *item_name, bool *val)
+{
+    cJSON *item;
+    cJSON *json;
+
+    json = json_open_file(file_name);
+    if (json == NULL) {
+        *val = false;
+        return -1;
+    }
+
+    item = cJSON_GetObjectItem(json, item_name);
+    if ((item == NULL) || (cJSON_IsBool(item) == false)) {
+        wifi_hal_error_print("%s:%d: (%s) does "
+            "not exist or is not a boolean.\n",
+            __func__, __LINE__, item_name);
+        cJSON_Delete(json);
+        *val = false;
+        return -1;
+    }
+    *val = (item->type & cJSON_True) ? true : false;
+
+    cJSON_Delete(json);
+    return 0;
+}
+
 /* This routine will take mac address from the user and returns associated interfacename */
 bool get_ifname_from_mac(const mac_address_t *mac, char *ifname)
 {

--- a/src/wifi_hal_wnm_rrm.c
+++ b/src/wifi_hal_wnm_rrm.c
@@ -47,7 +47,9 @@
 #include "ap/dfs.h"
 #include <sys/wait.h>
 #include <linux/if_ether.h>
+#ifdef __GLIBC__
 #include <netinet/ether.h>
+#endif
 #include <linux/filter.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
Reason for change: updating the APIS with respect to Hostapd 2.12
Test Procedure: Command to check core file is ls /tmp/*core*
Risks: None.
