### PR TITLE
RDKBWIFI-37: Ports backhaul mesh cfg reading to BPi and fixes MAC parsing

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -154,7 +154,7 @@ int platform_get_keypassphrase_default(char *password, int vap_index)
     wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
     /* if the vap_index is that of mesh STA then try to obtain the ssid from
        /nvram/EasymeshCfg.json file */
-    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+    if (is_wifi_hal_vap_mesh_sta(vap_index)  || is_wifi_hal_vap_mesh_backhaul(vap_index)) {
         if (!json_parse_backhaul_keypassphrase(password)) {
             wifi_hal_dbg_print("%s:%d, read password from jSON file\n", __func__, __LINE__);
             return 0;
@@ -176,7 +176,7 @@ int platform_get_ssid_default(char *ssid, int vap_index)
     wifi_hal_dbg_print("%s:%d \n", __func__, __LINE__);
     /* if the vap_index is that of mesh STA or mesh backhaul then try to obtain the ssid from
        /nvram/EasymeshCfg.json file */
-    if (is_wifi_hal_vap_mesh_sta(vap_index)) {
+    if (is_wifi_hal_vap_mesh_sta(vap_index)  || is_wifi_hal_vap_mesh_backhaul(vap_index)) {
         if (!json_parse_backhaul_ssid(ssid)) {
             wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
             return 0;

--- a/src/wifi_hal_frame_test.c
+++ b/src/wifi_hal_frame_test.c
@@ -21,19 +21,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <errno.h>
 #include <unistd.h>
 #include <net/if_arp.h>
 #include <arpa/inet.h>
 #include <net/if.h>
-#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 #include <unistd.h>
 #include "wifi_hal.h"
 #include "wifi_hal_rdk.h"
+#include "wifi_hal_priv.h"
 #include "pcap.h"
 #include "ieee80211.h"
 
@@ -199,32 +198,6 @@ int parse_mgmt_frame(struct ieee80211_frame *frame, size_t len, frame_test_arg_t
 int parse_ctl_frame(struct ieee80211_frame *frame, size_t len, frame_test_arg_t *arg, wifi_direction_t dir)
 {
     return RETURN_ERR;
-}
-
-int get_mac_address (char *intf_name,  mac_address_t mac)
-{
-#ifdef LINUX_PORT
-    int sock;
-    struct ifreq ifr;
-
-    if ((sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
-        printf("Failed to create socket\n");
-        return -1;
-    }
-
-    ifr.ifr_addr.sa_family = AF_INET;
-       strcpy(ifr.ifr_name, intf_name);
-    if (ioctl(sock, SIOCGIFHWADDR, &ifr) != 0) {
-        close(sock);
-        printf("ioctl failed to get hardware address\n");
-        return -1;
-    }
-
-    memcpy(mac, (unsigned char *)ifr.ifr_hwaddr.sa_data, sizeof(mac_address_t));
-    close(sock);
-#endif
-
-    return 0;
 }
 
 int parse_frame(unsigned char *data, size_t len, frame_test_arg_t *arg, wifi_direction_t *frame_dir)

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <net/if.h>
 #include <linux/rtnetlink.h>
 #include <netpacket/packet.h>
@@ -1577,6 +1578,28 @@ int getIpStringFromAdrress (char * ipString, ip_addr_t * ip)
     return 1;
 }
 #endif
+
+int get_mac_address (char *intf_name,  mac_address_t mac)
+{
+    int sock;
+    struct ifreq ifr;
+
+    if ((sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+        return RETURN_ERR;
+    }
+
+    ifr.ifr_addr.sa_family = AF_INET;
+    strcpy(ifr.ifr_name, intf_name);
+    if (ioctl(sock, SIOCGIFHWADDR, &ifr) != 0) {
+        close(sock);
+        return RETURN_ERR;
+    }
+
+    memcpy(mac, (unsigned char *)ifr.ifr_hwaddr.sa_data, sizeof(mac_address_t));
+    close(sock);
+
+    return RETURN_OK;
+}
 
 int set_interface_properties(unsigned int phy_index, wifi_interface_info_t *interface)
 {

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -872,6 +872,7 @@ wifi_interface_info_t *wifi_hal_get_vap_interface_by_type(wifi_radio_info_t *rad
 int nl80211_init_primary_interfaces();
 int nl80211_init_radio_info();
 int getIpStringFromAdrress(char * ipString,  ip_addr_t * ip);
+int get_mac_address (char *intf_name,  mac_address_t mac);
 int create_ecomode_interfaces(void);
 void update_ecomode_radio_capabilities(wifi_radio_info_t *radio);
 int convert_string_to_int(int **int_list, char *val);


### PR DESCRIPTION


Reason for change:
- For the Mesh SSID change, the same as #160, just ported to Banana Pi
- For `ifconfig`, newer versions user `ether` instead of `HWaddr` so grepping for a specific string causes issues. 
```
br-lan: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        inet6 fe80::f4dd:a6ff:fe3b:1241  prefixlen 64  scopeid 0x20<link>
        ether 00:0c:43:26:80:b9  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 11  bytes 1354 (1.3 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1504
        ether fe:19:05:94:61:5c  txqueuelen 1000  (Ethernet)
        RX packets 403231  bytes 314620117 (314.6 MB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 112814  bytes 54730025 (54.7 MB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 101  
```
Test Procedure:
Start OneWifi and see if the AL MAC and CM MAC are set. 

Risks: Medium
Priority: P1

@amarnathhullur @gsathish86 

This has been tested and works on the Banana Pi and Raspberry Pi although (because of the broader MAC address fetching changes), this should likely be tested on the internal tests before being merged.
