### PR TITLE
XF10-97: XF10 Bringup [rdk-wifi-hal]

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -60,7 +60,7 @@
 #define mld_link_info _mld_link_info
 #if defined(SCXER10_PORT)
 #include <wifi-include/wlioctl.h>
-#elif defined(SKYSR213_PORT)
+#elif defined(SKYSR213_PORT) || defined(SCXF10_PORT)
 #include <wlioctl.h>
 #include <wlioctl_defs.h>
 #else


### PR DESCRIPTION
Reason for change: Add XF10 product flag support

Test Procedure: Build should work
Priority:P1
Risks:Low