### PR TITLE
RDKB-57507: set new channel when radar detected

### DIFF
--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -881,14 +881,40 @@ static void nl80211_ch_switch_notify_event(wifi_interface_info_t *interface, str
 }
 
 // This function will handle all DFS Events
-static void nl80211_dfs_radar_event(wifi_interface_info_t *interface, struct nlattr **tb) {
-#ifdef CMXB7_PORT
+static void nl80211_dfs_radar_event(wifi_interface_info_t *interface, struct nlattr **tb)
+{
+    wifi_radio_info_t *radio;
+    wifi_interface_info_t *mgt_interface;
     enum nl80211_radar_event event_type = 0;
     int freq = 5180, cf1 = 5180, cf2 = 0, bw = 0, ht_enabled = 0, chan_offset = 0, bandwidth = 0;
 
-    if( strncmp(interface->name, "wlan2", sizeof(interface->name)) ) {
-        wifi_hal_info_print("%s:%d name:%s bss_start:%d \n", __func__, __LINE__, interface->name, interface->bss_started);
-        return ;
+    radio = get_radio_by_rdk_index(interface->vap_info.radio_index);
+    if (radio == NULL) {
+        wifi_hal_error_print("%s:%d failed get radio for index %d\n", __func__, __LINE__,
+            interface->vap_info.radio_index);
+        return;
+    }
+
+    if (radio->oper_param.band != WIFI_FREQUENCY_5_BAND &&
+        radio->oper_param.band != WIFI_FREQUENCY_5L_BAND &&
+        radio->oper_param.band != WIFI_FREQUENCY_5H_BAND) {
+        return;
+    }
+
+    if (g_wifi_hal.platform_flags & PLATFORM_FLAGS_UPDATE_WIPHY_ON_PRIMARY) {
+        mgt_interface = get_primary_interface(radio);
+    }
+    else {
+        mgt_interface = get_private_vap_interface(radio);
+    }
+
+    if (mgt_interface == NULL) {
+        wifi_hal_error_print("%s:%d failed to get primary/private interface\n", __func__, __LINE__);
+        return;
+    }
+
+    if (interface != mgt_interface) {
+        return;
     }
 
     if (!tb[NL80211_ATTR_WIPHY_FREQ] || !tb[NL80211_ATTR_RADAR_EVENT])
@@ -992,7 +1018,7 @@ static void nl80211_dfs_radar_event(wifi_interface_info_t *interface, struct nla
             wifi_hal_error_print("%s:%d  Unknown radar event detected\n", __FUNCTION__, __LINE__);
             break;
     }
-#endif
+
     return ;
 }
 

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -485,6 +485,7 @@ typedef struct {
     unsigned int  prev_channel;
     unsigned int  prev_channelWidth;
     bool radio_presence; //True for ECO mode Active radio, false for ECO mode power down sleeping radio
+    bool radar_detected;
 } wifi_radio_info_t;
 
 typedef wifi_vap_name_t wifi_vap_type_t;


### PR DESCRIPTION
Impacted Platforms:
All RDKB OneWiFi Platforms

Reason for change:
When channel is changed hostap needs to set new beacon buffer with CSA IEs. In case of automatic channel change by driver CSA IEs are missing. To avoid this auto channel selection for DFS radar event is disabled in driver and enabled in application.

Test Procedure:
- enable mgt frame control dmcli eRT setv Device.WiFi.AccessPoint.2.X_RDKCENTRAL-COM_HostapMgtFrameCtrl bool true dmcli eRT setv Device.WiFi.ApplyAccessPointSettings bool true
- enable DFS dmcli eRT setv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DFS.Enable bool true
- set DSF channel dmcli eRT setv Device.WiFi.Radio.2.Channel uint 100 dmcli eRT setv Device.WiFi.ApplyRadioSettings bool 1
- trigger radar event wl -i wl1 radar 2
- check channel is changed
- check CSA IE are available in beacon before channel switch

Risks: Low

Priority: P1

Signed-off-by: Karthikeyan Nanjundan Karthikeyan_Nanjundan@comcast.com