### PR TITLE
RDKB-60772: prevent from unwanted setting of hostapd_bss_config::mld_ap

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1112,7 +1112,7 @@ int update_hostap_bss(wifi_interface_info_t *interface)
 
 #ifdef CONFIG_IEEE80211BE
     conf->disable_11be = !radio->iconf.ieee80211be;
-#if !defined(VNTXER5_PORT) && !defined(TARGET_GEMINI7_2)
+#if !defined(VNTXER5_PORT) && !defined(TARGET_GEMINI7_2) && !defined(XB10_PORT) && !defined(SCXER10_PORT)
     conf->mld_ap = vap->u.bss_info.mld_info.common_info.mld_enable;
 #endif
 #endif /* CONFIG_IEEE80211BE */


### PR DESCRIPTION
Reason for change:
        Due to insufficient null pointer sanitation (update_hostap_mlo->hostapd_bss_link_deinit) the crash appear when MLD_Enable is set to true.
	For the future implementation is also required to prevent from change of hostapd_bss_config::mld_ap
	in this early stage before proper hostapd_bss_link_deinit is performed

Test Procedure:
	The prerequisites:
	wl_mlo_config=-1 -1 -1 -1

	Check pid of OneWifi process "ps | grep One"

	Configure MLD_Enable = true
	dmcli eRT setv Device.WiFi.AccessPoint.1.MLD_Enable bool true
	dmcli eRT setv Device.WiFi.ApplyAccessPointSettings bool true

	Check if OneWifi process is still running and have same pid
	Check if the MLD_Enable was set properly to new value "true"
	dmcli eRT getv Device.WiFi.AccessPoint.1.MLD_Enable

	Priority: P1
	Risks: Low