### PR TITLE
If a VAP is mesh backhaul, pull SSID from EashmeshCfg.json

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -198,7 +198,7 @@ int platform_get_ssid_default(char *ssid, int vap_index)
     wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
     /* if the vap_index is that of mesh STA or mesh backhaul then try to obtain the ssid from
        /nvram/EasymeshCfg.json file */
-    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+    if (is_wifi_hal_vap_mesh_sta(vap_index) || is_wifi_hal_vap_mesh_backhaul(vap_index)) {
         if (!json_parse_backhaul_ssid(ssid)) {
             wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
             return 0;


### PR DESCRIPTION
If running on a Raspberry Pi, the HAL now respects that an interface is an AP mesh backhaul from `InterfaceMap.json` and pulls in credentials for the BSS from `EasymeshCfg.json`

`InterfaceMap.json` on Pi with USB Wi-Fi dongle (since Pi base radio doesn't support Multi-VAP):

```
{
    "PhyList": [
        {
            "Index": 0,
            "RadioList": [
                {
                    "Index": 1,
                    "RadioName": "wlan0",
                    "InterfaceList": [
                        {
                            "InterfaceName": "wlan0",
                            "Bridge": "brlan0",
                            "vlanId": 0,
                            "vapIndex": 0,
                            "vapName": "private_ssid_5g"
                        }
                    ]
                }
            ]
        },
        {
            "Index": 1,
            "RadioList": [
                {
                    "Index": 0,
                    "RadioName": "wlan1",
                    "InterfaceList": [
                       {
                            "InterfaceName": "wlan1",
                            "Bridge": "brlan0",
                            "vlanId": 0,
                            "vapIndex": 1,
                            "vapName": "mesh_backhaul_2g"
                        }
                    ]
                }
            ]
        }
    ]
}
```


On co-located EasyMesh Controller+Agent:
```
tpolomik@raspberrypi:~/rdk-easymesh-dev/rdk-wifi-hal $ iw dev
phy#1
	Interface wlan1
		ifindex 4
		wdev 0x100000001
		addr 1c:bf:ce:f4:bf:58
		ssid mesh_backhaul
		type AP
		channel 1 (2412 MHz), width: 20 MHz, center1: 2412 MHz
		txpower 30.00 dBm
		multicast TXQ:
			qsz-byt	qsz-pkt	flows	drops	marks	overlmt	hashcol	tx-bytes	tx-packets
			0	0	0	0	0	0	0	0		0
phy#0
	Unnamed/non-netdev interface
		wdev 0x2
		addr da:3a:dd:85:9f:57
		type P2P-device
		txpower 31.00 dBm
	Interface wlan0
		ifindex 3
		wdev 0x1
		addr d8:3a:dd:85:9f:57
		ssid private_ssid
		type AP
		channel 44 (5220 MHz), width: 80 MHz, center1: 5210 MHz
		txpower 31.00 dBm
```

@amarnathhullur I believe this fixes the "bug" I demonstrated in this morning's dev meeting regarding `mesh_backhaul` SSID not being created despite the `InterfaceMap.json` containing `backhaul_mesh_2g` VAP entry.


