### PR TITLE
SHARMAN-3087 : Security method WPA/WPA2 mixed mode is not set proper

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -595,7 +595,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
 
         case wifi_security_mode_wpa_wpa2_personal:
         case wifi_security_mode_wpa_wpa2_enterprise:
-            conf->wpa = 1;
+            conf->wpa = 3;
             break;
 
         case wifi_security_mode_none:


### PR DESCRIPTION
SHARMAN-3087 : Security method WPA/WPA2 mixed mode is not set correctly. (#306)

Reason for change: rdk-wifi-hal change to include WPA_PROTO_RSN and WPA_PROTO_WPA. Test Procedure: beacon info should contain both RSN and WPA tags. Risks: Low
Priority:P1