### PR TITLE
RDKB-59859: Add Banana pi sta support

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -745,7 +745,7 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
     RADIO_INDEX_ASSERT(index);
     NULL_PTR_ASSERT(operationParam);
 
-#ifdef CONFIG_WIFI_EMULATOR
+#if defined(CONFIG_WIFI_EMULATOR) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
     radio = get_radio_by_rdk_index(index);
     if (radio == NULL) {
         wifi_hal_error_print("%s:%d:Could not find radio index:%d\n", __func__, __LINE__, index);
@@ -1591,7 +1591,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             }
 
         } else if (vap->vap_mode == wifi_vap_mode_sta) {
-#if defined(CONFIG_WIFI_EMULATOR) || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
+#if defined(CONFIG_WIFI_EMULATOR)
             if (nl80211_create_bridge(interface->name, vap->bridge_name) != 0) {
                 wifi_hal_error_print("%s:%d: interface:%s failed to create bridge:%s\n",
                         __func__, __LINE__, interface->name, vap->bridge_name);
@@ -1610,6 +1610,12 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             //XXX set correct status after reconfigure and call conn status callback
             //nl80211_start_scan(interface);
             interface->vap_initialized = true;
+
+#ifdef CONFIG_WIFI_EMULATOR_EXT_AGENT
+            nl80211_interface_enable(interface->name, false);
+            nl80211_set_mac(interface);
+            nl80211_interface_enable(interface->name, true);
+#endif
             if (radio->configured && radio->oper_param.enable) {
                 wifi_hal_info_print("%s:%d: interface:%s set operstate 1\n", __func__,
                     __LINE__, interface->name);
@@ -1619,7 +1625,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                     interface->name);
                 nl80211_interface_enable(interface->name, false);
             }
-#endif //CONFIG_WIFI_EMULATOR || defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
+#endif //CONFIG_WIFI_EMULATOR
         }
 
         if (vap->vap_mode == wifi_vap_mode_ap) {

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -447,6 +447,10 @@ int update_hostap_data(wifi_interface_info_t *interface)
         wifi_hal_error_print("%s:%d:driver params is NULL\n", __func__, __LINE__);
         return RETURN_ERR;
     }
+#ifdef CONFIG_WIFI_EMULATOR_EXT_AGENT
+    interface->u.sta.wpa_sm = NULL;
+#endif
+
     return RETURN_OK;
 }
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -3749,7 +3749,11 @@ int nl80211_set_mac(wifi_interface_info_t *interface)
         return NLE_NOMEM;
     }
 
+#ifdef CONFIG_WIFI_EMULATOR_EXT_AGENT
+    addr = nl_addr_build(AF_LLC, vap->u.sta_info.mac, ETH_ALEN);
+#else
     addr = nl_addr_build(AF_LLC, ether_aton(to_mac_str(vap->u.sta_info.mac, mac_str)), ETH_ALEN);
+#endif
     rtnl_link_set_addr(newlink, addr);
 
     ret = rtnl_link_change(sk, device, newlink, NLM_F_CREATE | NLM_F_REPLACE);


### PR DESCRIPTION
Reason for change: Add support of Banana pi
	in sta mode
Test Procedure:
Risks: Low
Priority: P1