### PR TITLE
RDKB-61540: Address MLO compilation issues seen on 2.10 hostap

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -149,6 +149,7 @@ int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationPa
 
 int platform_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
 {
+#if (HOSTAPD_VERSION >= 211)
     wifi_vap_info_t *vap;
     wifi_interface_info_t *interface;
     struct hostapd_data *hapd, *link_bss;
@@ -185,7 +186,7 @@ int platform_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             }
         }
     }
-
+#endif
     return 0;
 }
 
@@ -885,6 +886,7 @@ static bool wifi_hal_is_mld_link_exists(struct hostapd_data *hapd)
 
 int update_hostap_mlo(wifi_interface_info_t *interface)
 {
+#if (HOSTAPD_VERSION >= 211)
     struct hostapd_bss_config *conf;
     struct hostapd_data *hapd, *first_link, *link_bss;
 
@@ -958,7 +960,7 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
             return -1;
         }
     }
-
+#endif
     return 0;
 }
 #endif /* CONFIG_IEEE80211BE */

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -577,7 +577,7 @@ INT wifi_hal_pre_init()
         pre_init_fn();
     }
 
-#ifdef BANANA_PI_PORT
+#if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
     void hostapd_wpa_event(void *ctx, enum wpa_event_type event, union wpa_event_data *data);
 
     wpa_supplicant_event = hostapd_wpa_event;

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -226,7 +226,7 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
                     len - 24 - sizeof(mgmt->u.assoc_resp);
             }
             event.assoc_reject.status_code = status;
-#if defined(BANANA_PI_PORT)
+#if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
             wpa_supplicant_event(&interface->wpa_s, EVENT_ASSOC_REJECT, &event);
 #else
             wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_ASSOC_REJECT, &event);
@@ -262,7 +262,7 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
 	event.assoc_info.beacon_ies_len = 0;
     }
 
-#if defined(BANANA_PI_PORT)
+#if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
     wpa_supplicant_event(&interface->wpa_s, EVENT_ASSOC, &event);
 #else
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_ASSOC, &event);
@@ -292,7 +292,7 @@ static void nl80211_authenticate_event(wifi_interface_info_t *interface, struct 
         wifi_hal_dbg_print("%s:%d: NO FRAME \n", __func__, __LINE__);
     }
 
-#if defined(BANANA_PI_PORT)
+#if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
     wpa_supplicant_event(&interface->wpa_s, EVENT_AUTH, &event);
 #else
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_AUTH, &event);
@@ -806,7 +806,7 @@ static void nl80211_disconnect_event(wifi_interface_info_t *interface, struct nl
 #if defined(CONFIG_WIFI_EMULATOR) || defined(BANANA_PI_PORT)
     wpa_supplicant_cancel_auth_timeout(&interface->wpa_s);
     interface->wpa_s.disconnected = 1;
-#if defined(BANANA_PI_PORT)
+#if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
     wpa_supplicant_event(&interface->wpa_s, EVENT_DISASSOC, NULL);
 #else
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_DISASSOC, NULL);


### PR DESCRIPTION
Reason for change: Address compilation error for platform using 2.10 or lesser based hostapd to use legacy mechanism for notifying supplicant event.

Test Procedure: Compilation and build checked.
Risks: Low
Priority: P1