### PR TITLE
RDKB-61227:  Facing crash reboot after triggering onewifi cases.

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8311,7 +8311,7 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
         wifi_hal_stats_error_print("%s:%d: Stats is NULL\n", __func__, __LINE__);
         return -1;
     }
-
+    char mld_zero_mac[ETH_ALEN] = 00:00:00:00:00:00;
     for (int i = 0; i < count; i++) {
         u8 bw;
         uint32_t standard = 0;
@@ -8401,7 +8401,8 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_FAILED_RETRIES, cli_FailedRetransCount) < 0 ||
             nla_put_u32(msg, RDK_VENDOR_ATTR_STA_INFO_ASSOC_NUM, stats[i].cli_Associations) < 0 ||
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_RETRIES, cli_RetryCount) < 0 ||
-            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 ) {
+            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 || 
+            nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, mld_zero_mac) < 0) {
 
             nla_nest_cancel(msg, nlattr_sta_info);
             nlmsg_free(msg);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8311,7 +8311,7 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
         wifi_hal_stats_error_print("%s:%d: Stats is NULL\n", __func__, __LINE__);
         return -1;
     }
-    char mld_zero_mac[ETH_ALEN] = 00:00:00:00:00:00;
+    char mld_zero_mac[ETH_ALEN] = {0};
     for (int i = 0; i < count; i++) {
         u8 bw;
         uint32_t standard = 0;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8417,10 +8417,7 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
             nlmsg_free(msg);
             return -1;
         }
-        //print the MLD MAC address from the stats structure
-        wifi_hal_stats_dbg_print("SJY %s:%d: MLD MAC address is %02x:%02x:%02x:%02x:%02x:%02x\n", __func__, __LINE__,
-            stats[i].cli_MLDAddr[0], stats[i].cli_MLDAddr[1], stats[i].cli_MLDAddr[2],
-            stats[i].cli_MLDAddr[3], stats[i].cli_MLDAddr[4], stats[i].cli_MLDAddr[5]);
+
         nlattr_sta_info = nla_nest_start(msg, RDK_VENDOR_ATTR_STA_INFO);
         if (!nlattr_sta_info) {
             wifi_hal_stats_error_print("%s:%d: Failed to add station list attribute for vap index %d\n", __func__, __LINE__, vap_index);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8369,7 +8369,10 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
             nlmsg_free(msg);
             return -1;
         }
-
+        //print the MLD MAC address from the stats structure
+        wifi_hal_stats_dbg_print("SJY %s:%d: MLD MAC address is %02x:%02x:%02x:%02x:%02x:%02x\n", __func__, __LINE__,
+            stats[i].cli_MLDAddr[0], stats[i].cli_MLDAddr[1], stats[i].cli_MLDAddr[2],
+            stats[i].cli_MLDAddr[3], stats[i].cli_MLDAddr[4], stats[i].cli_MLDAddr[5]);
         nlattr_sta_info = nla_nest_start(msg, RDK_VENDOR_ATTR_STA_INFO);
         if (!nlattr_sta_info) {
             wifi_hal_stats_error_print("%s:%d: Failed to add station list attribute for vap index %d\n", __func__, __LINE__, vap_index);
@@ -8402,7 +8405,7 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
             nla_put_u32(msg, RDK_VENDOR_ATTR_STA_INFO_ASSOC_NUM, stats[i].cli_Associations) < 0 ||
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_RETRIES, cli_RetryCount) < 0 ||
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 ||
-            nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, mld_zero_mac) < 0 ) {
+            nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, stats[i].cli_MLDAddr) < 0 ) {
 
             nla_nest_cancel(msg, nlattr_sta_info);
             nlmsg_free(msg);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8359,7 +8359,7 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
         wifi_hal_stats_error_print("%s:%d: Stats is NULL\n", __func__, __LINE__);
         return -1;
     }
-    char mld_zero_mac[ETH_ALEN] = {0};
+
     for (int i = 0; i < count; i++) {
         u8 bw;
         uint32_t standard = 0;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8401,14 +8401,9 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_FAILED_RETRIES, cli_FailedRetransCount) < 0 ||
             nla_put_u32(msg, RDK_VENDOR_ATTR_STA_INFO_ASSOC_NUM, stats[i].cli_Associations) < 0 ||
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_RETRIES, cli_RetryCount) < 0 ||
-            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 ) {
+            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 ||
+            nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, mld_zero_mac) < 0 ) {
 
-            nla_nest_cancel(msg, nlattr_sta_info);
-            nlmsg_free(msg);
-            return -1;
-        }
-        if(nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, mld_zero_mac) < 0) {
-            wifi_hal_stats_error_print("%s:%d: Failed to add MLD MAC attribute for vap index %d\n", __func__, __LINE__, vap_index);
             nla_nest_cancel(msg, nlattr_sta_info);
             nlmsg_free(msg);
             return -1;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8401,9 +8401,14 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_FAILED_RETRIES, cli_FailedRetransCount) < 0 ||
             nla_put_u32(msg, RDK_VENDOR_ATTR_STA_INFO_ASSOC_NUM, stats[i].cli_Associations) < 0 ||
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_RETRIES, cli_RetryCount) < 0 ||
-            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 || 
-            nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, mld_zero_mac) < 0) {
+            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 ) {
 
+            nla_nest_cancel(msg, nlattr_sta_info);
+            nlmsg_free(msg);
+            return -1;
+        }
+        if(nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, mld_zero_mac) < 0) {
+            wifi_hal_stats_error_print("%s:%d: Failed to add MLD MAC attribute for vap index %d\n", __func__, __LINE__, vap_index);
             nla_nest_cancel(msg, nlattr_sta_info);
             nlmsg_free(msg);
             return -1;


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: As nl attribute not being set from CCI,
the null pointer gets dereferenced and gets crashed.

Test Procedure: 
1. Load the above mentioned image
2.After the device got boot up , run the test trigger from vb and check 
   for kernel panic and test results.
3. If KP occurs or the test trigger got failed, issue reproduced.

Risks: Medium

Priority: P0

Signed-off-by: sanjayvenkatesan1902@gmail.com