### PR TITLE
RDKB-60953, BCOMB-3031: Add AMSDU TID handling (#308)

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -647,6 +647,15 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
     memcpy((unsigned char *)&old_operationParam, (unsigned char *)&radio->oper_param, sizeof(wifi_radio_operationParam_t));
 
     nl80211_interface_enable(primary_interface->name, operationParam->enable);
+#if defined(TCXB8_PORT) || defined(XB10_PORT)
+    if (nl80211_set_amsdu_tid(primary_interface, operationParam->amsduTid) != RETURN_OK)
+    {
+        wifi_hal_error_print(
+            "%s:%d:Failed to update AMSDU TID params ! AMSDU possibly out of sync \n",
+            __func__, __LINE__);
+        // fall-through, don't return error
+    }
+#endif
 
     if (radio->configured && radio->oper_param.enable != operationParam->enable) {
         memcpy((unsigned char *)&radio->oper_param, (unsigned char *)operationParam, sizeof(wifi_radio_operationParam_t));

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -774,6 +774,10 @@ int     nl80211_update_interface(wifi_interface_info_t *interface);
 int     nl80211_interface_enable(const char *ifname, bool enable);
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
+
+#if defined(TCXB8_PORT) || defined(XB10_PORT)
+int     nl80211_set_amsdu_tid(wifi_interface_info_t *interface, uint8_t *amsdu_tid);
+#endif
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
 
 typedef struct {


### PR DESCRIPTION
Reason for change: Implements handling of AMSDU TID
Test Procedure: Verify build, set/get AMSDU TID
Risks: None
Priority: P1