### PR TITLE
RDKB-58764: Greylist MacFilter is empty even after AAA Reject is sent…

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1933,6 +1933,10 @@ INT wifi_hal_addApAclDevice(INT apIndex, mac_address_t DeviceMacAddress)
         return RETURN_ERR;
     }
     vap = &interface->vap_info;
+    if (is_wifi_hal_vap_hotspot_from_interfacename(interface->name) && !vap->u.bss_info.enabled) {
+        wifi_hal_info_print("%s:%d Skipping addition of MAC Entry to ACL since %s is not enabled\n",__func__,__LINE__,interface->name);
+        return RETURN_OK;
+    }
 
     key = to_mac_str(DeviceMacAddress, sta_mac_str);
     
@@ -1996,6 +2000,10 @@ INT wifi_hal_addApAclDevice(INT apIndex, CHAR *DeviceMacAddress)
         return RETURN_ERR;
     }
     vap = &interface->vap_info;
+    if (is_wifi_hal_vap_hotspot_from_interfacename(interface->name) && !vap->u.bss_info.enabled) {
+        wifi_hal_info_print("%s:%d Skipping addition of MAC Entry to ACL since %s is not enabled\n",__func__,__LINE__,interface->name);
+        return RETURN_OK;
+    }
     
     wifi_hal_dbg_print("%s:%d: Interface: %s MAC: %s\n",  __func__, __LINE__, interface->name, DeviceMacAddress);
 

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1933,7 +1933,7 @@ INT wifi_hal_addApAclDevice(INT apIndex, mac_address_t DeviceMacAddress)
         return RETURN_ERR;
     }
     vap = &interface->vap_info;
-    if (is_wifi_hal_vap_hotspot_from_interfacename(interface->name) && !vap->u.bss_info.enabled) {
+    if (!vap->u.bss_info.enabled) {
         wifi_hal_info_print("%s:%d Skipping addition of MAC Entry to ACL since %s is not enabled\n",__func__,__LINE__,interface->name);
         return RETURN_OK;
     }
@@ -2000,7 +2000,7 @@ INT wifi_hal_addApAclDevice(INT apIndex, CHAR *DeviceMacAddress)
         return RETURN_ERR;
     }
     vap = &interface->vap_info;
-    if (is_wifi_hal_vap_hotspot_from_interfacename(interface->name) && !vap->u.bss_info.enabled) {
+    if (!vap->u.bss_info.enabled) {
         wifi_hal_info_print("%s:%d Skipping addition of MAC Entry to ACL since %s is not enabled\n",__func__,__LINE__,interface->name);
         return RETURN_OK;
     }


### PR DESCRIPTION
… (#254)

When MacFilter entries are trying to be added to the VAPs not enabled, we skip the entire process_greylist_mac_filter which is the issue.  Hence, skip those Hotspot VAPs which are not enabled