### PR TITLE
RDKB-59928: implement rate limit for mgt frames

### DIFF
--- a/src/collection.h
+++ b/src/collection.h
@@ -68,4 +68,8 @@ void     *hash_map_get_next    (hash_map_t *map, void *data);
 #define hash_map_foreach(map, p) \
     for (p = hash_map_get_first(map); p != NULL; p = hash_map_get_next(map, p))
 
+#define hash_map_foreach_safe(map, p, tmp)                                                     \
+    for (p = hash_map_get_first(map), tmp = (p ? hash_map_get_next(map, p) : NULL); p != NULL; \
+        p = tmp, tmp = (p ? hash_map_get_next(map, p) : NULL))
+
 #endif // _COLLECTION_H_

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -538,6 +538,13 @@ typedef struct {
     wifi_hal_frame_hook_fn_t frame_hooks_fn[MAX_APPS];
 } wifi_device_frame_hooks_t;
 
+typedef struct wifi_hal_rate_limit {
+    bool enabled;
+    int rate_limit;
+    int window_size;
+    int cooldown_time;
+} wifi_hal_mgt_frame_rate_limit_t;
+
 typedef struct {
     pthread_t nl_tid;
     pthread_t hapd_eloop_tid;
@@ -561,6 +568,8 @@ typedef struct {
 #endif
     pthread_mutexattr_t hapd_lock_attr;
     pthread_mutex_t hapd_lock;
+    hash_map_t *mgt_frame_rate_limit_hashmap;
+    wifi_hal_mgt_frame_rate_limit_t mgt_frame_rate_limit;
 } wifi_hal_priv_t;
 
 extern wifi_hal_priv_t g_wifi_hal;
@@ -970,6 +979,9 @@ int update_hostap_mlo(wifi_interface_info_t *interface);
 
 wifi_interface_info_t *wifi_hal_get_mbssid_tx_interface(wifi_radio_info_t *radio);
 void wifi_hal_configure_mbssid(wifi_radio_info_t *radio);
+
+void wifi_hal_set_mgt_frame_rate_limit(bool enable, int rate_limit, int window_size,
+    int cooldown_time);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Reason for change:
  Implement rate limit to block high number of auth requests

Test Procedure:

- Configure rate limit

dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.Enable bool true

dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.RateLimit uint 6

dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.WindowSize uint 1

dmcli eRT setv Device.WiFi.X_RDKCENTRAL-COM_MgtFrameRateLimit.CooldownTime uint 30

- Send 10 auth auth requests per second

- Check client is blocked

cat /tmp/wifiHal | grep "rate limit"

Risks: Low

Priority: P1