### PR TITLE
RDKB-58142: Onewifi SM - Mesh (11be & 320MHz )changes for supporting Wifi-7 clients

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -198,7 +198,7 @@ int platform_get_ssid_default(char *ssid, int vap_index)
     wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
     /* if the vap_index is that of mesh STA or mesh backhaul then try to obtain the ssid from
        /nvram/EasymeshCfg.json file */
-    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+    if (is_wifi_hal_vap_mesh_sta(vap_index) || is_wifi_hal_vap_mesh_backhaul(vap_index)) {
         if (!json_parse_backhaul_ssid(ssid)) {
             wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
             return 0;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9470,7 +9470,8 @@ static void parse_eht_oper(const uint8_t type, uint8_t len, const uint8_t *data,
             bss->oper_chan_bw = WIFI_CHANNELBANDWIDTH_160MHZ;
             break;
         case EHT_OPER_CHANNEL_WIDTH_320MHZ:
-
+            bss->oper_chan_bw = WIFI_CHANNELBANDWIDTH_320MHZ;
+            break;
         default:
             wifi_hal_error_print("%s:%d: Unknown EHT channel width\n", __func__, __LINE__);
             break;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9478,10 +9478,8 @@ static void parse_eht_oper(const uint8_t type, uint8_t len, const uint8_t *data,
         }
     }
 
-    if (bss->oper_freq_band & WIFI_FREQUENCY_6_BAND) {
-        bss->supp_standards |= WIFI_80211_VARIANT_BE;
-        bss->oper_standards = WIFI_80211_VARIANT_BE;
-    }
+    bss->supp_standards |= WIFI_80211_VARIANT_BE;
+    bss->oper_standards = WIFI_80211_VARIANT_BE;
 }
 #endif /* CONFIG_IEEE80211BE */
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9451,6 +9451,33 @@ static void parse_eht_capa(const uint8_t type, uint8_t len, const uint8_t *data,
     bss->supp_standards |= WIFI_80211_VARIANT_BE;
     bss->oper_standards = WIFI_80211_VARIANT_BE;
 }
+
+static void parse_eht_oper(const uint8_t type, uint8_t len, const uint8_t *data,
+    const struct parse_ies_data *ie_buffer, wifi_bss_info_t *bss)
+{
+    (void)type;
+    (void)ie_buffer;
+
+    if (len < 5) {
+        wifi_hal_error_print("%s:%d: Invalid EHT Operation element\n", __func__, __LINE__);
+        return;
+    }
+
+    switch (data[1]) {
+    case 1:
+        bss->oper_chan_bw = WIFI_CHANNELBANDWIDTH_320MHZ;
+        break;
+
+    default:
+        wifi_hal_error_print("%s:%d: MJ Unknown EHT channel width\n", __func__, __LINE__);
+        break;
+    }
+
+    if (bss->oper_freq_band & WIFI_FREQUENCY_6_BAND) {
+        bss->supp_standards |= WIFI_80211_VARIANT_BE;
+        bss->oper_standards = WIFI_80211_VARIANT_BE;
+    }
+}
 #endif /* CONFIG_IEEE80211BE */
 
 static void parse_bss_load(const uint8_t type, uint8_t len, const uint8_t *data,
@@ -9483,6 +9510,9 @@ static void parse_extension_tag(const uint8_t type, uint8_t len, const uint8_t *
 #ifdef CONFIG_IEEE80211BE
         case WLAN_EID_EXT_EHT_CAPABILITIES:
             parse_eht_capa(type, len, data, ie_buffer, bss);
+            break;
+        case WLAN_EID_EXT_EHT_OPERATION:
+            parse_eht_oper(type, len, data, ie_buffer, bss);
             break;
 #endif /* CONFIG_IEEE80211BE */
         default:

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9469,7 +9469,7 @@ static void parse_eht_oper(const uint8_t type, uint8_t len, const uint8_t *data,
         break;
 
     default:
-        wifi_hal_error_print("%s:%d: MJ Unknown EHT channel width\n", __func__, __LINE__);
+        wifi_hal_error_print("%s:%d: Unknown EHT channel width\n", __func__, __LINE__);
         break;
     }
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9458,19 +9458,23 @@ static void parse_eht_oper(const uint8_t type, uint8_t len, const uint8_t *data,
     (void)type;
     (void)ie_buffer;
 
-    if (len < 5) {
-        wifi_hal_error_print("%s:%d: Invalid EHT Operation element\n", __func__, __LINE__);
-        return;
-    }
+    if ((data[1] & EHT_OPER_INFO_PRESENT) && len >= 7) {
+        switch (data[6] & 0x07) {
+        case EHT_OPER_CHANNEL_WIDTH_40MHZ:
+            bss->oper_chan_bw = WIFI_CHANNELBANDWIDTH_40MHZ;
+            break;
+        case EHT_OPER_CHANNEL_WIDTH_80MHZ:
+            bss->oper_chan_bw = WIFI_CHANNELBANDWIDTH_80MHZ;
+            break;
+        case EHT_OPER_CHANNEL_WIDTH_160MHZ:
+            bss->oper_chan_bw = WIFI_CHANNELBANDWIDTH_160MHZ;
+            break;
+        case EHT_OPER_CHANNEL_WIDTH_320MHZ:
 
-    switch (data[1]) {
-    case 1:
-        bss->oper_chan_bw = WIFI_CHANNELBANDWIDTH_320MHZ;
-        break;
-
-    default:
-        wifi_hal_error_print("%s:%d: Unknown EHT channel width\n", __func__, __LINE__);
-        break;
+        default:
+            wifi_hal_error_print("%s:%d: Unknown EHT channel width\n", __func__, __LINE__);
+            break;
+        }
     }
 
     if (bss->oper_freq_band & WIFI_FREQUENCY_6_BAND) {


### PR DESCRIPTION
Reason for change: EHT capabilities is not present at rdk-wifi-hal
Test Procedure: Check WifiMon logs and look for 
                         "check_scan_complete_read_results" which ap_OperatingChannelBandwidth 
                          should be 320MHz for Radio2.
Priority: P1
Risks: Low
Signed-off-by: mothishree_mallaiyanjothimani@comcast.com