### PR TITLE
Fix cla.yml GitHub action.

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,6 +2,8 @@ name: "CLA"
 permissions:
   contents: read
   pull-requests: write
+  actions: write
+  statuses: write
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
PR #247 added copilot autofix on the action permissions.  actions:write and statuses:write are missing and causing problem with the cla.yml action.