### PR TITLE
RDKB-58427,RDKB-58741: Create platform emulator file

### DIFF
--- a/platform/wifi-emulator/platform_emulator.c
+++ b/platform/wifi-emulator/platform_emulator.c
@@ -1,0 +1,703 @@
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include "wifi_hal_priv.h"
+#include "wifi_hal.h"
+
+#define NULL_CHAR '\0'
+#define NEW_LINE '\n'
+#define MAX_BUF_SIZE 128
+#define MAX_CMD_SIZE 1024
+#define RPI_LEN_32 32
+#define INVALID_KEY                      "12345678"
+
+int wifi_nvram_defaultRead(char *in,char *out);
+int _syscmd(char *cmd, char *retBuf, int retBufSize);
+
+typedef struct {
+    mac_address_t *macs;
+    unsigned int num;
+} sta_list_t;
+
+/* FIXME: VIKAS/PRAMOD:
+ * If wifi_nvram_defaultRead fail, handle appropriately in callers.
+ */
+int wifi_nvram_defaultRead(char *in,char *out)
+{
+    char buf[MAX_BUF_SIZE]={'\0'};
+    char cmd[MAX_CMD_SIZE]={'\0'};
+    char *position;
+
+    sprintf(cmd,"grep '%s=' /nvram/wifi_defaults.txt",in);
+    if(_syscmd(cmd,buf,sizeof(buf)) == -1)
+    {
+        wifi_hal_dbg_print("\nError %d:%s:%s\n",__LINE__,__func__,__FILE__);
+        return -1;
+    }
+
+    if (buf[0] == NULL_CHAR)
+        return -1;
+    position = buf;
+    while(*position != NULL_CHAR)
+    {
+        if (*position == NEW_LINE)
+        {
+            *position = NULL_CHAR;
+            break;
+        }
+        position++;
+    }
+    position = strchr(buf, '=');
+    if (position == NULL)
+    {
+        wifi_hal_dbg_print("Line %d: invalid line '%s'",__LINE__, buf);
+        return -1;
+    }
+    *position = NULL_CHAR;
+    position++;
+    strncpy(out,position,strlen(position)+1);
+    return 0; 
+}
+
+int platform_pre_init()
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_post_init(wifi_vap_info_map_t *vap_map)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    system("brctl addif brlan0 wlan0");
+    system("brctl addif brlan0 wlan1");
+    return 0;
+}
+
+
+int platform_set_radio(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
+{
+    char output_val[RPI_LEN_32];
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+
+    if (map == NULL)
+    {
+        wifi_hal_dbg_print("%s:%d: wifi_vap_info_map_t *map is NULL \n", __func__, __LINE__);
+    }
+    for (index = 0; index < map->num_vaps; index++)
+    {
+      if (map->vap_array[index].vap_mode == wifi_vap_mode_ap)
+      {
+	//   Assigning default radius values 
+	    wifi_nvram_defaultRead("radius_s_port",output_val);
+	    map->vap_array[index].u.bss_info.security.u.radius.s_port = atoi(output_val);
+	    wifi_nvram_defaultRead("radius_s_ip",map->vap_array[index].u.bss_info.security.u.radius.s_ip);
+	    wifi_nvram_defaultRead("radius_key",map->vap_array[index].u.bss_info.security.u.radius.s_key);
+      }
+    } 
+    return 0;
+}
+
+int nvram_get_radio_enable_status(bool *radio_enable, int radio_index)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int nvram_get_vap_enable_status(bool *vap_enable, int vap_index)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int nvram_get_current_security_mode(wifi_security_modes_t *security_mode,int vap_index)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_get_keypassphrase_default(char *password, int vap_index)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
+    /*password is not sensitive,won't grant access to real devices*/ 
+    wifi_nvram_defaultRead("rpi_wifi_password",password);
+    if (strlen(password) == 0) {
+       wifi_hal_error_print("%s:%d nvram default password not found, "
+           "enforced alternative default password\n", __func__, __LINE__);
+       strncpy(password, INVALID_KEY, strlen(INVALID_KEY) + 1);
+    }
+    return 0;
+}
+
+int platform_get_ssid_default(char *ssid, int vap_index)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);   
+    sprintf(ssid,"RPI_RDKB-AP%d",vap_index);
+    return 0;
+}
+
+int platform_get_wps_pin_default(char *pin)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
+    wifi_nvram_defaultRead("wps_pin",pin);
+    return 0;
+}
+
+int platform_wps_event(wifi_wps_event_t data)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
+    return 0;
+}
+
+int platform_get_country_code_default(char *code)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);  
+    strcpy(code,"US");
+    return 0;
+}
+
+int nvram_get_current_password(char *l_password, int vap_index)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    /*password is not sensitive,won't grant access to real devices*/ 
+    wifi_nvram_defaultRead("rpi_wifi_password",l_password);
+    return 0;
+}
+
+int nvram_get_current_ssid(char *l_ssid, int vap_index)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__); 
+    sprintf(l_ssid,"RPI_RDKB-AP%d",vap_index);
+    return 0;
+}
+
+int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_flags_init(int *flags)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    *flags = PLATFORM_FLAGS_STA_INACTIVITY_TIMER;
+    return 0;
+}
+
+int platform_get_aid(void* priv, u16* aid, const u8* addr)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_free_aid(void* priv, u16* aid)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_sync_done(void* priv)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_get_channel_bandwidth(wifi_radio_index_t index,  wifi_channelBandwidth_t *channelWidth)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_update_radio_presence(void)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int nvram_get_mgmt_frame_power_control(int vap_index, int* output_dbm)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
+    return 0;
+}
+
+int platform_set_txpower(void* priv, uint txpower)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    return 0;
+}
+
+int platform_set_offload_mode(void* priv, uint offload_mode)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    return RETURN_OK;
+}
+
+int platform_get_radius_key_default(char *radius_key)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    wifi_nvram_defaultRead("radius_key",radius_key);
+    return 0;	
+}
+
+int platform_get_acl_num(int vap_index, uint *acl_count)
+{
+    return 0;
+}
+
+int platform_get_chanspec_list(unsigned int radioIndex, wifi_channelBandwidth_t bandwidth, wifi_channels_list_t channels, char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    return 0;
+}
+
+int platform_set_acs_exclusion_list(wifi_radio_index_t index,char *buff)
+{
+    wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+    return 0;
+}
+
+int platform_get_vendor_oui(char *vendor_oui, int vendor_oui_len)
+{
+    return -1;
+}
+
+int platform_set_neighbor_report(uint index, uint add, mac_address_t mac)
+{
+    return 0;
+}
+
+int platform_get_radio_phytemperature(wifi_radio_index_t index,
+    wifi_radioTemperature_t *radioPhyTemperature)
+{
+    return 0;
+}
+
+int platform_set_dfs(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
+{
+    return 0;
+}
+
+int wifi_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, INT dwell_time, UINT chan_num, UINT *chan_list)
+{
+    return wifi_hal_startNeighborScan(apIndex, scan_mode, dwell_time, chan_num, chan_list);
+}
+
+int wifi_getNeighboringWiFiStatus(INT radio_index, wifi_neighbor_ap2_t **neighbor_ap_array, UINT *output_array_size)
+{
+    return wifi_hal_getNeighboringWiFiStatus(radio_index, neighbor_ap_array, output_array_size);
+}
+
+int wifi_setQamPlus(void *priv)
+{
+    return 0;
+}
+
+int wifi_setApRetrylimit(void *priv)
+{
+    return 0;
+}
+
+
+INT wifi_getRadioChannelStats(INT radioIndex, wifi_channelStats_t *input_output_channelStats_array,
+    INT array_size)
+{
+    return RETURN_OK;
+}
+//--------------------------------------------------------------------------------------------------
+INT wifi_getApEnable(INT apIndex, BOOL *output_bool)
+{
+    return RETURN_OK;
+}
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_setApMacAddressControlMode(INT apIndex, INT filterMode)
+{
+    return RETURN_OK;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_getBssLoad(INT apIndex, BOOL *enabled)
+{
+    return RETURN_ERR;
+}
+
+//--------------------------------------------------------------------------------------------------
+INT wifi_setLayer2TrafficInspectionFiltering(INT apIndex, BOOL enabled)
+{
+    return RETURN_ERR;
+}
+//--------------------------------------------------------------------------------------------------
+INT wifi_setApIsolationEnable(INT apIndex, BOOL enable)
+{
+    return RETURN_ERR;
+}
+
+int platform_get_radio_caps(wifi_radio_index_t index)
+{ 
+    return 0;
+}
+
+INT wifi_getApDeviceRSSI(INT ap_index, CHAR *MAC, INT *output_RSSI)
+{
+    return 0;
+}
+
+static int get_sta_list_handler(struct nl_msg *msg, void *arg)
+{
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    sta_list_t *sta_list = (sta_list_t *)arg;
+
+    if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0),
+        NULL) < 0) {
+        wifi_hal_error_print("%s:%d Failed to parse sta data\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (tb[NL80211_ATTR_MAC]) {
+        sta_list->macs = realloc(sta_list->macs, (sta_list->num + 1) * sizeof(mac_address_t));
+        if (sta_list->macs) {
+            memcpy(sta_list->macs[sta_list->num], nla_data(tb[NL80211_ATTR_MAC]), sizeof(mac_address_t));
+            sta_list->num++;
+        }
+    }
+
+    return NL_OK;
+}
+
+static int get_sta_list(wifi_interface_info_t *interface, sta_list_t *sta_list)
+{
+    int ret;
+    struct nl_msg *msg = NULL;
+
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, NLM_F_DUMP, NL80211_CMD_GET_STATION);
+    if (msg == NULL) {
+        wifi_hal_error_print("%s:%d Failed to create NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    ret = nl80211_send_and_recv(msg, get_sta_list_handler, sta_list, NULL, NULL);
+    if (ret < 0) {
+        wifi_hal_error_print("%s:%d Failed to execute NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
+{
+    wifi_associated_dev3_t *dev = (wifi_associated_dev3_t *)arg;
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
+    struct nlattr *stats[NL80211_STA_INFO_MAX + 1];
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1] = {
+                [NL80211_STA_INFO_INACTIVE_TIME] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_RX_BYTES] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_BYTES] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_RX_PACKETS] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_PACKETS] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_TX_FAILED] = { .type = NLA_U32 },
+                [NL80211_STA_INFO_CONNECTED_TIME] = { .type = NLA_U32 },
+    };
+    struct nlattr *rate[NL80211_RATE_INFO_MAX + 1];
+    static struct nla_policy rate_policy[NL80211_RATE_INFO_MAX + 1] = {
+                [NL80211_RATE_INFO_BITRATE32] = { .type = NLA_U32 },
+    };
+    struct nl80211_sta_flag_update *sta_flags;
+
+    if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),genlmsg_attrlen(gnlh, 0),
+        NULL) < 0) {
+        wifi_hal_error_print("%s:%d Failed to parse sta data\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (!tb[NL80211_ATTR_STA_INFO]) {
+        wifi_hal_error_print("%s:%d Failed to get sta info attribute\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (tb[NL80211_ATTR_MAC]) {
+        memcpy(dev->cli_MACAddress, nla_data(tb[NL80211_ATTR_MAC]), sizeof(mac_address_t));
+    }
+
+    if (nla_parse_nested(stats, NL80211_STA_INFO_MAX, tb[NL80211_ATTR_STA_INFO], stats_policy)) {
+	wifi_hal_error_print("%s:%d Failed to parse nested attributes\n", __func__, __LINE__);
+        return NL_SKIP;
+    }
+
+    if (stats[NL80211_STA_INFO_RX_BYTES]) {
+        dev->cli_BytesReceived = nla_get_u32(stats[NL80211_STA_INFO_RX_BYTES]);
+    }
+    if (stats[NL80211_STA_INFO_TX_BYTES]) {
+        dev->cli_BytesSent = nla_get_u32(stats[NL80211_STA_INFO_TX_BYTES]);
+    }
+    if (stats[NL80211_STA_INFO_RX_PACKETS]) {
+        dev->cli_PacketsReceived = nla_get_u32(stats[NL80211_STA_INFO_RX_PACKETS]);
+    }
+    if (stats[NL80211_STA_INFO_TX_PACKETS]) {
+        dev->cli_PacketsSent = nla_get_u32(stats[NL80211_STA_INFO_TX_PACKETS]);
+    }
+    if (stats[NL80211_STA_INFO_TX_FAILED]) {
+        dev->cli_ErrorsSent = nla_get_u32(stats[NL80211_STA_INFO_TX_FAILED]);
+    }
+
+    if (stats[NL80211_STA_INFO_TX_BITRATE] &&
+        nla_parse_nested(rate, NL80211_RATE_INFO_MAX, stats[NL80211_STA_INFO_TX_BITRATE], rate_policy) == 0) {
+        if (rate[NL80211_RATE_INFO_BITRATE32]){
+            dev->cli_LastDataDownlinkRate = nla_get_u32(rate[NL80211_RATE_INFO_BITRATE32]) * 100;
+        }
+    }
+    if (stats[NL80211_STA_INFO_RX_BITRATE] &&
+        nla_parse_nested(rate, NL80211_RATE_INFO_MAX, stats[NL80211_STA_INFO_RX_BITRATE], rate_policy) == 0) {
+        if (rate[NL80211_RATE_INFO_BITRATE32]) {
+                dev->cli_LastDataUplinkRate = nla_get_u32(rate[NL80211_RATE_INFO_BITRATE32]) * 100;
+        }
+    }
+
+    if (stats[NL80211_STA_INFO_STA_FLAGS]) {
+        sta_flags = nla_data(stats[NL80211_STA_INFO_STA_FLAGS]);
+        dev->cli_AuthenticationState = sta_flags->mask & (1 << NL80211_STA_FLAG_AUTHORIZED) &&
+            sta_flags->set & (1 << NL80211_STA_FLAG_AUTHORIZED);
+    }
+
+    return NL_OK;
+}
+
+static int get_sta_stats(wifi_interface_info_t *interface, mac_address_t mac, wifi_associated_dev3_t *dev)
+{
+    int ret;
+    struct nl_msg *msg = NULL;
+
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_GET_STATION);
+    if (msg == NULL) {
+        wifi_hal_error_print("%s:%d Failed to create NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    nla_put(msg, NL80211_ATTR_MAC, sizeof(mac_address_t), mac);
+
+    ret = nl80211_send_and_recv(msg, get_sta_stats_handler, dev, NULL, NULL);
+    if (ret < 0) {
+        wifi_hal_error_print("%s:%d Failed to execute NL command\n", __func__, __LINE__);
+        return -1;
+    }
+
+    return 0;
+}
+
+INT wifi_getApAssociatedDeviceDiagnosticResult3(INT apIndex,
+    wifi_associated_dev3_t **associated_dev_array, UINT *output_array_size)
+{
+    int ret;
+    unsigned int i;
+    sta_list_t sta_list = {};
+    wifi_interface_info_t *interface;
+
+    interface = get_interface_by_vap_index(apIndex);
+    if (interface == NULL) {
+        wifi_hal_error_print("%s:%d Failed to get interface for index %d\n", __func__, __LINE__, apIndex);
+        return -1;
+    }
+
+    ret = get_sta_list(interface, &sta_list);
+    if (ret < 0) {
+        wifi_hal_error_print("%s:%d Failed to get sta list\n", __func__, __LINE__);
+        goto exit;
+    }
+
+    *associated_dev_array = sta_list.num ?
+        calloc(sta_list.num, sizeof(wifi_associated_dev3_t)) : NULL;
+    *output_array_size = sta_list.num;
+
+    for (i = 0; i < sta_list.num; i++) {
+        ret = get_sta_stats(interface, sta_list.macs[i], &(*associated_dev_array)[i]);
+        if (ret < 0) {
+            wifi_hal_error_print("%s:%d Failed to get sta stats\n", __func__, __LINE__);
+            free(*associated_dev_array);
+            *associated_dev_array = NULL;
+            *output_array_size = 0;
+            goto exit;
+        }
+    }
+
+exit:
+    free(sta_list.macs);
+    return ret;
+}
+
+INT wifi_setRadioDfsAtBootUpEnable(INT radioIndex, BOOL enable) // Tr181
+{
+    return 0;
+}
+
+INT wifi_getRadioChannel(INT radioIndex, ULONG *output_ulong)
+{
+    return 0;
+}
+
+INT wifi_steering_eventRegister(wifi_steering_eventCB_t event_cb)
+{
+    return RETURN_OK;
+}
+
+int wifi_rrm_send_beacon_req(struct wifi_interface_info_t *interface, const u8 *addr,
+    u16 num_of_repetitions, u8 measurement_request_mode, u8 oper_class, u8 channel,
+    u16 random_interval, u16 measurement_duration, u8 mode, const u8 *bssid,
+    struct wpa_ssid_value *ssid, u8 *rep_cond, u8 *rep_cond_threshold, u8 *rep_detail,
+    const u8 *ap_ch_rep, unsigned int ap_ch_rep_len, const u8 *req_elem, unsigned int req_elem_len,
+    u8 *ch_width, u8 *ch_center_freq0, u8 *ch_center_freq1, u8 last_indication)
+{
+    return 0;
+}
+
+/* called by BTM API */
+int wifi_wnm_send_bss_tm_req(struct wifi_interface_info_t *interface, struct sta_info *sta,
+    u8 dialog_token, u8 req_mode, int disassoc_timer, u8 valid_int, const u8 *bss_term_dur,
+    const char *url, const u8 *nei_rep, size_t nei_rep_len, const u8 *mbo_attrs, size_t mbo_len)
+{
+    return 0;
+}
+
+int handle_wnm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    struct ieee80211_mgmt *mgmt, size_t len)
+{
+    return 0;
+}
+
+int handle_rrm_action_frame(struct wifi_interface_info_t *interface, const mac_address_t sta,
+    const struct ieee80211_mgmt *mgmt, size_t len, int ssi_signal)
+{
+    return 0;
+}
+
+INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
+{
+    return 0;
+}
+
+int wifi_drv_set_ap_mlo(struct nl_msg *msg, void *priv, struct wpa_driver_ap_params *params)
+{
+    return 0;
+}
+
+#ifdef CONFIG_IEEE80211BE
+int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
+    struct wpa_driver_ap_params *params)
+{
+    (void)msg;
+    (void)msg_mlo;
+    (void)priv;
+    (void)params;
+
+    return 0;
+}
+
+int nl80211_send_mlo_msg(struct nl_msg *msg)
+{
+    (void)msg;
+
+    return 0;
+}
+
+void wifi_drv_get_phy_eht_cap_mac(struct eht_capabilities *eht_capab, struct nlattr **tb)
+{
+    (void)eht_capab;
+    (void)tb;
+}
+
+int update_hostap_mlo(wifi_interface_info_t *interface)
+{
+    (void)interface;
+
+    return 0;
+}
+#endif /* CONFIG_IEEE80211BE */
+
+INT wifi_steering_clientDisconnect(UINT steeringgroupIndex, INT apIndex, mac_address_t client_mac,
+    wifi_disconnectType_t type, UINT reason)
+{
+    return 0;
+}
+
+INT wifi_setProxyArp(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_setCountryIe(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_getLayer2TrafficInspectionFiltering(INT apIndex, BOOL *enabled)
+{
+    return 0;
+}
+
+INT wifi_getCountryIe(INT apIndex, BOOL *enabled)
+{
+    return 0;
+}
+
+INT wifi_setP2PCrossConnect(INT apIndex, BOOL disabled)
+{
+    return 0;
+}
+
+INT wifi_getDownStreamGroupAddress(INT apIndex, BOOL *disabled)
+{
+    return 0;
+}
+
+INT wifi_getProxyArp(INT apIndex, BOOL *enabled)
+{
+    return 0;
+}
+
+INT wifi_applyGASConfiguration(wifi_GASConfiguration_t *input_struct)
+{
+    return 0;
+}
+
+INT wifi_pushApHotspotElement(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_setBssLoad(INT apIndex, BOOL enabled)
+{
+    return 0;
+}
+
+INT wifi_getApInterworkingServiceEnable(INT apIndex, BOOL *output_bool)
+{
+    return 0;
+}
+
+INT wifi_sendActionFrame(INT apIndex, mac_address_t MacAddr, UINT frequency, UCHAR *frame, UINT len)
+{
+    wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency);
+    return RETURN_OK;
+}
+
+INT wifi_setDownStreamGroupAddress(INT apIndex, BOOL disabled)
+{
+    return 0;
+}
+INT wifi_getApAssociatedClientDiagnosticResult(INT ap_index, char *key,wifi_associated_dev3_t *assoc)
+{
+    return RETURN_ERR;
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,8 +40,8 @@ librdk_wifiemulatorhal_la_LDFLAGS = -lm -lcjson -lssl -lcrypto
 librdk_wifiemulatorhal_la_LDFLAGS += -lhostap -lnl-3 -lnl-genl-3 -lnl-route-3
 librdk_wifiemulatorhal_la_SOURCES += wifi_hal.c wifi_hal_hostapd.c wifi_hal_nl80211.c wifi_hal_nl80211_events.c wifi_hal_nl80211_utils.c collection.c wifi_hal_mgmt_rx_one_wifi.c
 
-librdk_wifiemulatorhal_la_CPPFLAGS += -I$(top_srcdir)/../platform/raspberry-pi
-librdk_wifiemulatorhal_la_SOURCES += ../platform/raspberry-pi/platform_pi.c
+librdk_wifiemulatorhal_la_CPPFLAGS += -I$(top_srcdir)/../platform/wifi-emulator
+librdk_wifiemulatorhal_la_SOURCES += ../platform/wifi-emulator/platform_emulator.c
 
 else
 lib_LTLIBRARIES = librdk_wifihal.la

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -603,6 +603,21 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
     RADIO_INDEX_ASSERT(index);
     NULL_PTR_ASSERT(operationParam);
 
+#ifdef CONFIG_WIFI_EMULATOR
+    radio = get_radio_by_rdk_index(index);
+    if (radio == NULL) {
+        wifi_hal_error_print("%s:%d:Could not find radio index:%d\n", __func__, __LINE__, index);
+        return RETURN_ERR;
+    }
+
+    radio->configured = true;
+    radio->oper_param.enable = true;
+    memcpy((unsigned char *)&radio->oper_param, (unsigned char *)operationParam,
+        sizeof(wifi_radio_operationParam_t));
+
+    return RETURN_OK;
+#endif
+
     if ((op_class = get_op_class_from_radio_params(operationParam)) == -1) {
         wifi_hal_error_print("%s:%d:Could not find country code for radio index:%d\n", __func__, __LINE__, index);
         return WIFI_HAL_INVALID_ARGUMENTS; // RDKB-47696: Passing invalid channel should return WIFI_HAL_INVALID_ARGUMENTS(-4)
@@ -1709,22 +1724,6 @@ INT wifi_hal_getScanResults(wifi_radio_index_t index, wifi_channel_t *channel, w
     return RETURN_OK;
 }
 
-static int chann_to_freq(unsigned char chan)
-{
-    if (chan >= MIN_CHANNEL_2G && chan <= MAX_CHANNEL_2G) {
-        return 2407 + 5 * chan;
-    }
-
-    if (chan >= MIN_CHANNEL_5G && chan <= MAX_CHANNEL_5G) {
-        return 5000 + 5 * chan;
-    }
-
-    wifi_hal_error_print("%s:%d: Failed to convert channel %u to frequency\n", __func__, __LINE__,
-        chan);
-
-    return 0;
-}
-
 #ifdef WIFI_HAL_VERSION_3_PHASE2
 INT wifi_hal_addApAclDevice(INT apIndex, mac_address_t DeviceMacAddress)
 {
@@ -2114,10 +2113,11 @@ INT wifi_hal_startScan(wifi_radio_index_t index, wifi_neighborScanMode_t scan_mo
     wifi_interface_info_t *interface;
     wifi_vap_info_t *vap;
     bool found = false;
-    wifi_radio_operationParam_t *radio_param;
+    wifi_radio_operationParam_t *radio_param, param;
     char country[8] = {0}, tmp_str[32] = {0}, chan_list_str[512] = {0};
     unsigned int freq_list[32], i;
     ssid_t  ssid_list[8];
+    int op_class, freq_num = 0;
 
     wifi_hal_dbg_print("%s:%d: index: %d mode: %d dwell time: %d\n", __func__, __LINE__, index,
         scan_mode, dwell_time);
@@ -2169,16 +2169,30 @@ INT wifi_hal_startScan(wifi_radio_index_t index, wifi_neighborScanMode_t scan_mo
     }
 
     get_coutry_str_from_code(radio_param->countryCode, country);
+    memcpy((unsigned char *)&param, (unsigned char *)radio_param, sizeof(wifi_radio_operationParam_t));
 
     for (i = 0; i < num; i++) {
-        //freq_list[i] = ieee80211_chan_to_freq(country, radio_param->op_class, (scan_mode == WIFI_RADIO_SCAN_MODE_ONCHAN)? radio_param->channel:chan_list[i]);
-        freq_list[i] = chann_to_freq((scan_mode == WIFI_RADIO_SCAN_MODE_ONCHAN) ?
-            radio_param->channel : chan_list[i]);
-        if (freq_list[i] == 0) {
-            return RETURN_ERR;
+        param.channel = (scan_mode == WIFI_RADIO_SCAN_MODE_ONCHAN) ?
+            radio_param->channel : chan_list[i]; 
+
+        if ((op_class = get_op_class_from_radio_params(&param)) == -1) {
+            wifi_hal_error_print("%s:%d: Invalid channel %d\n", __func__, __LINE__, param.channel);
+            continue;
         }
-        sprintf(tmp_str, "%d ", freq_list[i]);
+
+        freq_list[freq_num] = ieee80211_chan_to_freq(country, op_class, param.channel);
+        if (freq_list[freq_num] == 0) {
+            continue;
+        }
+        sprintf(tmp_str, "%d ", freq_list[freq_num]);
         strcat(chan_list_str, tmp_str);
+
+	freq_num++;
+    }
+
+    if (freq_num == 0) {
+        wifi_hal_error_print("%s:%d: No valid channels\n", __func__, __LINE__);
+        return RETURN_ERR;
     }
 
     strcpy(ssid_list[0], vap->u.sta_info.ssid);
@@ -2188,7 +2202,7 @@ INT wifi_hal_startScan(wifi_radio_index_t index, wifi_neighborScanMode_t scan_mo
     hash_map_cleanup(interface->scan_info_map);
     pthread_mutex_unlock(&interface->scan_info_mutex);
 
-    return (nl80211_start_scan(interface, 0, num, freq_list, dwell_time, 1, ssid_list) == 0) ? RETURN_OK:RETURN_ERR;
+    return (nl80211_start_scan(interface, 0, freq_num, freq_list, dwell_time, 1, ssid_list) == 0) ? RETURN_OK:RETURN_ERR;
 }
 
 /*****************************/

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -2552,7 +2552,8 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
             wpa_sm_set_param(sm, WPA_PARAM_PAIRWISE, WPA_CIPHER_NONE);
             wpa_sm_set_param(sm, WPA_PARAM_GROUP, WPA_CIPHER_NONE);
         } else {
-            sel = (WPA_KEY_MGMT_IEEE8021X | WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_PSK_SHA256 | wpa_key_mgmt_11w) & data.key_mgmt;
+            sel = (WPA_KEY_MGMT_SAE | WPA_KEY_MGMT_IEEE8021X | WPA_KEY_MGMT_PSK |
+                WPA_KEY_MGMT_PSK_SHA256 | wpa_key_mgmt_11w) & data.key_mgmt;
             key_mgmt = pick_akm_suite(sel); 
 
             if (key_mgmt == -1) {

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7305,6 +7305,7 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
     security = &vap->u.sta_info.security;
 
 #ifdef CONFIG_WIFI_EMULATOR
+    struct wpa_bss *bss;
     wifi_radio_info_t *radio;
     wifi_hal_dbg_print("%s:%d:bssid:%s frequency:%d ssid:%s\n", __func__, __LINE__,
         to_mac_str(backhaul->bssid, bssid_str), backhaul->freq, backhaul->ssid);
@@ -7356,7 +7357,8 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
         (security->mode == wifi_security_mode_wpa3_enterprise)) {
         interface->wpa_s.current_ssid->ieee80211w = MGMT_FRAME_PROTECTION_REQUIRED;
         if (interface->wpa_s.conf->sae_groups == NULL) {
-            interface->wpa_s.conf->sae_groups = (int *)malloc(MAX_SAE_GROUP);
+            interface->wpa_s.conf->sae_groups =
+                os_malloc(sizeof(*interface->wpa_s.conf->sae_groups) * MAX_SAE_GROUP);
             if (interface->wpa_s.conf->sae_groups == NULL) {
                 wifi_hal_error_print("%s:%d: NULL pointer\n", __func__, __LINE__);
                 free(interface->wpa_s.current_bss);
@@ -7364,7 +7366,11 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
                 return -1;
             }
         }
-        memset(interface->wpa_s.conf->sae_groups, 0, MAX_SAE_GROUP);
+
+	interface->wpa_s.conf->sae_groups[0] = 19;
+	interface->wpa_s.conf->sae_groups[1] = 20;
+	interface->wpa_s.conf->sae_groups[2] = 21;
+	interface->wpa_s.conf->sae_groups[3] = -1;
     }
     if (interface->wpa_s.current_ssid->ssid == NULL) {
         interface->wpa_s.current_ssid->ssid = malloc(strlen(backhaul->ssid) + 1);
@@ -7450,10 +7456,28 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
     if (interface->ie != NULL) {
         memcpy(curr_bss + 1, interface->ie, interface->ie_len);
     }
+
+    if (radio->oper_param.band == WIFI_FREQUENCY_6_BAND) {
+        interface->wpa_s.conf->sae_pwe = 1;
+
+        interface->wpa_s.current_ssid->pt = sae_derive_pt(interface->wpa_s.conf->sae_groups,
+            interface->wpa_s.current_ssid->ssid,
+            interface->wpa_s.current_ssid->ssid_len,
+            interface->wpa_s.current_ssid->sae_password,
+            os_strlen(interface->wpa_s.current_ssid->sae_password),
+            interface->wpa_s.current_ssid->sae_password_id);
+    }
+
     interface->wpa_s.driver = &g_wpa_supplicant_driver_nl80211_ops;
     memcpy(interface->wpa_s.conf->ssid, interface->wpa_s.current_ssid, sizeof(struct wpa_ssid));
     memcpy(interface->wpa_s.bssid, backhaul->bssid, ETH_ALEN);
     dl_list_add(&interface->wpa_s.bss, &interface->wpa_s.current_bss->list);
+
+    bss = wpa_bss_get_bssid_latest(&interface->wpa_s, backhaul->bssid);
+    if (bss) { 
+        memcpy(bss + 1, interface->ie, interface->ie_len);
+    }
+
     sme_send_authentication(&interface->wpa_s, curr_bss, interface->wpa_s.current_ssid, 1);
     return 0;
 #else

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -247,6 +247,10 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
         }
         nl80211_parse_wmm_params(tb[NL80211_ATTR_STA_WME], &event.assoc_info.wmm_params);
     }
+
+    event.assoc_info.beacon_ies = interface->ie;
+    event.assoc_info.beacon_ies_len = interface->ie_len;
+
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_ASSOC, &event);
     return;
 }


### PR DESCRIPTION
Reason for change: Create platform emulator file
Test Procedure:
Risks: Low
Priority: P1

Signed-off-by: YuriyMasechko <yuriy.masechko@globallogic.com>

RDKB-58427: Add WPA3 mgmt key for sta

Reason for change: WPA3 mgmt key selection was misseing
	in case of stored beacon/probe response
Test Procedure:
Risks: Low
Priority: P1

Signed-off-by: YuriyMasechko <yuriy.masechko@globallogic.com>

RDKB-58741 - 6GHz client connection (#101)

Reason for change: Update params in rdk-wifi-emulator-hal Test Procedure: 6G client connectivity should work properly Risks: Low
Priority:P0

Signed-off-by: YuriyMasechko <yuriy.masechko@globallogic.com>

RDKB-58741 - Get op class based on requsted chan (#110)

Reason for change: Radio op class could be different then
	requested scan channel op class. Take op class based on
	requested channel rather then radio channel
Test Procedure: Connect XLE/virtual sta using different bands Risks: Low
Priority:P0

RDKB-58741 - Validate scan channels

Reason for change: Cancel scan only if all channels
	are invalid
Test Procedure: RPI scan works
Risks: Low
Priority:P0

RDKB-58741 - Validate scan channels

Reason for change: Cancel scan only if all channels are invalid
Test Procedure: RPI scan works
Risks: Low
Priority:P0