### PR TITLE
RDKB-59523:[OneWifi] Fix 6Ghz Wifi connectivity with WPA3-personal sec

### DIFF
--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -244,7 +244,10 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
     }
 
     if (interface->vap_info.radio_index < MAX_NUM_RADIOS) {
+        wifi_hal_dbg_print("%s:%d: set beacon ie for radio_index:%d\n", __func__,
+            __LINE__, interface->vap_info.radio_index);
         ie_info_t *bss_ie = &interface->bss_elem_ie[interface->vap_info.radio_index];
+        wpa_hexdump(MSG_MSGDUMP, "ASSOC_BSS_IE", bss_ie->buff, bss_ie->buff_len);
         event.assoc_info.beacon_ies = bss_ie->buff;
         event.assoc_info.beacon_ies_len = bss_ie->buff_len;
     } else {


### PR DESCRIPTION
Reason for change: Made a code changes to store bss ie
                   and beacon ie based on radio band.

Test Procedure:1. Load the OneWifi build.
               2. Test 5g and 6g Wi-Fi STA connection.

Priority: P1
Risks: Low

Signed-off-by: aniketnarsinhbhai_Patel@comcast.com