### PR TITLE
RDKB-57707: Add nl command code changes for RPI

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -43,6 +43,10 @@ Licensed under the BSD-3 License
 int wifi_nvram_defaultRead(char *in,char *out);
 int _syscmd(char *cmd, char *retBuf, int retBufSize);
 
+typedef struct {
+    mac_address_t *macs;
+    unsigned int num;
+} sta_list_t;
 
 /* FIXME: VIKAS/PRAMOD:
  * If wifi_nvram_defaultRead fail, handle appropriately in callers.
@@ -379,10 +383,188 @@ INT wifi_getApDeviceRSSI(INT ap_index, CHAR *MAC, INT *output_RSSI)
     return 0;
 }
 
+static int get_sta_list_handler(struct nl_msg *msg, void *arg)
+{
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    sta_list_t *sta_list = (sta_list_t *)arg;
+
+    if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0),
+        NULL) < 0) {
+        wifi_hal_stats_error_print("%s:%d Failed to parse sta data\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (tb[NL80211_ATTR_MAC]) {
+        sta_list->macs = realloc(sta_list->macs, (sta_list->num + 1) * sizeof(mac_address_t));
+        if (sta_list->macs) {
+            memcpy(sta_list->macs[sta_list->num], nla_data(tb[NL80211_ATTR_MAC]), sizeof(mac_address_t));
+            sta_list->num++;
+        }
+    }
+
+    return NL_OK;
+}
+
+static int get_sta_list(wifi_interface_info_t *interface, sta_list_t *sta_list)
+{
+    int ret;
+    struct nl_msg *msg = NULL;
+
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, NLM_F_DUMP, NL80211_CMD_GET_STATION);
+    if (msg == NULL) {
+        wifi_hal_stats_error_print("%s:%d Failed to create NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    ret = nl80211_send_and_recv(msg, get_sta_list_handler, sta_list, NULL, NULL);
+    if (ret < 0) {
+        wifi_hal_stats_error_print("%s:%d Failed to execute NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
+{
+    wifi_associated_dev3_t *dev = (wifi_associated_dev3_t *)arg;
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
+    struct nlattr *stats[NL80211_STA_INFO_MAX + 1];
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1] = {
+                [NL80211_STA_INFO_INACTIVE_TIME] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_RX_BYTES] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_BYTES] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_RX_PACKETS] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_PACKETS] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_FAILED] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_CONNECTED_TIME] = { .type = NLA_U32 },
+    };
+    struct nlattr *rate[NL80211_RATE_INFO_MAX + 1];
+    static struct nla_policy rate_policy[NL80211_RATE_INFO_MAX + 1] = {
+                [NL80211_RATE_INFO_BITRATE32] = { .type = NLA_U32 },
+    };
+    struct nl80211_sta_flag_update *sta_flags;
+
+    if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),genlmsg_attrlen(gnlh, 0),
+        NULL) < 0) {
+        wifi_hal_error_print("%s:%d Failed to parse sta data\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (!tb[NL80211_ATTR_STA_INFO]) {
+        wifi_hal_error_print("%s:%d Failed to get sta info attribute\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (tb[NL80211_ATTR_MAC]) {
+        memcpy(dev->cli_MACAddress, nla_data(tb[NL80211_ATTR_MAC]), sizeof(mac_address_t));
+    }
+
+    if (nla_parse_nested(stats, NL80211_STA_INFO_MAX, tb[NL80211_ATTR_STA_INFO], stats_policy)) {
+	wifi_hal_error_print("%s:%d Failed to parse nested attributes\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (stats[NL80211_STA_INFO_RX_BYTES]) {
+        dev->cli_BytesReceived = nla_get_u32(stats[NL80211_STA_INFO_RX_BYTES]);
+    }
+    if (stats[NL80211_STA_INFO_TX_BYTES]) {
+        dev->cli_BytesSent = nla_get_u32(stats[NL80211_STA_INFO_TX_BYTES]);
+    }
+    if (stats[NL80211_STA_INFO_RX_PACKETS]) {
+        dev->cli_PacketsReceived = nla_get_u32(stats[NL80211_STA_INFO_RX_PACKETS]);
+    }
+    if (stats[NL80211_STA_INFO_TX_PACKETS]) {
+        dev->cli_PacketsSent = nla_get_u32(stats[NL80211_STA_INFO_TX_PACKETS]);
+    }
+    if (stats[NL80211_STA_INFO_TX_FAILED]) {
+        dev->cli_ErrorsSent = nla_get_u32(stats[NL80211_STA_INFO_TX_FAILED]);
+    }
+
+    if (stats[NL80211_STA_INFO_TX_BITRATE] &&
+        nla_parse_nested(rate, NL80211_RATE_INFO_MAX, stats[NL80211_STA_INFO_TX_BITRATE], rate_policy) == 0) {
+        if (rate[NL80211_RATE_INFO_BITRATE32]){
+            dev->cli_LastDataDownlinkRate = nla_get_u32(rate[NL80211_RATE_INFO_BITRATE32]) * 100;
+        }
+    }
+    if (stats[NL80211_STA_INFO_RX_BITRATE] &&
+        nla_parse_nested(rate, NL80211_RATE_INFO_MAX, stats[NL80211_STA_INFO_RX_BITRATE], rate_policy) == 0) {
+        if (rate[NL80211_RATE_INFO_BITRATE32]) {
+                dev->cli_LastDataUplinkRate = nla_get_u32(rate[NL80211_RATE_INFO_BITRATE32]) * 100;
+        }
+    }
+
+    if (stats[NL80211_STA_INFO_STA_FLAGS]) {
+        sta_flags = nla_data(stats[NL80211_STA_INFO_STA_FLAGS]);
+        dev->cli_AuthenticationState = sta_flags->mask & (1 << NL80211_STA_FLAG_AUTHORIZED) &&
+            sta_flags->set & (1 << NL80211_STA_FLAG_AUTHORIZED);
+    }
+
+    return NL_OK;
+}
+
+static int get_sta_stats(wifi_interface_info_t *interface, mac_address_t mac, wifi_associated_dev3_t *dev)
+{
+    int ret;
+    struct nl_msg *msg = NULL;
+
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_GET_STATION);
+    if (msg == NULL) {
+        wifi_hal_error_print("%s:%d Failed to create NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    nla_put(msg, NL80211_ATTR_MAC, sizeof(mac_address_t), mac);
+
+    ret = nl80211_send_and_recv(msg, get_sta_stats_handler, dev, NULL, NULL);
+    if (ret < 0) {
+        wifi_hal_error_print("%s:%d Failed to execute NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    return 0;
+}
+
 INT wifi_getApAssociatedDeviceDiagnosticResult3(INT apIndex,
     wifi_associated_dev3_t **associated_dev_array, UINT *output_array_size)
 {
-    return 0;
+    int ret;
+    unsigned int i;
+    sta_list_t sta_list = {};
+    wifi_interface_info_t *interface;
+
+    interface = get_interface_by_vap_index(apIndex);
+    if (interface == NULL) {
+        wifi_hal_stats_error_print("%s:%d Failed to get interface for index %d\n", __func__, __LINE__, apIndex);
+        return -1;
+    }
+
+    ret = get_sta_list(interface, &sta_list);
+    if (ret < 0) {
+        wifi_hal_stats_error_print("%s:%d Failed to get sta list\n", __func__, __LINE__);
+        goto exit;
+    }
+
+    *associated_dev_array = sta_list.num ?
+        calloc(sta_list.num, sizeof(wifi_associated_dev3_t)) : NULL;
+    *output_array_size = sta_list.num;
+
+    for (i = 0; i < sta_list.num; i++) {
+        ret = get_sta_stats(interface, sta_list.macs[i], &(*associated_dev_array)[i]);
+        if (ret < 0) {
+            wifi_hal_stats_error_print("%s:%d Failed to get sta stats\n", __func__, __LINE__);
+            free(*associated_dev_array);
+            *associated_dev_array = NULL;
+            *output_array_size = 0;
+            goto exit;
+        }
+    }
+
+exit:
+    free(sta_list.macs);
+    return ret;
 }
 
 INT wifi_setRadioDfsAtBootUpEnable(INT radioIndex, BOOL enable) // Tr181

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -95,8 +95,6 @@ struct family_data {
     int id;
 };
 
-struct nl_msg *nl80211_drv_cmd_msg(int nl80211_id, wifi_interface_info_t *intf, int flags, uint8_t cmd);
-
 int nl80211_send_and_recv(struct nl_msg *msg,
              int (*valid_handler)(struct nl_msg *, void *),
              void *valid_data,

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -817,6 +817,7 @@ int     wifi_send_eapol(void *priv, const u8 *addr, const u8 *data,
                     size_t data_len, int encrypt,
                     const u8 *own_addr, u32 flags);
 void   *wifi_drv_init(struct hostapd_data *hapd, struct wpa_init_params *params);
+struct nl_msg *nl80211_drv_cmd_msg(int nl80211_id, wifi_interface_info_t *intf, int flags, uint8_t cmd);
 struct nl_msg *nl80211_drv_vendor_cmd_msg(int nl80211_id, wifi_interface_info_t *intf, int flags,
     uint32_t vendor_id, uint32_t subcmd);
 int nl80211_send_and_recv(struct nl_msg *msg, int (*valid_handler)(struct nl_msg *, void *),


### PR DESCRIPTION
Reason for change: Added code for getting associated device stats using nl commands. Used existing rdk-wifi-hal API for msg creation, send and receive.
Test Procedure: Ensure associated device stats data is populated for RPI4 device
Risks: Medium
Priority: P1