### PR TITLE
RDKB-57769: wifi tr181 to mlo configuration

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1068,6 +1068,7 @@ int update_hostap_bss(wifi_interface_info_t *interface)
 
 #ifdef CONFIG_IEEE80211BE
     conf->disable_11be = !radio->iconf.ieee80211be;
+    conf->mld_ap = vap->u.bss_info.mld_info.common_info.mld_enable;
 #endif /* CONFIG_IEEE80211BE */
 
     strcpy(conf->iface, interface->name);

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1068,7 +1068,9 @@ int update_hostap_bss(wifi_interface_info_t *interface)
 
 #ifdef CONFIG_IEEE80211BE
     conf->disable_11be = !radio->iconf.ieee80211be;
+#ifndef SCXER10_PORT
     conf->mld_ap = vap->u.bss_info.mld_info.common_info.mld_enable;
+#endif
 #endif /* CONFIG_IEEE80211BE */
 
     strcpy(conf->iface, interface->name);

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1068,7 +1068,7 @@ int update_hostap_bss(wifi_interface_info_t *interface)
 
 #ifdef CONFIG_IEEE80211BE
     conf->disable_11be = !radio->iconf.ieee80211be;
-#ifndef VNTXER5_PORT
+#if !defined(VNTXER5_PORT) && !defined(TARGET_GEMINI7_2)
     conf->mld_ap = vap->u.bss_info.mld_info.common_info.mld_enable;
 #endif
 #endif /* CONFIG_IEEE80211BE */

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1068,7 +1068,7 @@ int update_hostap_bss(wifi_interface_info_t *interface)
 
 #ifdef CONFIG_IEEE80211BE
     conf->disable_11be = !radio->iconf.ieee80211be;
-#ifndef SCXER10_PORT
+#ifndef VNTXER5_PORT
     conf->mld_ap = vap->u.bss_info.mld_info.common_info.mld_enable;
 #endif
 #endif /* CONFIG_IEEE80211BE */


### PR DESCRIPTION
Reason for change: Implement the following tr181's to support configuration of mlo params, these need to be added under Device.WiFi.AccessPoint:
	mld_enable
	mld_id
	mld_link_id
	mld_addr
	mld_apply
corresponding to:
	RDK_VENDOR_ATTR_MLD_ENABLE
	RDK_VENDOR_ATTR_MLD_ID
	RKD_VENDOR_ATTR_MLD_LINK_ID
	RDK_VENDOR_ATTR_MLD_MAC
	RDK_VENDOR_ATTR_MLD_CONFIG_APPLY
Test Procedure: mld_enable - true for mlo, false for slo mld_id - should be from 0 to 7 from private through mesh mld_link_id - link id of vap
mld_addr - should be bssid of vap for slo, should be bssid of first vap of the group in an mlo. mld_apply - should be 1 for the last vap in a group Priority: P1
Risks: high