### PR TITLE
RDKB-61103 : 36/160 not switching to 80MHz (#262)

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -14109,8 +14109,10 @@ int nl80211_dfs_radar_detected (wifi_interface_info_t *interface, int freq, int 
 
     radio = get_radio_by_rdk_index(interface->vap_info.radio_index);
 
-    if(! ( radio->oper_param.channel >= dfs_start ) && ( radio->oper_param.channel <= dfs_end ) ) {
-        wifi_hal_info_print("%s:%d Radio is operating in a non-dfs Channel \n", __FUNCTION__, __LINE__);
+    if (((radio->oper_param.channel < dfs_start) || (radio->oper_param.channel > dfs_end)) &&
+        (bandwidth != WIFI_CHANNELBANDWIDTH_160MHZ)) {
+        wifi_hal_info_print("%s:%d Radio is operating in a non-dfs Channel \n", __FUNCTION__,
+            __LINE__);
         return 0;
     }
 


### PR DESCRIPTION
* XER10-1719 : 36/160 not switching to 80MHz

Reason for change: When 5G radio is operating at 36/160 configuration,
                   it doesn't switch bandwidth to 80MHz when radar is detected.
Test Procedure: - Set the 5G radio to channel 36 and bandwidth 160MHz with DFS
                  enabled.
                - Generate a radar detected via wl command
                - The bandwidth should be switched to 80MHz.
Risks: None
Priority: P1