### PR TITLE
RDKB-58755:[OneWifi]4way_handshake timeout increase for Apple Clients…

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1311,7 +1311,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
     platform_create_vap_t set_vap_params_fn;
     unsigned int i;
     char msg[2048];
-    int ret = 0;
+    int ret = RETURN_OK;
 #ifdef NL80211_ACL
     int set_acl = 0;
 #else
@@ -1321,7 +1321,6 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
 #if defined(VNTXER5_PORT)
     char mld_ifname[32];
 #endif
-    int ret = RETURN_OK;
 
     RADIO_INDEX_ASSERT(index);
     NULL_PTR_ASSERT(map);

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1321,6 +1321,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
 #if defined(VNTXER5_PORT)
     char mld_ifname[32];
 #endif
+    int ret = RETURN_OK;
 
     RADIO_INDEX_ASSERT(index);
     NULL_PTR_ASSERT(map);
@@ -1501,7 +1502,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                         wifi_hal_info_print("%s:%d: interface:%s enable ap\n", __func__,
                             __LINE__, interface->name);
                         interface->beacon_set = 0;
-                        start_bss(interface);
+                        ret = start_bss(interface);
                         interface->bss_started = true;
                     }
                 } else {
@@ -1543,7 +1544,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                         wifi_hal_info_print("%s:%d: interface:%s enable ap\n", __func__,
                             __LINE__, interface->name);
                         interface->beacon_set = 0;
-                        start_bss(interface);
+                        ret = start_bss(interface);
                         interface->bss_started = true;
                     }
                     else {
@@ -1563,7 +1564,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                     wifi_hal_info_print("%s:%d: interface:%s enable ap\n", __func__,
                         __LINE__, interface->name);
                     interface->beacon_set = 0;
-                    start_bss(interface);
+                    ret = start_bss(interface);
                     interface->bss_started = true;
                 }
             }
@@ -1684,7 +1685,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
         set_vap_params_fn(index, map);
     }
 
-    return RETURN_OK;
+    return ret;
 }
 
 INT wifi_hal_kickAssociatedDevice(INT ap_index, mac_address_t mac)

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -955,6 +955,10 @@ static void nl80211_ch_switch_notify_event(wifi_interface_info_t *interface, str
         ch_switch_update_hostap_config(radio, channel, op_class, freq, cf1, cf2,
             hostap_channel_width, l_channel_width);
 
+        if (interface->vap_info.vap_mode == wifi_vap_mode_ap) {
+            wifi_hal_info_print("%s:%d:csa_in_progress:%d for radio:%d\r\n", __func__,
+                __LINE__, interface->u.ap.hapd.csa_in_progress, interface->vap_info.radio_index);
+        }
         if (interface->vap_info.vap_mode == wifi_vap_mode_ap &&
             (interface->u.ap.hapd.csa_in_progress || interface->u.ap.hapd.iface->freq != freq)) {
             pthread_mutex_lock(&g_wifi_hal.hapd_lock);

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -939,7 +939,7 @@ int     nl80211_get_channel_bw_conn(wifi_interface_info_t *interface);
 void    update_wpa_sm_params(wifi_interface_info_t *interface);
 void    update_eapol_sm_params(wifi_interface_info_t *interface);
 void    *nl_recv_func(void *arg);
-void    start_bss(wifi_interface_info_t *interface);
+int     start_bss(wifi_interface_info_t *interface);
 int     process_global_nl80211_event(struct nl_msg *msg, void *arg);
 int     no_seq_check(struct nl_msg *msg, void *arg);
 void    *eloop_run_thread(void *data);


### PR DESCRIPTION
…-RC fix

Reason for change: Added Radio Channel changed CSA in progress print
                   as part of channel change CB.

Test Procedure: 1. Load OneWifi Image.
                2. Connect client with all vaps.
                3. Change radio channel.
                4. Immediately trigger change SSID for private_vap.
                5. Check client connectivity with Client.

Risks: Low
Priority: P0

Change-Id: I8707a4143a12dc4fc0a5aca441c072c61b4b44cd
Signed-off-by: aniketnarsinhbhai_Patel@comcast.com