### PR TITLE
RDKB-60772:  MLO changes: fixed older hostapd compatibility

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -3041,6 +3041,7 @@ static int hostapd_setup_bss_internal(struct hostapd_data *hapd)
 }
 
 #ifdef CONFIG_IEEE80211BE
+#if HOSTAPD_VERSION >= 211
 static int set_mld_shared_resources(struct hostapd_data *hapd)
 {
     int ret;
@@ -3074,12 +3075,15 @@ static void clear_mld_shared_resources(struct hostapd_data *hapd)
         }
     }
 }
+#endif /* HOSTAPD_VERSION >= 211 */
 #endif /* CONFIG_IEEE80211BE */
 
 void deinit_bss(struct hostapd_data *hapd)
 {
 #ifdef CONFIG_IEEE80211BE
+#if HOSTAPD_VERSION >= 211
     clear_mld_shared_resources(hapd);
+#endif
 #endif
     hostapd_bss_deinit_no_free(hapd);
     hostapd_free_hapd_data(hapd);
@@ -3114,11 +3118,13 @@ int start_bss(wifi_interface_info_t *interface)
             __LINE__, vap->vap_name, vap->vap_index, ret, interface->u.ap.hapd.csa_in_progress);
     }
 #ifdef CONFIG_IEEE80211BE
+#if HOSTAPD_VERSION >= 211
     ret = set_mld_shared_resources(hapd);
     if (ret != RETURN_OK) {
         wifi_hal_error_print("%s:%d: vap:%s:%d mld set shared resources failed:%d csa status:%d\n", __func__,
             __LINE__, vap->vap_name, vap->vap_index, ret, interface->u.ap.hapd.csa_in_progress);
     }
+#endif
 #endif
     pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
 


### PR DESCRIPTION
Reason for change: Compilation failed for platforms using hostapd versions older than 2_11 and with CONFIG_IEEE80211BE enabled.
	Compilation failed because older hostapd does not contain the hostapd_mld_is_first_bss function.

Test Procedure:

Risks: Low
Priority: P1