### PR TITLE
RDKB-60772: Fixed adding/removing MLO links

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1112,9 +1112,6 @@ int update_hostap_bss(wifi_interface_info_t *interface)
 
 #ifdef CONFIG_IEEE80211BE
     conf->disable_11be = !radio->iconf.ieee80211be;
-#if !defined(VNTXER5_PORT) && !defined(TARGET_GEMINI7_2)
-    conf->mld_ap = vap->u.bss_info.mld_info.common_info.mld_enable;
-#endif
 #endif /* CONFIG_IEEE80211BE */
 
     strcpy(conf->iface, interface->name);


### PR DESCRIPTION
Reason for change:
       Multiple times added the same link into mlo links causes for_each_mld_link(link, hapd) loop forever.
	The main problem was the link was not removed properly due to conf->mld_ap was changed to false before removing the original link.
	The issue was reported in connection with the configuring of BssMaxNumSta.

Test Procedure:
	Enable MLO operation of all private VAPs in one MLO group.

	Configure new value for BssMaxNumSta:
	dmcli eRT setv Device.WiFi.AccessPoint.2.X_CISCO_COM_BssMaxNumSta int 99
	dmcli eRT setv Device.WiFi.ApplyAccessPointSettings bool true

	Check if new value was properly applied:
	dmcli eRT getv Device.WiFi.AccessPoint.2.X_CISCO_COM_BssMaxNumSta

	Priority: P1
	Risks: Low