### PR TITLE
DTMESH-532 optimisation fails to recreate the station interface

### DIFF
--- a/platform/qualcomm/platform_ext.c
+++ b/platform/qualcomm/platform_ext.c
@@ -514,6 +514,8 @@ int platform_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             snprintf(cmd, sizeof(cmd), "cfg80211tool %s ap_bridge 1", interface_name);
             wifi_hal_dbg_print("%s:%d Executing %s\n",__func__,__LINE__, cmd);
             system(cmd);
+            snprintf(cmd, sizeof(cmd), "cfg80211tool %s athnewind 1", interface_name);
+            system(cmd);
         }
     }
     wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1622,11 +1622,6 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                 wifi_hal_info_print("%s:%d: interface:%s set operstate 1\n", __func__,
                     __LINE__, interface->name);
                 wifi_drv_set_operstate(interface, 1);
-#ifdef TARGET_GEMINI7_2
-		if (!vap->u.sta_info.enabled) {
-                    nl80211_delete_interface(radio->index, interface->name, interface->index);
-		}
-#endif
             } else {
                 wifi_hal_info_print("%s:%d: interface:%s set down\n", __func__, __LINE__,
                     interface->name);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7997,7 +7997,18 @@ int nl80211_disconnect_sta(wifi_interface_info_t *interface)
     if ((msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_DISCONNECT)) == NULL) {
         return -1;
     }
-    ret = nl80211_send_and_recv(msg, NULL, &g_wifi_hal, NULL, NULL);
+#ifdef EAPOL_OVER_NL
+    if (g_wifi_hal.platform_flags & PLATFORM_FLAGS_CONTROL_PORT_FRAME &&
+        interface->bss_nl_connect_event_fd >= 0) {
+        wifi_hal_error_print("%s:%d: disconnect command send via control port \n", __func__,
+            __LINE__);
+        ret = nl80211_set_rx_control_port_owner(msg, interface);
+    } else {
+#endif
+        ret = nl80211_send_and_recv(msg, NULL, &g_wifi_hal, NULL, NULL);
+#ifdef EAPOL_OVER_NL
+    }
+#endif
     if (ret == 0) {
         return 0;
     }


### PR DESCRIPTION
AP interface bootup fails if station interface is present.
If we delete the station interface that is affecting optimisation logic.
nl80211 send of NL80211_CMD_DISCONNECT event fails to send if EAPOL_OVER_NL is enabled.