### PR TITLE
RDKB-58681: fixed same SSID RNR IE flag

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -15756,6 +15756,7 @@ static u8* wifi_drv_get_rnr_colocation_ie(void *priv, u8 *eid, size_t *current_l
     size_t i, len = *current_len;
     u8 bss_param, tbtt_count = 0;
     u8 *tbtt_count_pos, *eid_start = eid, *size_offset = eid - len + 1;
+    wifi_interface_info_t *interface_iter, *tx_interface;
     wifi_interface_info_t *interface = (wifi_interface_info_t *)priv;
 
     radio = get_radio_by_rdk_index(interface->vap_info.radio_index);
@@ -15780,8 +15781,10 @@ static u8* wifi_drv_get_rnr_colocation_ie(void *priv, u8 *eid, size_t *current_l
         return eid_start;
     }
 
-    interface = hash_map_get_first(radio->interface_map);
-    while (interface) {
+    tx_interface = wifi_hal_get_mbssid_tx_interface(radio);
+
+    interface_iter = hash_map_get_first(radio->interface_map);
+    while (interface_iter != NULL) {
         if (!len || len + RNR_TBTT_HEADER_LEN + RNR_TBTT_INFO_LEN > 255) {
             eid_start = eid;
             *eid++ = WLAN_EID_REDUCED_NEIGHBOR_REPORT;
@@ -15797,12 +15800,13 @@ static u8* wifi_drv_get_rnr_colocation_ie(void *priv, u8 *eid, size_t *current_l
         len += RNR_TBTT_HEADER_LEN;
 
         pthread_mutex_lock(&g_wifi_hal.hapd_lock);
-        for (;interface; interface = hash_map_get_next(radio->interface_map, interface)) {
+        for (; interface_iter != NULL;
+            interface_iter = hash_map_get_next(radio->interface_map, interface_iter)) {
 
             bss_param = 0;
-            hapd = &interface->u.ap.hapd;
+            hapd = &interface_iter->u.ap.hapd;
 
-            if (!hapd->conf || !hapd->started) {
+            if (hapd->conf == NULL || hapd->iconf == NULL || !hapd->started) {
                 continue;
             }
 
@@ -15816,15 +15820,21 @@ static u8* wifi_drv_get_rnr_colocation_ie(void *priv, u8 *eid, size_t *current_l
             memcpy(eid, &hapd->conf->ssid.short_ssid, 4);
             eid += 4;
 
-            bss_param |= RNR_BSS_PARAM_MULTIPLE_BSSID;
+            bss_param |= hapd->iconf->mbssid != MBSSID_DISABLED ? RNR_BSS_PARAM_MULTIPLE_BSSID : 0;
 
-            if (is_wifi_hal_vap_private(interface->vap_info.vap_index)) {
+            if (interface_iter == tx_interface) {
                 bss_param |= RNR_BSS_PARAM_TRANSMITTED_BSSID;
             }
 
             if (is_6ghz_op_class(hapd->iconf->op_class) &&
                 hapd->conf->unsol_bcast_probe_resp_interval) {
                 bss_param |= RNR_BSS_PARAM_UNSOLIC_PROBE_RESP_ACTIVE;
+            }
+
+            if (interface->u.ap.hapd.conf != NULL &&
+                strncmp(interface->u.ap.hapd.conf->ssid.ssid, hapd->conf->ssid.ssid,
+                    sizeof(hapd->conf->ssid.ssid)) == 0) {
+                bss_param |= RNR_BSS_PARAM_SAME_SSID;
             }
 
             bss_param |= RNR_BSS_PARAM_CO_LOCATED | RNR_BSS_PARAM_MEMBER_CO_LOCATED_ESS;


### PR DESCRIPTION
Reason for change:
  - Same SSID flag in RNR IE was 0
  - Use MBSSID API for MBSSID flags in RNR IE 
Test Procedure:
 - Check RNR IE Same SSID flag
Risks: Low
Priority: P1