### PR TITLE
DTMESH-461 [DT] Changes for Onewifi Leader mode bring-up

### DIFF
--- a/src/wifi_hal_rdk_util.c
+++ b/src/wifi_hal_rdk_util.c
@@ -361,10 +361,6 @@ int validate_wifi_interface_vap_info_params(wifi_vap_info_t *vap_info, char *msg
         ret = RETURN_ERR;
         snprintf(msg + strlen(msg), len - strlen(msg), " showSsid: %d", bss_info->showSsid);
     }
-    if (strncmp(vap_info->bridge_name, "", strlen(vap_info->bridge_name)) == 0) {
-        ret = RETURN_ERR;
-        snprintf(msg + strlen(msg), len - strlen(msg), " Bridge name is null for vap index %u", vap_info->vap_index);
-    }
 
     // security parameter values
     if (bss_info->security.mode <= 0 || bss_info->security.mode >  wifi_security_mode_wpa3_compatibility ||


### PR DESCRIPTION
Reason for change: Backhaul AP creation fails when bridge name is null which is not mandatory for all vaps