### PR TITLE
RDKB-59512: Update macfilter mode to blacklist for easymesh

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1609,6 +1609,15 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
         }
 
         if (vap->vap_mode == wifi_vap_mode_ap) {
+#if (defined(EASY_MESH_NODE) || defined(EASY_MESH_COLOCATED_NODE))
+            if (isVapMeshBackhaul(vap->vap_index)) {
+#if defined(_PLATFORM_RASPBERRYPI_)
+                interface->vap_info.u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
+#elif defined(_PLATFORM_BANANAPI_R4_)
+                vap->u.bss_info.mac_filter_mode = wifi_mac_filter_mode_black_list;
+#endif
+            }
+#endif // EASY_MESH_NODE || EASY_MESH_COLOCATED_NODE
 #ifdef NL80211_ACL
             if (set_acl == 1) {
                 nl80211_set_acl(interface);


### PR DESCRIPTION
Reason for change: To allow client connection in mesh_backhaul disable macfilter mode whitelist for easymesh
Test Procedure: Ensure with mesh_backhaul, client device can be connected.
Risks: Medium
Priority: P1