### PR TITLE
RDKB-60458: Need emulator defines in rdk-wifi-hal code

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -241,7 +241,7 @@ static void set_wl_runtime_configs (const wifi_vap_info_map_t *vap_map)
 }
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
-#if defined(CONFIG_WIFI_EMULATOR)
+#if defined WIFI_EMULATOR_CHANGE
 #define SEM_NAME "/semlock"
 
 int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_array,
@@ -341,7 +341,7 @@ int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_a
     sem_close(sem);
     return RETURN_OK;
 }
-#endif // CONFIG_WIFI_EMULATOR
+#endif // WIFI_EMULATOR_CHANGE
 #endif
 
 INT wifi_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, INT dwell_time, UINT chan_num, UINT *chan_list)
@@ -360,12 +360,12 @@ INT wifi_getNeighboringWiFiStatus(INT radio_index, wifi_neighbor_ap2_t **neighbo
         wifi_hal_stats_error_print("%s:%d: wifi_hal_getNeighboringWiFiStatus failed\n", __func__,
             __LINE__);
     }
-#if defined(CONFIG_WIFI_EMULATOR)
+#if defined WIFI_EMULATOR_CHANGE
     if (get_emu_neighbor_stats(radio_index, neighbor_ap_array, output_array_size) != RETURN_OK) {
         wifi_hal_stats_error_print("%s:%d: get_emu_neighbor_stats failed\n", __func__, __LINE__);
         return RETURN_ERR;
     }
-#endif // CONFIG_WIFI_EMULATOR
+#endif // WIFI_EMULATOR_CHANGE
     return ret;
 }
 

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -241,7 +241,6 @@ static void set_wl_runtime_configs (const wifi_vap_info_map_t *vap_map)
 }
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
-#if defined WIFI_EMULATOR_CHANGE
 #define SEM_NAME "/semlock"
 
 int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_array,
@@ -341,7 +340,6 @@ int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_a
     sem_close(sem);
     return RETURN_OK;
 }
-#endif // WIFI_EMULATOR_CHANGE
 #endif
 
 INT wifi_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, INT dwell_time, UINT chan_num, UINT *chan_list)

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -241,7 +241,7 @@ static void set_wl_runtime_configs (const wifi_vap_info_map_t *vap_map)
 }
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
-#if defined(CONFIG_WIFI_EMULATOR)
+#if defined WIFI_EMULATOR_CHANGE
 #define SEM_NAME "/semlock"
 
 int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_array,
@@ -341,7 +341,7 @@ int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_a
     sem_close(sem);
     return RETURN_OK;
 }
-#endif // CONFIG_WIFI_EMULATOR
+#endif // WIFI_EMULATOR_CHANGE
 #endif
 
 INT wifi_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, INT dwell_time, UINT chan_num, UINT *chan_list)

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -241,6 +241,7 @@ static void set_wl_runtime_configs (const wifi_vap_info_map_t *vap_map)
 }
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
+#if defined(CONFIG_WIFI_EMULATOR)
 #define SEM_NAME "/semlock"
 
 int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_array,
@@ -340,6 +341,7 @@ int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_a
     sem_close(sem);
     return RETURN_OK;
 }
+#endif // CONFIG_WIFI_EMULATOR
 #endif
 
 INT wifi_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, INT dwell_time, UINT chan_num, UINT *chan_list)
@@ -358,12 +360,12 @@ INT wifi_getNeighboringWiFiStatus(INT radio_index, wifi_neighbor_ap2_t **neighbo
         wifi_hal_stats_error_print("%s:%d: wifi_hal_getNeighboringWiFiStatus failed\n", __func__,
             __LINE__);
     }
-#if defined WIFI_EMULATOR_CHANGE
+#if defined(CONFIG_WIFI_EMULATOR)
     if (get_emu_neighbor_stats(radio_index, neighbor_ap_array, output_array_size) != RETURN_OK) {
         wifi_hal_stats_error_print("%s:%d: get_emu_neighbor_stats failed\n", __func__, __LINE__);
         return RETURN_ERR;
     }
-#endif
+#endif // CONFIG_WIFI_EMULATOR
     return ret;
 }
 

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -241,6 +241,7 @@ static void set_wl_runtime_configs (const wifi_vap_info_map_t *vap_map)
 }
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
+#if defined(CONFIG_WIFI_EMULATOR)
 #define SEM_NAME "/semlock"
 
 int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_array,
