### PR TITLE
RDKB-59574: Restrict sta scan and candidates to the configured radio

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -2302,6 +2302,15 @@ INT wifi_hal_startScan(wifi_radio_index_t index, wifi_neighborScanMode_t scan_mo
         return RETURN_ERR;
     }
 
+#if defined(_PLATFORM_BANANAPI_R4_)
+    if (interface->rdk_radio_index != index) {
+        wifi_hal_stats_error_print("%s:%d:Not allowing scan on radio_index: %d because not "
+            "matching with interface->rdk_radio_index:%d\n",
+            __func__, __LINE__, index, interface->rdk_radio_index);
+        return RETURN_ERR;
+    }
+#endif
+
     vap = &interface->vap_info;
     radio_param = &radio->oper_param;
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7571,9 +7571,24 @@ static int scan_results_handler(struct nl_msg *msg, void *arg)
         scan_info = hash_map_get_first(interface->scan_info_map);
         while (scan_info != NULL) {
             if (strcmp(scan_info->ssid, interface->vap_info.u.sta_info.ssid) == 0){
-                bss[desired_scanned_ssid_pos] = *scan_info;
-                ssid_found_count++;
-                desired_scanned_ssid_pos++;
+#if defined(_PLATFORM_BANANAPI_R4_)
+                int scan_info_radio_index = -1;
+                wifi_convert_freq_band_to_radio_index(scan_info->oper_freq_band,
+                    &scan_info_radio_index);
+                if (scan_info_radio_index == interface->rdk_radio_index) {
+#endif
+                    bss[desired_scanned_ssid_pos] = *scan_info;
+                    ssid_found_count++;
+                    desired_scanned_ssid_pos++;
+#if defined(_PLATFORM_BANANAPI_R4_)
+                } else {
+                    wifi_hal_stats_dbg_print(
+                        "%s:%d: [SCAN] Not considering result from freq_band:%d"
+                        " scan_radio_index:%d rdk_radio_index:%d.\n",
+                        __func__, __LINE__, scan_info->oper_freq_band, scan_info_radio_index,
+                        interface->rdk_radio_index);
+                }
+#endif
             }
             scan_info = hash_map_get_next(interface->scan_info_map, scan_info);
         }

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -1104,6 +1104,7 @@ int json_parse_integer(const char* file_name, const char *item_name, int *val);
 int json_parse_boolean(const char* file_name, const char *item_name, bool *val);
 bool get_ifname_from_mac(const mac_address_t *mac, char *ifname);
 int wifi_hal_configure_sta_4addr_to_bridge(wifi_interface_info_t *interface, int add);
+int wifi_convert_freq_band_to_radio_index(int band, int *radio_index);
 
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,

--- a/src/wifi_hal_rdk_util.c
+++ b/src/wifi_hal_rdk_util.c
@@ -587,3 +587,29 @@ bool get_ifname_from_mac(const mac_address_t *mac, char *ifname)
     freeifaddrs(ifaddr);
     return found;
 }
+
+int wifi_convert_freq_band_to_radio_index(int band, int *radio_index)
+{
+    int status = RETURN_OK;
+
+    switch (band) {
+    case WIFI_FREQUENCY_2_4_BAND:
+        *radio_index = 0;
+        break;
+
+    case WIFI_FREQUENCY_5_BAND:
+    case WIFI_FREQUENCY_5L_BAND:
+        *radio_index = 1;
+        break;
+
+    case WIFI_FREQUENCY_5H_BAND:
+    case WIFI_FREQUENCY_6_BAND:
+        *radio_index = 2;
+        break;
+
+    default:
+        status = RETURN_ERR;
+        break;
+    }
+    return status;
+}


### PR DESCRIPTION
Reason for change: Selection of STA scan and candidate list should ensure sta interface radio_index should match. This is required to connect to appropriate AP in the same radio index. Test Procedure: Ensured connection with this change. Priority: P1