### PR TITLE
RDKB-57273:Passpoint 6GHz support for Xfinity Gateways

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,8 +125,7 @@ librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/banana-pi -I${PKG_CONF
 librdk_wifihal_la_SOURCES += ../platform/banana-pi/platform.c
 endif
 
-include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h hs20.h ../util_crypto/aes_siv.h 
->>>>>>> 36cf454... RDKB-57273 Fix for After enabling passpoint on 6 ghz Xfinity ssid , client doesnot connect to the ssid (#205)
+include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h ../util_crypto/aes_siv.h 
 
 if ONE_WIFIBUILD
 include_HEADERS += wifi_hal_priv.h wifi_hal_wnm_rrm.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,6 +120,14 @@ librdk_wifihal_la_SOURCES += ../platform/raspberry-pi/platform_pi.c
 endif
 include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h ../util_crypto/aes_siv.h
 
+if BANANA_PI_PORT
+librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/banana-pi -I${PKG_CONFIG_SYSROOT_DIR}${includedir}/rdk-wifi-libhostap/wpa_supplicant
+librdk_wifihal_la_SOURCES += ../platform/banana-pi/platform.c
+endif
+
+include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h hs20.h ../util_crypto/aes_siv.h 
+>>>>>>> 36cf454... RDKB-57273 Fix for After enabling passpoint on 6 ghz Xfinity ssid , client doesnot connect to the ssid (#205)
+
 if ONE_WIFIBUILD
 include_HEADERS += wifi_hal_priv.h wifi_hal_wnm_rrm.h
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,13 +120,6 @@ librdk_wifihal_la_SOURCES += ../platform/raspberry-pi/platform_pi.c
 endif
 include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h ../util_crypto/aes_siv.h
 
-if BANANA_PI_PORT
-librdk_wifihal_la_CPPFLAGS += -I$(top_srcdir)/../platform/banana-pi -I${PKG_CONFIG_SYSROOT_DIR}${includedir}/rdk-wifi-libhostap/wpa_supplicant
-librdk_wifihal_la_SOURCES += ../platform/banana-pi/platform.c
-endif
-
-include_HEADERS = wifi_hal_rdk.h wifi_hal_rdk_framework.h ieee80211.h ../util_crypto/aes_siv.h 
-
 if ONE_WIFIBUILD
 include_HEADERS += wifi_hal_priv.h wifi_hal_wnm_rrm.h
 endif

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -14726,6 +14726,34 @@ static size_t wifi_drv_mbssid_hs20_indication(struct hostapd_data *bss, struct h
     return ie_len;
 }
 
+static size_t wifi_drv_mbssid_roaming_consortium(struct hostapd_data *bss, struct hostapd_data *tx_bss, u8 *buf)
+{
+    u8 ie_buf[64], tx_ie_buf[64];
+    size_t ie_len, tx_ie_len;
+    u8 *ie_end, *tx_ie_end;
+    ie_end = hostapd_eid_roaming_consortium(bss, ie_buf);
+    ie_len = ie_end - ie_buf;
+    
+    if (ie_len == 0) {
+        wifi_hal_dbg_print("%s:%d No Roaming Consortium IE present for bss, returning 0\n", 
+                          __func__, __LINE__);
+        return 0;
+    }
+    /* Generate Roaming Consortium IE for TX BSS */
+    tx_ie_end = hostapd_eid_roaming_consortium(tx_bss, tx_ie_buf);
+    tx_ie_len = tx_ie_end - tx_ie_buf;
+    /* Skip duplicate IEs in non-TX profiles */
+    if (ie_len == tx_ie_len && memcmp(ie_buf, tx_ie_buf, ie_len) == 0) {
+        return 0;
+    }
+
+    if (buf) {
+        memcpy(buf, ie_buf, ie_len);
+    }
+    
+    return ie_len;
+}
+
 static size_t wifi_drv_mbssid_mbo(struct hostapd_data *bss, u8 *buf)
 {
     u8 ie_buf[64];
@@ -14864,6 +14892,7 @@ static size_t wifi_drv_eid_mbssid_elem_len(wifi_radio_info_t *radio,
         nontx_profile_len += wifi_drv_mbssid_interworking(bss, tx_bss, NULL);
         nontx_profile_len += wifi_drv_mbssid_adv_proto(bss, tx_bss, NULL);
 	nontx_profile_len += wifi_drv_mbssid_hs20_indication(bss, tx_bss, NULL);
+        nontx_profile_len += wifi_drv_mbssid_roaming_consortium(bss, tx_bss, NULL);
         nontx_profile_len += wifi_drv_mbssid_mbo(bss, NULL);
         nontx_profile_len += wifi_drv_mbssid_wmm(bss, NULL);
 
@@ -14956,6 +14985,7 @@ static u8 *wifi_drv_eid_mbssid_elem(wifi_radio_info_t *radio, wifi_interface_inf
         eid += wifi_drv_mbssid_interworking(bss, tx_bss, eid);
         eid += wifi_drv_mbssid_adv_proto(bss, tx_bss, eid);
 	eid += wifi_drv_mbssid_hs20_indication(bss, tx_bss, eid);
+        eid += wifi_drv_mbssid_roaming_consortium(bss, tx_bss, eid);
         eid += wifi_drv_mbssid_mbo(bss, eid);
         eid += wifi_drv_mbssid_wmm(bss, eid);
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -47,7 +47,7 @@
 #include "ap/sta_info.h"
 #include "ap/dfs.h"
 #include "ap/wmm.h"
-#include "hs20.h"
+#include "ap/hs20.h"
 #include <sys/wait.h>
 #include <netinet/ether.h>
 #include <linux/filter.h>

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -47,6 +47,7 @@
 #include "ap/sta_info.h"
 #include "ap/dfs.h"
 #include "ap/wmm.h"
+#include "hs20.h"
 #include <sys/wait.h>
 #include <netinet/ether.h>
 #include <linux/filter.h>
@@ -14701,6 +14702,30 @@ static size_t wifi_drv_mbssid_adv_proto(struct hostapd_data *bss, struct hostapd
     return ie_len;
 }
 
+static size_t wifi_drv_mbssid_hs20_indication(struct hostapd_data *bss, struct hostapd_data *tx_bss, u8 *buf)
+{
+    u8 ie_buf[16], tx_ie_buf[16];
+    size_t ie_len, tx_ie_len;
+    u8 *ie_end, *tx_ie_end;
+    ie_end = hostapd_eid_hs20_indication(bss, ie_buf);
+    ie_len = ie_end - ie_buf;
+    if (ie_len == 0) {
+        wifi_hal_dbg_print("%s:%d No HS20 IE present for bss, returning 0\n", __func__, __LINE__);
+        return 0;
+    }
+
+    tx_ie_end = hostapd_eid_hs20_indication(tx_bss, tx_ie_buf);
+    tx_ie_len = tx_ie_end - tx_ie_buf;
+    if (ie_len == tx_ie_len && memcmp(ie_buf, tx_ie_buf, ie_len) == 0) {
+        return 0;
+    }
+
+    if (buf) {
+        memcpy(buf, ie_buf, ie_len);
+    }
+    return ie_len;
+}
+
 static size_t wifi_drv_mbssid_mbo(struct hostapd_data *bss, u8 *buf)
 {
     u8 ie_buf[64];
@@ -14838,7 +14863,7 @@ static size_t wifi_drv_eid_mbssid_elem_len(wifi_radio_info_t *radio,
 
         nontx_profile_len += wifi_drv_mbssid_interworking(bss, tx_bss, NULL);
         nontx_profile_len += wifi_drv_mbssid_adv_proto(bss, tx_bss, NULL);
-
+	nontx_profile_len += wifi_drv_mbssid_hs20_indication(bss, tx_bss, NULL);
         nontx_profile_len += wifi_drv_mbssid_mbo(bss, NULL);
         nontx_profile_len += wifi_drv_mbssid_wmm(bss, NULL);
 
@@ -14930,7 +14955,7 @@ static u8 *wifi_drv_eid_mbssid_elem(wifi_radio_info_t *radio, wifi_interface_inf
 
         eid += wifi_drv_mbssid_interworking(bss, tx_bss, eid);
         eid += wifi_drv_mbssid_adv_proto(bss, tx_bss, eid);
-
+	eid += wifi_drv_mbssid_hs20_indication(bss, tx_bss, eid);
         eid += wifi_drv_mbssid_mbo(bss, eid);
         eid += wifi_drv_mbssid_wmm(bss, eid);
 


### PR DESCRIPTION
Adding the Hotspot 2.0 and Roaming Consortium parameters in the Beacons of Secure Hotspot VAPs when passpoint is enabled