### PR TITLE
RDKB-60610: Implement channel change based on CSA beacon frame.

### DIFF
--- a/platform/banana-pi/kernel-patches/openwrt/0001-BPIR4_Enable_Beacon_Frame_Subscription.patch
+++ b/platform/banana-pi/kernel-patches/openwrt/0001-BPIR4_Enable_Beacon_Frame_Subscription.patch
@@ -1,0 +1,46 @@
+From: Rakhil P E <rakhilpe001@gmail.com>
+Date: Mon, 21 Jul 2025 09:09:00 +0000
+Subject: [PATCH] Enable beacon reception in station mode
+
+This patch enables reception of beacon frames in station mode
+by modifying default management frame subtypes.
+
+---
+ package/kernel/mac80211/src/net/mac80211/main.c       | 2 ++
+ .../mediatek/mt76/mt7996/init.c                       | 13 +++++++++++++
+ 2 files changed, 15 insertions(+)
+
+
+--- /package/kernel/mac80211/src/net/mac80211/main.c.orig	2025-07-24 06:52:36.481632003 +0000
++++ /package/kernel/mac80211/src/net/mac80211/main.c	2025-07-24 06:58:27.666659013 +0000
+@@ -678,7 +678,8 @@
+		 */
+		.rx = BIT(IEEE80211_STYPE_ACTION >> 4) |
+			BIT(IEEE80211_STYPE_AUTH >> 4) |
+-			BIT(IEEE80211_STYPE_PROBE_REQ >> 4),
++			BIT(IEEE80211_STYPE_PROBE_REQ >> 4) |
++			BIT(IEEE80211_STYPE_BEACON >> 4),
+	},
+	[NL80211_IFTYPE_AP] = {
+		.tx = 0xffff,
+--- /package/kernel/mac80211/src/drivers/net/wireless/mediatek/mt76/mt7996/init.c.orig	2025-07-24 06:53:02.959147002 +0000
++++ /package/kernel/mac80211/src/drivers/net/wireless/mediatek/mt76/mt7996/init.c	2025-07-24 06:56:37.967777004 +0000
+@@ -441,6 +441,18 @@
+ 
+	wiphy->available_antennas_rx = phy->mt76->antenna_mask;
+	wiphy->available_antennas_tx = phy->mt76->antenna_mask;
++
++	static const struct ieee80211_txrx_stypes mt7996_mgmt_stypes[NUM_NL80211_IFTYPES] = {
++		[NL80211_IFTYPE_STATION] = {
++			.rx = BIT(IEEE80211_STYPE_ACTION >> 4) |
++				BIT(IEEE80211_STYPE_AUTH >> 4) |
++				BIT(IEEE80211_STYPE_PROBE_REQ >> 4) |
++				BIT(IEEE80211_STYPE_BEACON >> 4),
++			.tx = BIT(IEEE80211_STYPE_ACTION >> 4),
++		},
++	};
++
++	wiphy->mgmt_stypes = mt7996_mgmt_stypes;
+ }
+ 
+ static void

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -870,6 +870,9 @@ static void nl80211_ch_switch_notify_event(wifi_interface_info_t *interface, str
     int l_channel_width, hostap_channel_width, op_class;
     enum nl80211_radar_event event_type = 0;
     wifi_radio_info_t *radio;
+#if defined(EASY_MESH_NODE) && defined(_PLATFORM_BANANAPI_R4_)
+    wifi_interface_info_t *sta_interface;
+#endif
 
     wifi_hal_dbg_print("%s:%d: wifi_chan_event_type: %d interface: %s\n", __func__, __LINE__,
         wifi_chan_event_type, interface->name);
@@ -1002,6 +1005,15 @@ static void nl80211_ch_switch_notify_event(wifi_interface_info_t *interface, str
         cf1, cf2, op_class, ch_type, event_type);
 
     if (wifi_chan_event_type == WIFI_EVENT_CHANNELS_CHANGED) {
+#if defined(EASY_MESH_NODE) && defined(_PLATFORM_BANANAPI_R4_)
+        hash_map_foreach(radio->interface_map, sta_interface) {
+            if (sta_interface->vap_info.vap_mode == wifi_vap_mode_sta) {
+                wifi_hal_dbg_print("%s:%d: register mgmt frames for STA interface\n", __func__,
+                    __LINE__);
+                nl80211_register_mgmt_frames(sta_interface);
+            }
+        }
+#endif // EASY_MESH_NODE && _PLATFORM_BANANAPI_R4_
         radio_param->channel = channel;
         radio_param->channelWidth = l_channel_width;
         radio_param->operatingClass = op_class;

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -923,6 +923,7 @@ int     wifi_hal_emu_set_radio_diag_stats(unsigned int radio_index, bool emu_sta
 int     wifi_hal_emu_set_neighbor_stats(unsigned int radio_index, bool emu_state, wifi_neighbor_ap2_t *neighbor_stats, unsigned int count);
 #endif //CONFIG_WIFI_EMULATOR
 #endif
+int     nl80211_register_mgmt_frames(wifi_interface_info_t *interface);
 int     nl80211_start_scan(wifi_interface_info_t *interface, uint flags,
         unsigned int num_freq, unsigned int  *freq_list, unsigned int dwell_time,
         unsigned int num_ssid,  ssid_t *ssid_list);


### PR DESCRIPTION
Reason for change: Implement channel change based on CSA beacon frame.
Test Procedure: Ensure channel change work in easymesh network.
Risks: Medium
Priority: P1

Signed-off-by: Rakhil P E <rakhilpe001@gmail.com>