### PR TITLE
RDKBWIFI-38: Copies over entire BSS IE buffer to scan results and cleans up parsing

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -2484,6 +2484,8 @@ static int wpa_sm_sta_get_beacon_ie(void *ctx)
     wifi_interface_info_t *interface;
     wifi_bss_info_t *backhaul;
     wifi_bss_info_t *bss;
+    ieee80211_tlv_t *rsn_ie = NULL;
+    int ret = -1;
 
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
 
@@ -2493,14 +2495,18 @@ static int wpa_sm_sta_get_beacon_ie(void *ctx)
     pthread_mutex_lock(&interface->scan_info_mutex);
     bss = hash_map_get_first(interface->scan_info_map);
     while (bss != NULL) {
-        if (memcmp(backhaul->bssid, bss->bssid, sizeof(bssid_t)) == 0) {
-            if (bss->ie_len > 0) {
-                int ret;
-                wifi_hal_dbg_print("SET RSN IE\n");
-                ret = wpa_sm_set_ap_rsn_ie(interface->u.sta.wpa_sm, bss->ie, bss->ie_len);
-                pthread_mutex_unlock(&interface->scan_info_mutex);
-                return ret;
+        if (memcmp(backhaul->bssid, bss->bssid, sizeof(bssid_t)) == 0 && bss->ie != NULL) {
+
+            rsn_ie = (ieee80211_tlv_t *)get_ie((unsigned char *)bss->ie, bss->ie_len, WLAN_EID_RSN);
+            if (rsn_ie == NULL) {
+                bss = hash_map_get_next(interface->scan_info_map, bss);
+                continue;
             }
+
+            ret = wpa_sm_set_ap_rsn_ie(interface->u.sta.wpa_sm, (const unsigned char *)rsn_ie,
+                rsn_ie->length + sizeof(ieee80211_tlv_t));
+            pthread_mutex_unlock(&interface->scan_info_mutex);
+            return ret;
         }
         bss = hash_map_get_next(interface->scan_info_map, bss);
     }
@@ -2559,6 +2565,7 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
     mac_addr_str_t bssid_str;
     int sel, key_mgmt = 0;
     int wpa_key_mgmt_11w = 0;
+    ieee80211_tlv_t *rsn_ie = NULL;
 
     vap = &interface->vap_info;
     sec = &vap->u.sta_info.security;
@@ -2653,8 +2660,11 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
     wpa_sm_set_param(sm, WPA_PARAM_RSN_ENABLED, 1);
     wpa_sm_set_param(sm, WPA_PARAM_PROTO, WPA_PROTO_RSN);
 
-    if (backhaul->ie_len && (wpa_parse_wpa_ie_rsn(backhaul->ie, backhaul->ie_len, &data) == 0)) {
-	wpa_sm_set_param(sm, WPA_PARAM_PAIRWISE, WPA_CIPHER_CCMP);
+    rsn_ie = (ieee80211_tlv_t *)get_ie(backhaul->ie, backhaul->ie_len, WLAN_EID_RSN);
+    if (rsn_ie &&
+        (wpa_parse_wpa_ie_rsn((const unsigned char *)rsn_ie,
+             rsn_ie->length + sizeof(ieee80211_tlv_t), &data) == 0)) {
+        wpa_sm_set_param(sm, WPA_PARAM_PAIRWISE, WPA_CIPHER_CCMP);
         wpa_sm_set_param(sm, WPA_PARAM_GROUP, data.group_cipher);
 
         if (data.key_mgmt & WPA_KEY_MGMT_NONE) {

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8561,6 +8561,7 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
 #if !defined(CONFIG_WIFI_EMULATOR) && !defined(BANANA_PI_PORT)
     u32 ver = 0;
     u8 *pos, rsn_ie[128];
+    ieee80211_tlv_t *bh_rsn = NULL;
     struct wpa_auth_config wpa_conf = {0};
     struct wpa_ie_data data;
     struct nl_msg *msg;
@@ -8792,8 +8793,10 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
 
     pos = rsn_ie;
 
-
-    if (backhaul->ie_len && (wpa_parse_wpa_ie_rsn(backhaul->ie, backhaul->ie_len, &data) == 0)) {
+    bh_rsn = (ieee80211_tlv_t *)get_ie(backhaul->ie, backhaul->ie_len, WLAN_EID_RSN);
+    if (bh_rsn &&
+        (wpa_parse_wpa_ie_rsn((const u8 *)bh_rsn, bh_rsn->length + sizeof(ieee80211_tlv_t),
+             &data) == 0)) {
         wpa_conf.wpa_group = data.group_cipher;
         wpa_conf.rsn_pairwise = WPA_CIPHER_CCMP;
         if (data.key_mgmt & WPA_KEY_MGMT_NONE) {
@@ -9921,12 +9924,11 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
     mac_addr_str_t  bssid_str = {0};
     wifi_vap_info_t *vap;
     ieee80211_tlv_t *rsn_ie = NULL;
-    ieee80211_tlv_t *ie = NULL, *ie_ssid = NULL;
-    signed int len;
-    unsigned short ie_ssid_len;
+    ieee80211_tlv_t *ie = NULL;
+    ieee80211_tlv_t *beacon_ies = NULL;
+    signed int len, beacon_ie_len;
     const char *key = NULL;
-    wifi_bss_info_t* scan_info_ap = NULL;
-    ssid_t          ssid = {0};
+    wifi_bss_info_t *scan_info_ap = NULL;
 
     interface = (wifi_interface_info_t *)arg;
     vap = &interface->vap_info;
@@ -9967,10 +9969,9 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
         return NL_SKIP;
     }
 
-    if (get_ie_by_eid(WLAN_EID_SSID, (unsigned char *)ie, len, (unsigned char **)&ie_ssid, &ie_ssid_len) == true) {
-        size_t ssid_len = ie_ssid_len - sizeof(ieee80211_tlv_t);
-        if (ssid_len > sizeof(ssid_t)-1) ssid_len = sizeof(ssid_t)-1;
-        memcpy(ssid, ie_ssid->value, ssid_len);
+    if (bss[NL80211_BSS_BEACON_IES]) {
+        beacon_ies = nla_data(bss[NL80211_BSS_BEACON_IES]);
+        beacon_ie_len = nla_len(bss[NL80211_BSS_BEACON_IES]);
     }
 
     // - create separate AP info entry for wifi_getNeighboringWiFiStatus().
@@ -9986,7 +9987,6 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
 
     // - update BSSID and SSID in AP scan results
     memcpy(scan_info_ap->bssid, bssid, sizeof(mac_address_t));
-    _COPY(scan_info_ap->ssid, ssid);
 
     // - freq / channel / band
     if (bss[NL80211_BSS_FREQUENCY]) {
@@ -10051,15 +10051,21 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
 #endif
 
     // - ies
-    if (bss[NL80211_BSS_INFORMATION_ELEMENTS]) {
-        parse_ies(nla_data(bss[NL80211_BSS_INFORMATION_ELEMENTS]),
-            nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]), scan_info_ap);
+    uint32_t radio_index = 0;
+    wifi_convert_freq_band_to_radio_index(scan_info_ap->oper_freq_band, (int *)&radio_index);
+
+    if (ie) {
+        // Parse standard IEs including SSID
+        parse_ies(ie, len, scan_info_ap);
+    } else {
+        // Parse IEs from beacon IEs (including SSID)
+        parse_ies(beacon_ies, beacon_ie_len, scan_info_ap);
     }
-    else {
-        if (bss[NL80211_BSS_BEACON_IES]) {
-            parse_ies(nla_data(bss[NL80211_BSS_BEACON_IES]),
-                nla_len(bss[NL80211_BSS_BEACON_IES]), scan_info_ap);
-        }
+
+    if (ie != NULL && len > 0) {
+        // Copy into IEs buffer
+        scan_info_ap->ie_len = len;
+        memcpy(scan_info_ap->ie, ie, scan_info_ap->ie_len);
     }
 
     if (vap->vap_mode == wifi_vap_mode_sta) {
@@ -10070,69 +10076,47 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
                         to_mac_str(bssid, bssid_str), scan_info_ap->rssi, scan_info_ap->freq, scan_info_ap->ssid);
             memcpy(vap->u.sta_info.bssid, bssid, sizeof(bssid_t));
 #if defined(CONFIG_WIFI_EMULATOR) || defined(BANANA_PI_PORT)
-            if (bss[NL80211_BSS_INFORMATION_ELEMENTS]) {
-                uint32_t radio_index = 0;
-                uint32_t ie_len = nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
-                wifi_convert_freq_band_to_radio_index(scan_info_ap->oper_freq_band,
-                    (int *)&radio_index);
-                wifi_ie_info_t *bss_ie = &interface->bss_elem_ie[radio_index];
 
-                if (bss_ie->buff == NULL) {
-                    bss_ie->buff = (unsigned char *)malloc(ie_len);
-                } else if (ie_len > bss_ie->buff_len) {
-                    bss_ie->buff = (unsigned char *)realloc(bss_ie->buff, ie_len);
-                }
-                if (bss_ie->buff != NULL) {
-                    bss_ie->buff_len = ie_len;
-                    memset(bss_ie->buff, 0, bss_ie->buff_len);
-                    memcpy(bss_ie->buff, nla_data(bss[NL80211_BSS_INFORMATION_ELEMENTS]), bss_ie->buff_len);
+            wifi_ie_info_t *bss_ie = &interface->bss_elem_ie[radio_index];
+            wifi_ie_info_t *beacon_ie = &interface->beacon_elem_ie[radio_index];
 
-                    wifi_hal_stats_dbg_print("%s:%d: bss ie for radio:%d\n", __func__, __LINE__, radio_index);
-                    wpa_hexdump(MSG_MSGDUMP, "SCAN_BSS_IE", bss_ie->buff, bss_ie->buff_len);
-                } else {
-                    wifi_hal_stats_error_print("%s:%d bss ie not updated for radio:%d\r\n", __func__, __LINE__, radio_index);
-                    bss_ie->buff_len = 0;
-                }
+            // `realloc` mallocs a buffer of size 'beacon_ie_len' if buff == NULL
+            if (ie && (bss_ie->buff = (u8 *)realloc(bss_ie->buff, len)) != NULL) {
+
+                // ie and len previously parsed
+                bss_ie->buff_len = len;
+                memcpy(bss_ie->buff, ie, bss_ie->buff_len);
+
+                wifi_hal_stats_dbg_print("%s:%d: bss ie for radio:%d\n", __func__, __LINE__,
+                    radio_index);
+                wpa_hexdump(MSG_MSGDUMP, "SCAN_BSS_IE", bss_ie->buff, bss_ie->buff_len);
+            } else {
+                wifi_hal_stats_error_print("%s:%d bss ie not updated for radio:%d\r\n", __func__,
+                    __LINE__, radio_index);
+                bss_ie->buff_len = 0;
             }
-            if (bss[NL80211_BSS_BEACON_IES]) {
-                uint32_t radio_index = 0;
-                uint32_t beacon_ie_len = nla_len(bss[NL80211_BSS_BEACON_IES]);
-                wifi_convert_freq_band_to_radio_index(scan_info_ap->oper_freq_band,
-                    (int *)&radio_index);
-                wifi_ie_info_t *beacon_ie = &interface->beacon_elem_ie[radio_index];
 
-                if (beacon_ie->buff == NULL) {
-                    beacon_ie->buff = (unsigned char *)malloc(beacon_ie_len);
-                } else if (beacon_ie_len > beacon_ie->buff_len) {
-                    beacon_ie->buff = (unsigned char *)realloc(beacon_ie->buff, beacon_ie_len);
-                }
-                if (beacon_ie->buff != NULL) {
-                    beacon_ie->buff_len = beacon_ie_len;
-                    memset(beacon_ie->buff, 0, beacon_ie->buff_len);
-                    memcpy(beacon_ie->buff, nla_data(bss[NL80211_BSS_BEACON_IES]), beacon_ie->buff_len);
-                } else {
-                    wifi_hal_stats_error_print("%s:%d beacon ie not updated for radio:%d\r\n", __func__, __LINE__, radio_index);
-                    beacon_ie->buff_len = 0;
-                }
+            if (beacon_ies &&
+                (beacon_ie->buff = (u8 *)realloc(beacon_ie->buff, beacon_ie_len)) != NULL) {
+
+                // ie and len previously parsed
+                bss_ie->buff_len = beacon_ie_len;
+                memcpy(bss_ie->buff, beacon_ies, bss_ie->buff_len);
+
+                wifi_hal_stats_dbg_print("%s:%d: bss ie for radio:%d\n", __func__, __LINE__,
+                    radio_index);
+                wpa_hexdump(MSG_MSGDUMP, "SCAN_BSS_IE", bss_ie->buff, bss_ie->buff_len);
+            } else {
+                wifi_hal_stats_error_print("%s:%d bss ie not updated for radio:%d\r\n", __func__,
+                    __LINE__, radio_index);
+                bss_ie->buff_len = 0;
             }
 #endif
         }
     }
 
-    if (ie != NULL) {
-        // wifi_hal_dbg_print("[SCAN] RSN FOUND\n");
-        rsn_ie = (ieee80211_tlv_t *)get_ie((unsigned char*)ie, len, WLAN_EID_RSN);
-
-        if (rsn_ie != NULL) {
-            scan_info_ap->ie_len = rsn_ie->length + 2;
-            os_memcpy(scan_info_ap->ie, rsn_ie, scan_info_ap->ie_len);
-        } else {
-            // wifi_hal_dbg_print("[SCAN] RSN NOT FOUND\n");
-        }
-    }
-
     // - create or update the scan info in 'scan_info_map'
-    if (ssid[0] != '\0') {
+    if (scan_info_ap->ssid[0] != '\0') {
         wifi_hal_stats_dbg_print("%s:%d: [SCAN] found bss:%s rssi:%d ssid:%s on freq:%d \n",
             __func__, __LINE__, to_mac_str(bssid, bssid_str), scan_info_ap->rssi,
             scan_info_ap->ssid, scan_info_ap->freq);


### PR DESCRIPTION
Reason for change:

Currently only the RSN IE is copied over to the `wifi_bss_info_t::ie` buffer. This eliminates necessary information for other applications and services, now and (I am sure) in the future. This change copies the entire BSS IE buffer to the `wifi_bss_info_t::ie` buffer and, in the cases where the `wifi_bss_info_t::ie` buffer (acting as the RSN IE) was used, a `get_ie` call is used before to get the RSN IE and pass that to the corresponding function. 

While there is an existing `wifi_interface_t::bss_elem_ie` (only used for the emulator and the BPi for some reason), that is for a specific interface, not a specific scan result. This PR is intended to bring full BSS IE access to scan results.

There were also several repeated/unnecessary instances of parsing code and variables that are (at least no longer) needed.

Test Procedure:
Start OneWifi with a station interface (in the `InterfaceMap`) and network credentials in `EasymeshCfg.json` and confirm that the station can associate.

Risks: Medium
Priority: P1

**This has been tested on both the Banana Pi R4 and the Raspberry Pi 4. On both platforms, they yielded the same results on the `develop` branch build of OneWifi and this build of `OneWifi`**

**DEPENDS ON [**halinterface #36**](https://github.com/rdkcentral/rdkb-halif-wifi/pull/36) ✅ to be merged to work! Otherwise a segfault will occur**

@amarnathhullur @gsathish86 