### PR TITLE
platform_pi.c: pull EasyMesh mesh backhaul pw from EasymeshCfg.json

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -174,7 +174,7 @@ int platform_get_keypassphrase_default(char *password, int vap_index)
     wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
     /* if the vap_index is that of mesh STA then try to obtain the ssid from
        /nvram/EasymeshCfg.json file */
-    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+    if (is_wifi_hal_vap_mesh_sta(vap_index) || is_wifi_hal_vap_mesh_backhaul(vap_index)) {
         if (!json_parse_backhaul_keypassphrase(password)) {
             wifi_hal_dbg_print("%s:%d, read password from jSON file\n", __func__, __LINE__);
             return 0;


### PR DESCRIPTION
Without this change, the BSS `mesh_backhaul` will have passphrase `12345678` as a default. This PR respects `Backhaul_KeyPassphrase` key from `EasymeshCfg.json` for the mesh backhaul password instead.

Very similar to my previous PR: https://github.com/rdkcentral/rdk-wifi-hal/pull/160