### PR TITLE
RDKBACCL-737 : Enabling common rrm changes for Bpi

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -711,38 +711,6 @@ INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
     return 0;
 }
 
-#ifdef PLATFORM_LINUX
-int wifi_rrm_send_beacon_req(struct wifi_interface_info_t *interface, const u8 *addr,
-    u16 num_of_repetitions, u8 measurement_request_mode, u8 oper_class, u8 channel,
-    u16 random_interval, u16 measurement_duration, u8 mode, const u8 *bssid,
-    struct wpa_ssid_value *ssid, u8 *rep_cond, u8 *rep_cond_threshold, u8 *rep_detail,
-    const u8 *ap_ch_rep, unsigned int ap_ch_rep_len, const u8 *req_elem, unsigned int req_elem_len,
-    u8 *ch_width, u8 *ch_center_freq0, u8 *ch_center_freq1, u8 last_indication)
-{
-    return 0;
-}
-
-/* called by BTM API */
-int wifi_wnm_send_bss_tm_req(struct wifi_interface_info_t *interface, struct sta_info *sta,
-    u8 dialog_token, u8 req_mode, int disassoc_timer, u8 valid_int, const u8 *bss_term_dur,
-    const char *url, const u8 *nei_rep, size_t nei_rep_len, const u8 *mbo_attrs, size_t mbo_len)
-{
-    return 0;
-}
-
-int handle_wnm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
-    struct ieee80211_mgmt *mgmt, size_t len)
-{
-    return 0;
-}
-
-int handle_rrm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
-    const struct ieee80211_mgmt *mgmt, size_t len, int ssi_signal)
-{
-    return 0;
-}
-#endif
-
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
     struct wpa_driver_ap_params *params)

--- a/src/wifi_hal_wnm_rrm.c
+++ b/src/wifi_hal_wnm_rrm.c
@@ -557,7 +557,7 @@ static int handle_rx_wnm_notification_req(wifi_interface_info_t *interface,
     return WIFI_HAL_UNSUPPORTED;
 }
 
-#if !defined(PLATFORM_LINUX)
+#if !defined(PLATFORM_LINUX) || defined(_PLATFORM_BANANAPI_R4_)
 int handle_wnm_action_frame(wifi_interface_info_t *interface, const mac_address_t sta, struct ieee80211_mgmt *mgmt, size_t len)
 {
     u8 action;
@@ -782,7 +782,7 @@ static void wifi_set_disassoc_timer(struct hostapd_data *hapd, struct sta_info *
                 ap_handle_timer, hapd, sta);
 }
 
-#if !defined(PLATFORM_LINUX)
+#if !defined(PLATFORM_LINUX) || defined(_PLATFORM_BANANAPI_R4_)
 /* Implementation is based on wnm_send_bss_tm_req() from wnm_ap.c */
 int wifi_wnm_send_bss_tm_req(wifi_interface_info_t *interface, struct sta_info *sta,
             u8 dialog_token, u8 req_mode, int disassoc_timer, u8 valid_int,
@@ -1429,7 +1429,7 @@ int wifi_hal_parse_rm_beacon_request(unsigned int apIndex, char *buff, size_t le
     return 0;
 }
 
-#if !defined(PLATFORM_LINUX)
+#if !defined(PLATFORM_LINUX) || defined(_PLATFORM_BANANAPI_R4_)
 int handle_rrm_action_frame(wifi_interface_info_t *interface, const mac_address_t sta,
                     const struct ieee80211_mgmt *mgmt, size_t len, int ssi_signal)
 {


### PR DESCRIPTION
Reason for change: Support for beacon report sending
Test Procedure: Validated sending of Beacon report
Risks: Low