### PR TITLE
RDKBACCL-668 : Jumping Hostapd 2.11 to 2.12 for wifi 7 MLO

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -508,6 +508,15 @@ INT wifi_hal_pre_init()
         wifi_hal_info_print("%s:%d: platfrom pre init\n", __func__, __LINE__);
         pre_init_fn();
     }
+
+#ifdef CONFIG_IEEE80211BE
+void hostapd_wpa_event(void *ctx, enum wpa_event_type event,
+                       union wpa_event_data *data);
+
+     wpa_supplicant_event = hostapd_wpa_event;
+#endif
+
+
     return RETURN_OK;
 }
 

--- a/src/wifi_hal_dpp.c
+++ b/src/wifi_hal_dpp.c
@@ -2499,7 +2499,7 @@ INT wifi_dppProcessAuthResponse(wifi_device_dpp_context_t *dpp_ctx)
         return RETURN_ERR;
     }
 
-    if (status != STATUS_OK) {
+    if (status != WIFI_STATUS_OK) {
         // return authentication failure for now
 		dpp_ctx->enrollee_status = RESPONDER_STATUS_AUTH_FAILURE;
         return RETURN_ERR;
@@ -2731,7 +2731,7 @@ INT wifi_dppSendConfigResponse(wifi_device_dpp_context_t *ctx)
     wifi_dppConfigResponseFrame_t    *config_response_frame;
     wifi_dpp_session_data_t *data = NULL;
 	wifi_dpp_instance_t *instance;
-    unsigned char buff[2048], dpp_status = STATUS_OK;
+    unsigned char buff[2048], dpp_status = WIFI_STATUS_OK;
     wifi_tlv_t *tlv;
     unsigned int tlv_len = 0, wrapped_len = 0;
 
@@ -2902,7 +2902,7 @@ wifi_dppSendAuthCnf(wifi_device_dpp_context_t *ctx)
     unsigned char keyasn1[1024];
     unsigned char keyhash[SHA512_DIGEST_LENGTH];
     const unsigned char *key;
-    unsigned char buff[2048], dpp_status = STATUS_OK;
+    unsigned char buff[2048], dpp_status = WIFI_STATUS_OK;
     unsigned int asn1len, tlv_len = 0, wrapped_len = 0;
     wifi_dppPublicActionFrame_t    *public_action_frame;
     wifi_dpp_session_data_t *data = NULL;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -10006,7 +10006,7 @@ int wifi_drv_add_ts(void *priv, u8 tsid, const u8 *addr, u8 user_priority, u16 a
     return 0;
 }
 
-int wifi_drv_br_set_net_param(void *priv, enum drv_br_net_param param, unsigned int val)
+int wifi_drv_br_set_net_param(void *priv, enum drv_br_net_param param, const char *ifname, unsigned int val)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
     return 0;
@@ -10346,7 +10346,7 @@ int wifi_drv_status(void *priv, char *buf, size_t buflen)
     return 0;
 }
 
-int wifi_drv_get_survey(void *priv, unsigned int freq)
+int wifi_drv_get_survey(void *priv, unsigned int freq, int link_id)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
     return 0;
@@ -10529,7 +10529,7 @@ int wifi_drv_send_action(void *priv,
                       const u8 *dst, const u8 *src,
                       const u8 *bssid,
                       const u8 *data, size_t data_len,
-                      int no_cck)
+                      int no_cck, int link_id)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
 
@@ -11166,7 +11166,7 @@ int wifi_drv_get_seqnum(const char *iface, void *priv, const u8 *addr, int idx, 
 }
 
 int wifi_drv_set_wds_sta(void *priv, const u8 *addr, int aid, int val,
-                const char *bridge_ifname, char *ifname_wds)
+                const char *bridge_ifname, const char *ifname_wds)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
     return 0;
@@ -12649,7 +12649,7 @@ int wifi_drv_if_add(void *priv, enum wpa_driver_if_type type,
                      void *bss_ctx, void **drv_priv,
                      char *force_ifname, u8 *if_addr,
                      const char *bridge, int use_existing,
-                     int setup_ap)
+                     int setup_ap, int freq, u32 radio_mask)
 {
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
     return 0;

--- a/src/wifi_hal_rdk.h
+++ b/src/wifi_hal_rdk.h
@@ -177,7 +177,7 @@ typedef struct _wifi_EapStats_t{    // Passpoint stats defined rdkb-1317
 #endif
 #define DPP_CONFPROTO 0x01 // denoting the DPP Configuration protocol
 
-#define STATUS_OK 0
+#define WIFI_STATUS_OK 0
 #define STATUS_NOT_COMPATIBLE 1
 #define STATUS_AUTH_FAILURE 2
 #define STATUS_DECRYPT_FAILURE 3


### PR DESCRIPTION
Reason for change: Reverting patches of rdk-wifi-hal wrt to nl core file and API updation from meta-cmf-bananapi
Raised against rdk-wifi-hal MLOdemo branch 
Test Procedure: Command to check core file is ls /tmp/*core* and build got successful
Risks: None.