### PR TITLE
DTMESH-508:- Fix bootup crashes

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -524,7 +524,7 @@ INT wifi_hal_init()
         interface = hash_map_get_first(radio->interface_map);
 
         while (interface != NULL) {
-            if (update_hostap_data(interface) == RETURN_OK) {
+            if (interface->vap_info.vap_mode == wifi_vap_mode_ap && update_hostap_data(interface) == RETURN_OK) {
                 update_hostap_iface(interface);
                 update_hostap_iface_flags(interface);
                 init_hostap_hw_features(interface);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -6014,6 +6014,8 @@ int interface_info_handler(struct nl_msg *msg, void *arg)
             if (is_backhaul_interface(interface)) {
                 interface_set_mtu(interface, 1600);
             }
+            // update vap mode , Default values are not yet applied 
+            update_vap_mode(interface);
         }
     }
 

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -1488,6 +1488,17 @@ int is_backhaul_interface(wifi_interface_info_t *interface)
     return (strncmp(vap->vap_name, "mesh_backhaul", strlen("mesh_backhaul")) == 0) ? true : false;
 }
 
+void update_vap_mode(wifi_interface_info_t *interface)
+{
+    wifi_vap_info_t *vap = &interface->vap_info;
+
+    if (strncmp(vap->vap_name, "mesh_sta", strlen("mesh_sta")) == 0) {
+        vap->vap_mode = wifi_vap_mode_sta;
+    } else {
+        vap->vap_mode = wifi_vap_mode_ap;
+    }
+}
+
 void get_wifi_interface_info_map(wifi_interface_name_idex_map_t *interface_map)
 {
     memcpy(interface_map, interface_index_map, get_sizeof_interfaces_index_map()*sizeof(wifi_interface_name_idex_map_t));

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -1025,6 +1025,7 @@ unsigned int get_sizeof_interfaces_index_map(void);
 int validate_radio_operation_param(wifi_radio_operationParam_t *param);
 int validate_wifi_interface_vap_info_params(wifi_vap_info_t *vap_info, char *msg, int len);
 int is_backhaul_interface(wifi_interface_info_t *interface);
+void update_vap_mode(wifi_interface_info_t *interface);
 int get_interface_name_from_vap_index(unsigned int vap_index, char *interface_name);
 int get_ap_vlan_id(char *interface_name);
 int get_vap_mode_str_from_int_mode(unsigned char vap_mode, char *vap_mode_str);


### PR DESCRIPTION
Reason for the change :-

- execute hostap related methods only for AP interfaces
- update vap_mode during bootup, OneWifi default values are loaded later.
- DT extender device primary interface name radio interface name doesn't match