### PR TITLE
RDKB-59928: implement rate limit for mgt frames

### DIFF
--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -964,6 +964,7 @@ int wifi_drv_getApAclDeviceNum(int vap_index, uint *acl_count);
 int wifi_drv_get_chspc_configs(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char* buff);
 int wifi_drv_set_acs_exclusion_list(unsigned int radioIndex, char* str);
 int platform_get_acl_num(int vap_index, uint *acl_hal_count);
+time_t get_boot_time_in_sec(void);
 
 int get_total_num_of_vaps(void);
 int wifi_setQamPlus(void *priv);

--- a/src/wifi_hal_rdk_util.c
+++ b/src/wifi_hal_rdk_util.c
@@ -436,3 +436,11 @@ int validate_wifi_interface_vap_info_params(wifi_vap_info_t *vap_info, char *msg
 
     return ret;
 }
+
+time_t get_boot_time_in_sec(void)
+{
+    struct timespec tv_now;
+
+    clock_gettime(CLOCK_MONOTONIC, &tv_now);
+    return tv_now.tv_sec;
+}


### PR DESCRIPTION
Reason for change: added missing dependency
Test Procedure:
Risks: Low
Priority: P1