### PR TITLE
RDKBACCL-737 : observing build issues in rdk-wifi-hal with latest tip code

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,7 +125,7 @@ librdk_wifihal_la_SOURCES += ../platform/raspberry-pi/platform_pi.c
 endif
 
 if BANANA_PI_PORT
-librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/banana-pi
+librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/banana-pi -I${PKG_CONFIG_SYSROOT_DIR}${includedir}/rdk-wifi-libhostap/wpa_supplicant
 librdk_wifihal_la_SOURCES += ../platform/banana-pi/platform.c
 endif
 

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -41,7 +41,7 @@
 #include "config_supplicant.h"
 #endif
 #ifdef BANANA_PI_PORT
-#include "config.h"
+#include "wpa_supplicant/config.h"
 #endif
 
 #define MAC_ADDRESS_LEN 6

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -68,7 +68,7 @@
 #ifdef CONFIG_WIFI_EMULATOR
 #include "config_supplicant.h"
 #elif defined(BANANA_PI_PORT)
-#include "config.h"
+#include "wpa_supplicant/config.h"
 #endif
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)


### PR DESCRIPTION
Reason for change:  Fix for build issues with latest tip
Test Procedure: Able to compile rdk-wifi-hal
Risks: Low