### PR TITLE
RDKBACCL-322 : observing build issues in latest tip of rdk-wifi-hal

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,7 +129,7 @@ librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/banana-pi -I${PKG_CONF
 librdk_wifihal_la_SOURCES += ../platform/banana-pi/platform.c
 endif
 
-include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h hs20.h ../util_crypto/aes_siv.h 
+include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h ../util_crypto/aes_siv.h 
 
 if ONE_WIFIBUILD
 include_HEADERS += wifi_hal_priv.h wifi_hal_wnm_rrm.h


### PR DESCRIPTION
Reason for change:  Errors are below,
make[2]: *** No rule to make target 'hs20.h', needed by 'all-am'.  
Stop. make[2]: *** Waiting for unfinished jobs....
hs20.h came from rdk-wifi-libhostap and this file is available in below recipe-sysroot path,
~/build-bananapi4-rdk-broadband/tmp/work/cortexa53-rdk-linux/rdk-wifi-hal/6.1+gitAUTOINC+36cf454bc3-r0/recipe-sysroot/usr/include/rdk-wifi-libhostap/src/ap$ ls hs20.h hs20.h
Also, this path is already declared in makefile.am
Test Procedure: Able to compile rdk-wifi-hal
Risks: Low