### PR TITLE
XER10-2137 : Throughput drop when boosted/prioritized on 6GHz

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -45,7 +45,9 @@
 #include <semaphore.h>
 #include <stdint.h>
 #include <unistd.h>
-#endif // TCXB7_PORT || TCXB8_PORT || XB10_PORT || RDKB_ONE_WIFI_PROD
+#elif defined(SCXER10_PORT)
+#include <rdk_nl80211_hal.h>
+#endif // TCXB7_PORT || TCXB8_PORT || XB10_PORT || SCXF10_PORT || RDKB_ONE_WIFI_PROD
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || \
     defined(TCHCBRV2_PORT) || defined(SKYSR213_PORT) || defined(SCXF10_PORT) || defined(RDKB_ONE_WIFI_PROD)
@@ -3653,6 +3655,26 @@ static void platform_set_eht(wifi_radio_index_t index, bool enable)
     g_eht_oneshot_notify = NULL;
 
     return;
+}
+
+int platform_set_amsdu_tid(wifi_interface_info_t *interface, uint8_t *amsdu_tid)
+{
+    static uint8_t cur_amsdu_tid[MAX_NUM_RADIOS][RDK_VENDOR_NL80211_AMSDU_TID_MAX] = {
+        {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+        {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+        {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}};
+
+    int radio_index = interface->rdk_radio_index;
+
+    for (int index = 0; index < RDK_VENDOR_NL80211_AMSDU_TID_MAX; index++) {
+        /* minimize the calling of wl if same value */
+        if (cur_amsdu_tid[radio_index][index] != amsdu_tid[index]) {
+            v_secure_system("wl -i %s amsdu_tid %d %u", interface->name, index, amsdu_tid[index]);
+            cur_amsdu_tid[radio_index][index] = amsdu_tid[index];
+            wifi_hal_dbg_print("%s: %s amsdu_tid[%d] = %u\n", __func__, interface->name, index, amsdu_tid[index]);
+        }
+    }
+    return RETURN_OK;
 }
 
 #if defined(KERNEL_NO_320MHZ_SUPPORT)

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -810,7 +810,7 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
     memcpy((unsigned char *)&old_operationParam, (unsigned char *)&radio->oper_param, sizeof(wifi_radio_operationParam_t));
 
     nl80211_interface_enable(primary_interface->name, operationParam->enable);
-#if defined(TCXB8_PORT) || defined(XB10_PORT)
+#if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)
     if (nl80211_set_amsdu_tid(primary_interface, operationParam->amsduTid) != RETURN_OK)
     {
         wifi_hal_error_print(

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7518,6 +7518,11 @@ int nl80211_set_amsdu_tid(wifi_interface_info_t *interface, uint8_t *amsdu_tid)
     }
     return RETURN_OK;
 }
+#elif defined(SCXER10_PORT)
+int nl80211_set_amsdu_tid(wifi_interface_info_t *interface, uint8_t *amsdu_tid)
+{
+    return platform_set_amsdu_tid(interface, amsdu_tid);
+}
 #endif
 
 int nl80211_set_regulatory_domain(wifi_countrycode_type_t country_code)

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -906,7 +906,7 @@ int     nl80211_retry_interface_enable(wifi_interface_info_t *interface, bool en
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 
-#if defined(TCXB8_PORT) || defined(XB10_PORT)
+#if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)
 int     nl80211_set_amsdu_tid(wifi_interface_info_t *interface, uint8_t *amsdu_tid);
 #endif
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
@@ -1236,6 +1236,7 @@ INT platform_set_intf_mld_bonding(wifi_radio_info_t *radio, wifi_interface_info_
 
 #if defined(SCXER10_PORT) && defined(CONFIG_IEEE80211BE)
 extern void (*g_eht_oneshot_notify)(wifi_interface_info_t *interface);
+int platform_set_amsdu_tid(wifi_interface_info_t *interface, uint8_t *amsdu_tid);
 #if defined(KERNEL_NO_320MHZ_SUPPORT)
 void platform_switch_channel(wifi_interface_info_t *interface, struct csa_settings *settings);
 void platform_config_eht_chanspec(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam);


### PR DESCRIPTION
Reason for change: Support AMSDU TID set
Test Procedure: verify dmcli set/get AMSDU TID commands.
Risks: None
Priority: P1