### PR TITLE
RDKB-61235 CCI crashed on XB10 when executing XH0005

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -2830,35 +2830,41 @@ void update_eapol_sm_params(wifi_interface_info_t *interface)
             }
 #ifdef CONFIG_WIFI_EMULATOR
             if (vap->vap_mode == wifi_vap_mode_sta) {
-                if (interface->u.sta.wpa_eapol_config.openssl_ciphers == NULL) {
-                    interface->u.sta.wpa_eapol_config.openssl_ciphers = (char *)malloc(MAX_STR_LEN);
-                    if (interface->u.sta.wpa_eapol_config.openssl_ciphers == NULL) {
+                if (interface->wpa_s.current_ssid->eap.openssl_ciphers == NULL) {
+                    interface->wpa_s.current_ssid->eap.openssl_ciphers = (char *)malloc(
+                        MAX_STR_LEN);
+                    if (interface->wpa_s.current_ssid->eap.openssl_ciphers == NULL) {
                         wifi_hal_error_print("%s:%d: NULL Pointer\n", __func__, __LINE__);
                         return;
                     }
                 }
-                memset(interface->u.sta.wpa_eapol_config.openssl_ciphers, 0, MAX_STR_LEN);
-                strncpy(interface->u.sta.wpa_eapol_config.openssl_ciphers, SUPPORTED_CIPHERS,
-                        MAX_STR_LEN - 1);
-                if (interface->u.sta.wpa_eapol_config.phase2 == NULL) {
-                    interface->u.sta.wpa_eapol_config.phase2 = (char *)malloc(MAX_STR_LEN);
-                    if (interface->u.sta.wpa_eapol_config.phase2 == NULL) {
+                memset(interface->wpa_s.current_ssid->eap.openssl_ciphers, 0, MAX_STR_LEN);
+                strncpy(interface->wpa_s.current_ssid->eap.openssl_ciphers, SUPPORTED_CIPHERS,
+                    MAX_STR_LEN - 1);
+                if (interface->wpa_s.current_ssid->eap.phase2 == NULL) {
+                    interface->wpa_s.current_ssid->eap.phase2 = (char *)malloc(MAX_STR_LEN);
+                    if (interface->wpa_s.current_ssid->eap.phase2 == NULL) {
                         wifi_hal_error_print("%s:%d: NULL Pointer\n", __func__, __LINE__);
                         return;
                     }
                 }
-                memset(interface->u.sta.wpa_eapol_config.phase2, 0, MAX_STR_LEN);
+                memset(interface->wpa_s.current_ssid->eap.phase2, 0, MAX_STR_LEN);
                 switch (sec->u.radius.phase2) {
                 case WIFI_EAP_PHASE2_PAP:
-                    strncpy(interface->u.sta.wpa_eapol_config.phase2, "auth=PAP", MAX_STR_LEN - 1);
+                    strncpy(interface->wpa_s.current_ssid->eap.phase2, "auth=PAP", MAX_STR_LEN - 1);
                     break;
                 default:
                     // using PAP as default value.
-                    strncpy(interface->u.sta.wpa_eapol_config.phase2, "auth=PAP", MAX_STR_LEN - 1);
+                    strncpy(interface->wpa_s.current_ssid->eap.phase2, "auth=PAP", MAX_STR_LEN - 1);
                     break;
                 }
             }
-            interface->u.sta.wpa_eapol_config.fragment_size = 400;
+            interface->wpa_s.current_ssid->eap.fragment_size = 400;
+            interface->wpa_s.current_ssid->eap.identity = (unsigned char *)&sec->u.radius.identity;
+            interface->wpa_s.current_ssid->eap.identity_len = strlen(sec->u.radius.identity);
+            interface->wpa_s.current_ssid->eap.password = (unsigned char *)&sec->u.radius.key;
+            interface->wpa_s.current_ssid->eap.password_len = strlen(sec->u.radius.key);
+            interface->wpa_s.current_ssid->eap.eap_methods = &interface->u.sta.wpa_eapol_method;
             eapol_sm_notify_portControl(interface->u.sta.wpa_sm->eapol, Auto);
 #endif // CONFIG_WIFI_EMULATOR
             interface->u.sta.wpa_eapol_method.vendor = EAP_VENDOR_IETF;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7555,9 +7555,12 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
         }
     }
 
-    if ((security->mode == wifi_security_mode_wpa3_personal) ||
-       (security->mode == wifi_security_mode_wpa3_compatibility)) {
-        interface->wpa_s.current_ssid->sae_password = malloc(MAX_PWD_LEN);
+    if ( (security->mode == wifi_security_mode_wpa3_personal) ||
+        (security->mode == wifi_security_mode_wpa3_compatibility) ||
+        (security->mode == wifi_security_mode_wpa3_transition)) {
+        if (interface->wpa_s.current_ssid->sae_password == NULL) {
+            interface->wpa_s.current_ssid->sae_password = malloc(MAX_PWD_LEN);
+        }
         if (interface->wpa_s.current_ssid->sae_password == NULL) {
             wifi_hal_error_print("%s:%d: NULL pointer\n", __func__, __LINE__);
             free(interface->wpa_s.current_ssid->ssid);
@@ -7592,7 +7595,6 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
     memset(interface->wpa_s.current_ssid->ssid, 0, (strlen(backhaul->ssid) + 1));
     strcpy(interface->wpa_s.current_ssid->ssid, backhaul->ssid);
     if ((security->mode != wifi_security_mode_wpa2_personal) &&
-            (security->mode != wifi_security_mode_wpa3_transition) &&
             (security->mode != wifi_security_mode_wpa3_compatibility)) {
         interface->wpa_s.current_ssid->ssid_len = strlen(backhaul->ssid);
     }


### PR DESCRIPTION
Impacted Platforms:
All RDKB Platforms

Reason for change: Added support for WPA3-PT

Test Procedure: Trigger XH0005 test to see if its passing

Risks: None
Priority: P0
Signed-off-by:Pavithra_Sundaravadivel@comcast.com