### PR TITLE
RDKB-61158:[AUTO-SKY][Sprint]Onewifi crashed in signtaure 'process_frame_mgmt'

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -2171,8 +2171,6 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
                     wifi_hal_dbg_print("handle_disassoc - too short payload (len=%lu)\n",
                         (unsigned long)len);
                     reasoncode = reason;
-                } else if (is_greylist_reject) {
-                    reasoncode = WLAN_RADIUS_GREYLIST_REJECT;
                 } else {
                     reasoncode = le_to_host16(mgmt->u.disassoc.reason_code);
                 }


### PR DESCRIPTION
RDKB-61158: process_mgmt_frame crash in HUB6

Impacted Platforms:
All OneWifi platforms

Reason for change: Do not access station after freeing it. Make sure to check if greylist initiated and then copy its reason code. Should not affect Greylisting feature.

Test Procedure: Flash the build and check if any crash is happening during client connection and disconnection.
Perform tests by doing multiple FR/Reboots also.

Risks: Low

Signed-off-by:Srijeyarankesh_JS@comcast.com1