@@ -340,6 +341,7 @@ int get_emu_neighbor_stats(uint radio_index, wifi_neighbor_ap2_t **neighbor_ap_a
     sem_close(sem);
     return RETURN_OK;
 }
+#endif // CONFIG_WIFI_EMULATOR
 #endif
 
 INT wifi_startNeighborScan(INT apIndex, wifi_neighborScanMode_t scan_mode, INT dwell_time, UINT chan_num, UINT *chan_list)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7996,6 +7996,7 @@ int wifi_hal_emu_set_neighbor_stats(unsigned int radio_index, bool emu_state,
     return RETURN_OK;
 }
 
+#if defined (CONFIG_WIFI_EMULATOR)
 int wifi_hal_emu_set_radio_diag_stats(unsigned int radio_index, bool emu_state,
     wifi_radioTrafficStats2_t *radio_diag_stat, unsigned int count, unsigned int phy_index,
     unsigned int interface_index)
@@ -8131,6 +8132,7 @@ int wifi_hal_emu_set_radio_diag_stats(unsigned int radio_index, bool emu_state,
     free(interface);
     return 0;
 }
+#endif /* CONFIG_WIFI_EMULATOR */
 
 typedef struct {
     const char *str;
@@ -8174,6 +8176,8 @@ static void wl_cfgvendor_get_station_bw(wifi_associated_dev3_t *sta_info, u8 *bw
         default: *bw = 0; break;
     }
 }
+
+#if defined(CONFIG_WIFI_EMULATOR)
 static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, bool emu_state, wifi_associated_dev3_t *stats, unsigned int count, wifi_interface_info_t *interface)
 {
     wifi_hal_stats_dbg_print("%s:%d: value of vap index %d emu_enable %d and count is %d\n", __func__, __LINE__, vap_index, emu_state, count);
@@ -8537,6 +8541,7 @@ int wifi_hal_emu_set_radio_channel_stats(unsigned int radio_index, bool emu_stat
 
     return 0;
 }
+#endif /* CONFIG_WIFI_EMULATOR */
 #endif
 
 #if defined(CONFIG_WIFI_EMULATOR) || defined(BANANA_PI_PORT)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7905,6 +7905,7 @@ int nl80211_disconnect_sta(wifi_interface_info_t *interface)
 }
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
+#if defined(CONFIG_WIFI_EMULATOR)
 #define SEM_NAME "/semlock"
 
 int wifi_hal_emu_set_neighbor_stats(unsigned int radio_index, bool emu_state,
@@ -7996,7 +7997,6 @@ int wifi_hal_emu_set_neighbor_stats(unsigned int radio_index, bool emu_state,
     return RETURN_OK;
 }
 
-#if defined (CONFIG_WIFI_EMULATOR)
 int wifi_hal_emu_set_radio_diag_stats(unsigned int radio_index, bool emu_state,
     wifi_radioTrafficStats2_t *radio_diag_stat, unsigned int count, unsigned int phy_index,
     unsigned int interface_index)
@@ -8132,7 +8132,6 @@ int wifi_hal_emu_set_radio_diag_stats(unsigned int radio_index, bool emu_state,
     free(interface);
     return 0;
 }
-#endif /* CONFIG_WIFI_EMULATOR */
 
 typedef struct {
     const char *str;
@@ -8177,7 +8176,6 @@ static void wl_cfgvendor_get_station_bw(wifi_associated_dev3_t *sta_info, u8 *bw
     }
 }
 
-#if defined(CONFIG_WIFI_EMULATOR)
 static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, bool emu_state, wifi_associated_dev3_t *stats, unsigned int count, wifi_interface_info_t *interface)
 {
     wifi_hal_stats_dbg_print("%s:%d: value of vap index %d emu_enable %d and count is %d\n", __func__, __LINE__, vap_index, emu_state, count);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8175,7 +8175,6 @@ static void wl_cfgvendor_get_station_bw(wifi_associated_dev3_t *sta_info, u8 *bw
         default: *bw = 0; break;
     }
 }
