### PR TITLE
XB10-2046: Remove STA micromanagement from rdk-wifi-hal

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -2088,7 +2088,6 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
                 reason = station->disconnect_reason_code;
             }
 #endif
-            ap_free_sta(&interface->u.ap.hapd, station);
         } else {
             wifi_hal_dbg_print("%s:%d: interface:%s sta %s not found\n", __func__, __LINE__,
                 interface->name, to_mac_str(sta, sta_mac_str));
@@ -2160,7 +2159,6 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
                     reason = station->disconnect_reason_code;
                 }
 #endif
-            ap_free_sta(&interface->u.ap.hapd, station);
         }
         pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
 

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -458,9 +458,9 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
 #if !defined(PLATFORM_LINUX)
                 if (station->disconnect_reason_code == WLAN_RADIUS_GREYLIST_REJECT) {
                     reason = station->disconnect_reason_code;
+                    wifi_hal_info_print("reason from disconnect reason code is %d\n",reason);
                 }
 #endif
-                ap_free_sta(&interface->u.ap.hapd, station);
             }
             pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
 
@@ -505,7 +505,6 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
                     wifi_hal_info_print("reason from disconnect reason code is %d\n",reason);
                 }
 #endif
-                ap_free_sta(&interface->u.ap.hapd, station);
             }
             pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
 


### PR DESCRIPTION
Reason for change: Removed freeing STA when the same is being done by hostapd once packet is being forwarded to it.

Test procedure: Limit max number of STA to 3. Try connecting 4-5 times.

Risks: Low

Priority: P1