### PR TITLE
RDKB-60218 & RDKB-60219 Incorrect MAX channel set for 2G band in rdk-…

### DIFF
--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -624,12 +624,18 @@ static void nl80211_connect_event(wifi_interface_info_t *interface, struct nlatt
     mac_addr_str_t bssid_str;
     wifi_bss_info_t *backhaul;
     wifi_vap_security_t *sec;
+    wifi_radio_info_t *radio;
+    wifi_radio_operationParam_t *radio_param;
+
     sec = &interface->vap_info.u.sta_info.security;
 
     backhaul = &interface->u.sta.backhaul;
 
     wifi_hal_dbg_print("%s:%d:bssid:%s frequency:%d ssid:%s\n", __func__, __LINE__,
         to_mac_str(backhaul->bssid, bssid_str), backhaul->freq, backhaul->ssid);
+    radio = get_radio_by_rdk_index(interface->vap_info.radio_index);
+    radio_param = &radio->oper_param;
+
 
     assoc_req = interface->u.sta.assoc_req;
     assoc_rsp = interface->u.sta.assoc_rsp;
@@ -656,6 +662,8 @@ static void nl80211_connect_event(wifi_interface_info_t *interface, struct nlatt
             to_mac_str(mac, mac_str));
 
     }
+
+    ieee80211_freq_to_channel_ext(backhaul->freq,0,0,(unsigned char*)&radio_param->operatingClass, (unsigned char*)&radio_param->channel);
 
     if (tb[NL80211_ATTR_REQ_IE] == NULL) { 
         wifi_hal_dbg_print("%s:%d: req ie attribute absent\n", __func__, __LINE__);

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -185,7 +185,7 @@ extern "C" {
 #define MIN_FREQ_MHZ_2G             2412
 #define MAX_FREQ_MHZ_2G             2484
 #define MIN_CHANNEL_2G              1
-#define MAX_CHANNEL_2G              11
+#define MAX_CHANNEL_2G              14
 
 /* 5GHz radio */
 #define MIN_FREQ_MHZ_5G             5180


### PR DESCRIPTION
…wifi-hal (#245)

RDKB-60218:- Incorrect MAX channel set for 2G band in rdk-wifi-hal

Reason for change:-
Station mode scanning will fail in non US country codes.



RDKB-60219: update channel during connect event from driver Reason for change:-
Backahul station disconnect during Ap push when backahul connected through non default channels