-
 static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, bool emu_state, wifi_associated_dev3_t *stats, unsigned int count, wifi_interface_info_t *interface)
 {
     wifi_hal_stats_dbg_print("%s:%d: value of vap index %d emu_enable %d and count is %d\n", __func__, __LINE__, vap_index, emu_state, count);

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -907,7 +907,7 @@ void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *e
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
 
-#if defined(CONFIG_WIFI_EMULATOR)
+// emu_neighbor_stats_t is used by both CCI and Onewifi
 typedef struct {
     bool emu_enable;
     uint32_t radio_index;
@@ -915,6 +915,7 @@ typedef struct {
     wifi_neighbor_ap2_t data[];  // flexible array member
 } emu_neighbor_stats_t;
 
+#if defined(CONFIG_WIFI_EMULATOR)
 int     wifi_hal_emu_set_radio_channel_stats(unsigned int radio_index, bool emu_state, wifi_channelStats_t *chan_stat, unsigned int count, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_assoc_clients_stats(unsigned int vap_index, bool emu_state, wifi_associated_dev3_t *assoc_cli_stat, unsigned int count, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_radio_temp (unsigned int radio_index, bool emu_state, int temperature, unsigned int phy_index, unsigned int interface_index);

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -907,6 +907,7 @@ void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *e
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
 
+#if defined(CONFIG_WIFI_EMULATOR)
 typedef struct {
     bool emu_enable;
     uint32_t radio_index;
@@ -914,7 +915,6 @@ typedef struct {
     wifi_neighbor_ap2_t data[];  // flexible array member
 } emu_neighbor_stats_t;
 
-#if defined(CONFIG_WIFI_EMULATOR)
 int     wifi_hal_emu_set_radio_channel_stats(unsigned int radio_index, bool emu_state, wifi_channelStats_t *chan_stat, unsigned int count, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_assoc_clients_stats(unsigned int vap_index, bool emu_state, wifi_associated_dev3_t *assoc_cli_stat, unsigned int count, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_radio_temp (unsigned int radio_index, bool emu_state, int temperature, unsigned int phy_index, unsigned int interface_index);

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -906,7 +906,7 @@ int     nl80211_retry_interface_enable(wifi_interface_info_t *interface, bool en
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
-
+if defined(CONFIG_WIFI_EMULATOR)
 typedef struct {
     bool emu_enable;
     uint32_t radio_index;
@@ -919,6 +919,7 @@ int     wifi_hal_emu_set_assoc_clients_stats(unsigned int vap_index, bool emu_st
 int     wifi_hal_emu_set_radio_temp (unsigned int radio_index, bool emu_state, int temperature, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_radio_diag_stats(unsigned int radio_index, bool emu_state, wifi_radioTrafficStats2_t *radio_diag_stat, unsigned int count, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_neighbor_stats(unsigned int radio_index, bool emu_state, wifi_neighbor_ap2_t *neighbor_stats, unsigned int count);
+#endif //CONFIG_WIFI_EMULATOR
 #endif
 int     nl80211_start_scan(wifi_interface_info_t *interface, uint flags,
         unsigned int num_freq, unsigned int  *freq_list, unsigned int dwell_time,

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -906,7 +906,6 @@ int     nl80211_retry_interface_enable(wifi_interface_info_t *interface, bool en
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
-#if defined(CONFIG_WIFI_EMULATOR)
 typedef struct {
     bool emu_enable;
     uint32_t radio_index;
@@ -914,6 +913,7 @@ typedef struct {
     wifi_neighbor_ap2_t data[];  // flexible array member
 } emu_neighbor_stats_t;
 
+#if defined(CONFIG_WIFI_EMULATOR)
 int     wifi_hal_emu_set_radio_channel_stats(unsigned int radio_index, bool emu_state, wifi_channelStats_t *chan_stat, unsigned int count, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_assoc_clients_stats(unsigned int vap_index, bool emu_state, wifi_associated_dev3_t *assoc_cli_stat, unsigned int count, unsigned int phy_index, unsigned int interface_index);
 int     wifi_hal_emu_set_radio_temp (unsigned int radio_index, bool emu_state, int temperature, unsigned int phy_index, unsigned int interface_index);

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -906,7 +906,7 @@ int     nl80211_retry_interface_enable(wifi_interface_info_t *interface, bool en
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
-if defined(CONFIG_WIFI_EMULATOR)
+#if defined(CONFIG_WIFI_EMULATOR)
 typedef struct {
     bool emu_enable;
     uint32_t radio_index;

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -906,6 +906,7 @@ int     nl80211_retry_interface_enable(wifi_interface_info_t *interface, bool en
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
+
 typedef struct {
     bool emu_enable;
     uint32_t radio_index;


### PR DESCRIPTION
Reason for change: Emulator flags are not added to the functions at rdk-wifi-hal. Broadcom faces issue while porting to their internal platforms.
Test Procedure: Enable OneWiFiTestSuite RFC and check whether able to see the emulator related function calls at the /tmp/wifiHal logs
Priority: P1
Risks: Low
Signed-off-by: mothishree_mallaiyanjothimani@comcast.com