### PR TITLE
DTMESH-552 : Fix RSNXE mismatch detected during station association

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8894,6 +8894,14 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
         }
         else {
             pos += ret;
+#if HOSTAPD_VERSION >= 210
+            if (interface->u.sta.wpa_sm->assoc_rsnxe_len > 0 &&
+                interface->u.sta.wpa_sm->assoc_rsnxe_len <= (sizeof(rsn_ie) - ret)) {
+                os_memcpy(pos, interface->u.sta.wpa_sm->assoc_rsnxe,
+                    interface->u.sta.wpa_sm->assoc_rsnxe_len);
+                pos += interface->u.sta.wpa_sm->assoc_rsnxe_len;
+            }
+#endif
             nla_put(msg, NL80211_ATTR_IE, pos - rsn_ie, rsn_ie);
         }
 


### PR DESCRIPTION
Reason for the change:-
When leader device sends RSNXE as part of Probe response and Msg3 of EAPOL and OneWifi doesn't backup the RSNXE received during the Probe response. During msg3 of EAPOL libhostap tries to validate RSNXE against RSNXE of the scan results, And it finds mismatch leading to failure of EAPOL transaction.