### PR TITLE
RDKBWIFI-38: Fixes beacon_ie_len uninitialized warning

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9925,7 +9925,7 @@ static int scan_info_handler(struct nl_msg *msg, void *arg)
     wifi_vap_info_t *vap;
     uint8_t *ie = NULL;
     uint8_t *beacon_ies = NULL;
-    signed int len, beacon_ie_len;
+    signed int len, beacon_ie_len = 0;
     const char *key = NULL;
     wifi_bss_info_t *scan_info_ap = NULL;
 


### PR DESCRIPTION
RDKBWIFI-38: Fixes beacon_ie_len uninitialized warning
Reason for change: Fixes warnings present in #248 (d8c0db4)
Test Procedure: Images should be successfully built
Risks: Low
Priority: P1
Signed-off-by: SathishKumar_Gnanasekaran <SathishKumar_Gnanasekaran@comcast.com>