### PR TITLE
RDKB-59519: fixed MBSSID attribute check

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -4208,7 +4208,7 @@ static void wiphy_info_mbssid(struct wpa_driver_capa *cap, struct nlattr *attr)
         return;
     }
 
-    if (config[NL80211_MBSSID_CONFIG_ATTR_MAX_INTERFACES] != NULL) {
+    if (config[NL80211_MBSSID_CONFIG_ATTR_MAX_INTERFACES] == NULL) {
         return;
     }
 


### PR DESCRIPTION
Reason for change: wrong attr check for max MBSSID interfaces 
Test Procedure:
 cat /tmp/wifiHal | grep -i mbssid
 mbssid: max interfaces 8, max profile periodicity 0
Risks: Low
Priority: P1