### PR TITLE
SHARMAN-3623 - [AUTO-SKY][Sprint]Latest sprint nightly build failing in jenkins

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -43,6 +43,7 @@
 #include <wifi-include/wlioctl.h>
 #elif defined(SKYSR213_PORT)
 #include <wlioctl.h>
+#include <wlioctl_defs.h>
 #else
 #include <wifi/wlioctl.h>
 #endif


### PR DESCRIPTION
Impacted Platforms: SKYSR213

Reason for change: Including wlioctl_defs header file.

Test Procedure: Build should be successful.

Risks: Medium

Priority: P1