### PR TITLE
RDKB-59718 :Incorrect ap_SupportedStandards values for 6 GHz WiFi7 neighboring APs

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -9198,9 +9198,11 @@ static void parse_supprates(const uint8_t type, uint8_t len,
             if (bss->oper_freq_band & WIFI_FREQUENCY_5_BAND) {
                 bss->supp_standards |= WIFI_80211_VARIANT_A;
                 bss->oper_standards = WIFI_80211_VARIANT_A;
-            } else {
+            } else if (bss->oper_freq_band & WIFI_FREQUENCY_2_4_BAND){
                 bss->supp_standards |= WIFI_80211_VARIANT_G;
                 bss->oper_standards = WIFI_80211_VARIANT_G;
+            } else {
+                wifi_hal_dbg_print("%s:%d: [SCAN] Ignoring legacy rate for 6 GHz \n",__func__, __LINE__);
             }
         }
 


### PR DESCRIPTION
RDKB-59718 Incorrect ap_SupportedStandards values for 6 GHz WiFi7 neighboring APs
Reason for change: Skip assigning 802.11g for 6 GHz band

Test Procedure: 
1. Load the custom build 
2. verify the supported standards in Neighbour stats from wifi_api and DMCLI
`wifi_api wifi_getNeighboringWiFiDiagnosticResult2 1
Device.WiFi.NeighboringWiFiDiagnostic.Result.34.SupportedStandards`
3. Enable WiFiMon logs 
4. check the value for ap_SupportedStandards in wifiMon logs

Priority: P2
Risks: Low
Signed-off-by: sneha_kannan@comcast.com