### PR TITLE
RDKB-59523:[OneWifi] Fix 6Ghz Wifi connectivity with WPA3-personal sec

### DIFF
--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -243,8 +243,16 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
         nl80211_parse_wmm_params(tb[NL80211_ATTR_STA_WME], &event.assoc_info.wmm_params);
     }
 
-    event.assoc_info.beacon_ies = interface->ie;
-    event.assoc_info.beacon_ies_len = interface->ie_len;
+    if (interface->vap_info.radio_index < MAX_NUM_RADIOS) {
+        ie_info_t *bss_ie = &interface->bss_elem_ie[interface->vap_info.radio_index];
+        event.assoc_info.beacon_ies = bss_ie->buff;
+        event.assoc_info.beacon_ies_len = bss_ie->buff_len;
+    } else {
+        wifi_hal_info_print("%s:%d: wrong radio index:%d, beacon ie is not set\n",
+            __func__, __LINE__, interface->vap_info.radio_index);
+        event.assoc_info.beacon_ies = NULL;
+	event.assoc_info.beacon_ies_len = 0;
+    }
 
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_ASSOC, &event);
     return;

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -423,6 +423,11 @@ static inline uint* uint_array_values(const uint_array_t *array) {
     return array ? array->values : NULL;
 }
 
+typedef struct ie_info {
+    uint8_t *buff;
+    size_t  buff_len;
+} ie_info_t;
+
 typedef struct wifi_interface_info_t {
     char name[32];
     char bridge[32];
@@ -489,10 +494,8 @@ typedef struct wifi_interface_info_t {
     /* Wi-Fi band steering sta_list_map */
     hash_map_t  *bm_sta_map;
 #if defined(CONFIG_WIFI_EMULATOR) || defined(BANANA_PI_PORT)
-    unsigned char *ie;
-    size_t ie_len;
-    unsigned char *beacon_ie;
-    size_t beacon_ie_len;
+    ie_info_t bss_elem_ie[MAX_NUM_RADIOS];
+    ie_info_t beacon_elem_ie[MAX_NUM_RADIOS];
     struct wpa_supplicant wpa_s;
     struct wpa_ssid current_ssid_info;
 #endif


### PR DESCRIPTION
Reason for change: Made a code changes to store bss ie and beacon ie
                   for all received scan ssid for 2g, 5g and 6g.

Test Procedure:1. Load the OneWifi build.
               2. Test Wi-Fi STA connection.

Priority: P1
Risks: Low

Signed-off-by: aniketnarsinhbhai_Patel@comcast.com