### PR TITLE
RDKB-59636: CSA frame won't be triggered during next optimization aft…

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -926,7 +926,10 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
         radio->oper_param.operatingClass = operationParam->operatingClass;
         radio->oper_param.channelWidth = operationParam->channelWidth;
         radio->oper_param.autoChannelEnabled = operationParam->autoChannelEnabled;
-        radio->oper_param.DfsEnabledBootup = operationParam->DfsEnabledBootup;
+		radio->oper_param.DfsEnabledBootup = operationParam->DfsEnabledBootup;
+		strncpy(radio->oper_param.radarDetected, operationParam->radarDetected,
+				sizeof(radio->oper_param.radarDetected)-1);
+		radio->oper_param.DFSTimer = operationParam->DFSTimer;
         memcpy(radio->oper_param.channel_map, operationParam->channel_map,
             sizeof(radio->oper_param.channel_map));
 


### PR DESCRIPTION
RDKB-59636: CSA frame won't be triggered during next optimization after channel change.

Reason for change: PHY is getting reconfigured due to struct mismatch. 
Test Procedure: channel change should trigger CSA.
Risks: Low
Priority: P1