### PR TITLE
RDKB-59829 : support to cci external client on banana-pi and iperf

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -460,9 +460,11 @@ INT wifi_hal_init()
         wifi_hal_error_print("%s:%d: Failed to create the ECO mode interfaces\n", __func__, __LINE__);
     }
 
+#ifndef CONFIG_WIFI_EMULATOR_EXT_AGENT
     if (nl80211_init_primary_interfaces() != 0) {
         return RETURN_ERR;
     }
+#endif //CONFIG_WIFI_EMULATOR_EXT_AGENT
 
     if (nl80211_init_radio_info() != 0) {
         return RETURN_ERR;
@@ -1417,7 +1419,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
 
         wifi_hal_info_print("%s:%d: interface:%s set down\n", __func__, __LINE__, interface->name);
         nl80211_interface_enable(interface->name, false);
-#ifndef CONFIG_WIFI_EMULATOR
+#if  !defined(CONFIG_WIFI_EMULATOR) && !defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
         if (vap->vap_mode == wifi_vap_mode_sta) {
             bool sta_4addr = 0;
             wifi_hal_info_print("%s:%d: interface:%s remove from bridge\n", __func__, __LINE__,

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -2288,9 +2288,13 @@ static void wpa_sm_sta_set_state(void *ctx, enum wpa_states state)
         wifi_hal_configure_sta_4addr_to_bridge(interface, 0);
         if (callbacks->sta_conn_status_callback) {
             memcpy(&bss, &interface->u.sta.backhaul, sizeof(wifi_bss_info_t));
-
+#ifdef CONFIG_WIFI_EMULATOR_EXT_AGENT
+            sta.vap_index = interface->index;
+#else
             sta.vap_index = vap->vap_index;
+#endif
             sta.connect_status = wifi_connection_status_disconnected;
+
 
             callbacks->sta_conn_status_callback(vap->vap_index, &bss, &sta);
         }

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8950,7 +8950,7 @@ static int conn_get_interface_handler(struct nl_msg *msg, void *arg)
     wifi_station_stats_t sta;
     wifi_radio_info_t *radio =  NULL;
     wifi_radio_operationParam_t *radio_param = NULL;
-    int op_class;
+    int op_class = 0;
     u8 channel;
 
 
@@ -9018,16 +9018,22 @@ static int conn_get_interface_handler(struct nl_msg *msg, void *arg)
         return NL_SKIP;
     }
 
+#ifndef CONFIG_WIFI_EMULATOR_EXT_AGENT
     if ((op_class = get_op_class_from_radio_params(radio_param)) == -1) {
         wifi_hal_error_print("%s:%d: could not find op_class for radio index:%d\n", __func__, __LINE__, interface->vap_info.radio_index);
         return NL_SKIP;
     }
+#endif
 
     sta.channel = channel;
     sta.op_class = op_class;
     sta.channelWidth = channel_width;
 
+#ifdef CONFIG_WIFI_EMULATOR_EXT_AGENT
+    sta.vap_index = interface->index;
+#else
     sta.vap_index = vap->vap_index;
+#endif
     sta.connect_status = wifi_connection_status_connected;
 
     callbacks = get_hal_device_callbacks();

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -155,6 +155,7 @@ static void nl80211_new_station_event(wifi_interface_info_t *interface, struct n
 
 static void nl80211_del_station_event(wifi_interface_info_t *interface, struct nlattr **tb)
 {
+#ifndef CONFIG_WIFI_EMULATOR_EXT_AGENT
     union wpa_event_data event;
     struct nlattr *attr;
     mac_address_t mac;
@@ -176,6 +177,7 @@ static void nl80211_del_station_event(wifi_interface_info_t *interface, struct n
     wpa_supplicant_event(&interface->u.ap.hapd, EVENT_DISASSOC, &event);
     //Remove the station from the bridge, if present
     wifi_hal_configure_sta_4addr_to_bridge(interface, 0);
+#endif
 }
 #endif //_PLATFORM_RASPBERRYPI_ || _PLATFORM_BANANAPI_R4_
 
@@ -758,7 +760,12 @@ static void nl80211_disconnect_event(wifi_interface_info_t *interface, struct nl
     if (callbacks->sta_conn_status_callback) {
         memcpy(bss.bssid, interface->u.sta.backhaul.bssid, sizeof(bssid_t));
 
+#ifdef CONFIG_WIFI_EMULATOR_EXT_AGENT
+        sta.vap_index = interface->index;
+#else
         sta.vap_index = vap->vap_index;
+#endif
+
         sta.connect_status = wifi_connection_status_disconnected;
 
         callbacks->sta_conn_status_callback(vap->vap_index, &bss, &sta);


### PR DESCRIPTION
Reason for change: 1) banana pi as a client needs to connect to xb gateways Test Procedure: 1) Iperf test between xb gateway and Banana pi should be successful and the artifacts are uploaded to gateway.
Risks: Low
Priority: P1