### PR TITLE
RDKB-59523:[OneWifi] Fix 6Ghz Wifi connectivity with WPA3-personal sec

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8401,8 +8401,8 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
 
     wifi_convert_freq_band_to_radio_index(backhaul->oper_freq_band,
         (int *)&radio_index);
-    ie_info_t *bss_ie = &interface->bss_elem_ie[radio_index];
-    ie_info_t *beacon_ie = &interface->beacon_elem_ie[radio_index];
+    wifi_ie_info_t *bss_ie = &interface->bss_elem_ie[radio_index];
+    wifi_ie_info_t *beacon_ie = &interface->beacon_elem_ie[radio_index];
 
     wifi_hal_dbg_print("%s:%d:bssid:%s frequency:%d ssid:%s sta radio:%d for vap radio:%d\n",
         __func__, __LINE__, to_mac_str(backhaul->bssid, bssid_str),
@@ -9896,7 +9896,7 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
                 uint32_t ie_len = nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
                 wifi_convert_freq_band_to_radio_index(scan_info_ap->oper_freq_band,
                     (int *)&radio_index);
-                ie_info_t *bss_ie = &interface->bss_elem_ie[radio_index];
+                wifi_ie_info_t *bss_ie = &interface->bss_elem_ie[radio_index];
 
                 if (bss_ie->buff == NULL) {
                     bss_ie->buff = (unsigned char *)malloc(ie_len);
@@ -9920,7 +9920,7 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
                 uint32_t beacon_ie_len = nla_len(bss[NL80211_BSS_BEACON_IES]);
                 wifi_convert_freq_band_to_radio_index(scan_info_ap->oper_freq_band,
                     (int *)&radio_index);
-                ie_info_t *beacon_ie = &interface->beacon_elem_ie[radio_index];
+                wifi_ie_info_t *beacon_ie = &interface->beacon_elem_ie[radio_index];
 
                 if (beacon_ie->buff == NULL) {
                     beacon_ie->buff = (unsigned char *)malloc(beacon_ie_len);

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -246,7 +246,7 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
     if (interface->vap_info.radio_index < MAX_NUM_RADIOS) {
         wifi_hal_dbg_print("%s:%d: set beacon ie for radio_index:%d\n", __func__,
             __LINE__, interface->vap_info.radio_index);
-        ie_info_t *bss_ie = &interface->bss_elem_ie[interface->vap_info.radio_index];
+        wifi_ie_info_t *bss_ie = &interface->bss_elem_ie[interface->vap_info.radio_index];
         wpa_hexdump(MSG_MSGDUMP, "ASSOC_BSS_IE", bss_ie->buff, bss_ie->buff_len);
         event.assoc_info.beacon_ies = bss_ie->buff;
         event.assoc_info.beacon_ies_len = bss_ie->buff_len;

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -423,10 +423,12 @@ static inline uint* uint_array_values(const uint_array_t *array) {
     return array ? array->values : NULL;
 }
 
+#if defined(CONFIG_WIFI_EMULATOR) || defined(BANANA_PI_PORT)
 typedef struct ie_info {
     uint8_t *buff;
     size_t  buff_len;
-} ie_info_t;
+} wifi_ie_info_t;
+#endif
 
 typedef struct wifi_interface_info_t {
     char name[32];
@@ -494,8 +496,8 @@ typedef struct wifi_interface_info_t {
     /* Wi-Fi band steering sta_list_map */
     hash_map_t  *bm_sta_map;
 #if defined(CONFIG_WIFI_EMULATOR) || defined(BANANA_PI_PORT)
-    ie_info_t bss_elem_ie[MAX_NUM_RADIOS];
-    ie_info_t beacon_elem_ie[MAX_NUM_RADIOS];
+    wifi_ie_info_t bss_elem_ie[MAX_NUM_RADIOS];
+    wifi_ie_info_t beacon_elem_ie[MAX_NUM_RADIOS];
     struct wpa_supplicant wpa_s;
     struct wpa_ssid current_ssid_info;
 #endif


### PR DESCRIPTION
Reason for change: Change structure name from ie_info_t to wifi_ie_info_t

Test Procedure:1. Load the OneWifi build.
               2. Test 5g and 6g Wi-Fi STA connection.

Priority: P1
Risks: Low

Signed-off-by: aniketnarsinhbhai_Patel@comcast.com