### PR TITLE
RDKB-60004:Wi-Fi Telemetry to monitor interop issues with client connectivity(8.2_p3b)

### DIFF
--- a/src/action_framework.h
+++ b/src/action_framework.h
@@ -96,7 +96,7 @@ typedef struct {
     struct rtnl_kvr_handle  rtnl_kvr;
     wifi_newApAssociatedDevice_callback assoc_cb[MAX_REGISTERED_CB_NUM];
     unsigned int    num_assoc_cbs;
-    wifi_apDisassociatedDevice_callback disassoc_cb[MAX_REGISTERED_CB_NUM];
+    wifi_device_disassociated_callback disassoc_cb[MAX_REGISTERED_CB_NUM];
     unsigned int    num_disassoc_cbs;
     queue_t             *queue;
     wifi_RMBeaconReport_callback          bcnrpt_callback[MAX_AP_INDEX];
@@ -113,7 +113,7 @@ typedef struct {
     pthread_mutex_t     lock;
     pthread_t notification_thread_id;
     bool            notification_framework_initialized;
-    wifi_apDeAuthEvent_callback               apDeAuthEvent_cb[MAX_REGISTERED_CB_NUM];
+    wifi_device_deauthenticated_callback      apDeAuthEvent_cb[MAX_REGISTERED_CB_NUM];
     unsigned int    num_apDeAuthEvent_cbs;
     wifi_receivedMgmtFrame_callback     mgmt_frame_rx_callback;
        wifi_received8021xFrame_callback        eapol_frame_rx_callback;

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -3823,7 +3823,7 @@ void wifi_hal_newApAssociatedDevice_callback_register(wifi_newApAssociatedDevice
     callbacks->num_assoc_cbs++;
 }
 
-void wifi_hal_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback func)
+void wifi_hal_apDeAuthEvent_callback_register(wifi_device_deauthenticated_callback func)
 {
     wifi_device_callbacks_t *callbacks;
 
@@ -3863,7 +3863,7 @@ void wifi_hal_ap_max_client_rejection_callback_register(wifi_apMaxClientRejectio
     callbacks->max_cli_rejection_cb = func;
 }
 
-void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice_callback func)
+void wifi_hal_apDisassociatedDevice_callback_register(wifi_device_disassociated_callback func)
 {
     wifi_device_callbacks_t *callbacks;
 
@@ -3889,6 +3889,20 @@ void wifi_hal_stamode_callback_register(wifi_stamode_callback func)
 
     callbacks->stamode_cb[callbacks->num_stamode_cbs] = func;
     callbacks->num_stamode_cbs++;
+}
+
+void wifi_hal_apStatusCode_callback_register(wifi_apStatusCode_callback func)
+{
+    wifi_device_callbacks_t *callbacks;
+
+    callbacks = get_hal_device_callbacks();
+
+    if (callbacks == NULL || callbacks->num_statuscode_cbs> MAX_REGISTERED_CB_NUM) {
+        return;
+    }
+
+    callbacks->statuscode_cb[callbacks->num_statuscode_cbs] = func;
+    callbacks->num_statuscode_cbs++;
 }
 
 void wifi_hal_radius_eap_failure_callback_register(wifi_radiusEapFailure_callback func)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -993,7 +993,7 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
     unsigned int total_len=0;
     bool send_mgmt_to_char_dev = false;
 #endif
-
+    u16 reasoncode;
     if (mgmt == NULL) {
         return -1;
     }
@@ -1123,6 +1123,7 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
         break;
 
     case WLAN_FC_STYPE_ASSOC_RESP:
+	wifi_hal_dbg_print("%s:%d:assoc resp\n", __func__, __LINE__);
         mgmt_type = WIFI_MGMT_FRAME_TYPE_ASSOC_RSP;
         break;
 
@@ -1225,7 +1226,14 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
 
         for (int i = 0; i < callbacks->num_disassoc_cbs; i++) {
             if (callbacks->disassoc_cb[i] != NULL) {
-                callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str), reason);
+                if (len < IEEE80211_HDRLEN + sizeof(mgmt->u.disassoc)) {
+                    wifi_hal_dbg_print("handle_disassoc - too short payload (len=%lu)",(unsigned long) len);
+                    reasoncode = reason;
+                }
+                else {
+                    reasoncode = le_to_host16(mgmt->u.disassoc.reason_code);
+                }
+                callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(mgmt->sa, sta_mac_str), to_mac_str(mgmt->da, frame_da_str), mgmt_type, reasoncode);
             }
         }
 
@@ -1249,10 +1257,10 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
         mgmt_type = WIFI_MGMT_FRAME_TYPE_DEAUTH;
 
         if (len >= IEEE80211_HDRLEN + sizeof(mgmt->u.deauth)) {
-            wifi_hal_info_print("%s:%d: interface:%s received deauth frame from:%s to:%s sc:%d "
+            wifi_hal_info_print("%s:%d: interface:%s received deauth frame from:%s to:%s disassoc sc:%d deauth sc:%d "
                                 "len:%d reason:%d\n",
                 __func__, __LINE__, interface->name, to_mac_str(mgmt->sa, sta_mac_str),
-                to_mac_str(mgmt->da, frame_da_str), le_to_host16(mgmt->u.disassoc.reason_code), len,
+                to_mac_str(mgmt->da, frame_da_str), le_to_host16(mgmt->u.disassoc.reason_code), le_to_host16(mgmt->u.deauth.reason_code), len,
                 reason);
         } else {
             wifi_hal_info_print("%s:%d: interface:%s received deauth frame from:%s to:%s len:%d "
@@ -1266,14 +1274,20 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
         }
         for (int i = 0; i < callbacks->num_apDeAuthEvent_cbs; i++) {
             if (callbacks->apDeAuthEvent_cb[i] != NULL) {
-                callbacks->apDeAuthEvent_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str), reason);
+                if (len < IEEE80211_HDRLEN + sizeof(mgmt->u.deauth)) {
+                    wifi_hal_dbg_print("%s:%d handle_deauth - too short payload (len=%lu)",__func__, __LINE__, (unsigned long) len);
+                    reasoncode = reason;
+                }
+                else {
+                    reasoncode = le_to_host16(mgmt->u.deauth.reason_code);
+                }
+                callbacks->apDeAuthEvent_cb[i](vap->vap_index,to_mac_str(mgmt->sa,sta_mac_str),to_mac_str(mgmt->da,frame_da_str),mgmt_type,reasoncode);
             }
         }
 
         pthread_mutex_lock(&g_wifi_hal.hapd_lock);
         station = ap_get_sta(&interface->u.ap.hapd, sta);
         if (station) {
-            wifi_hal_dbg_print("station deauthreason in deauth frame is %d\n", station->disconnect_reason_code);
 #if !defined(PLATFORM_LINUX)
             if (station->disconnect_reason_code == WLAN_RADIUS_GREYLIST_REJECT) {
                 reason = station->disconnect_reason_code;
@@ -1286,7 +1300,15 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
         if (station) {
             for (int i = 0; i < callbacks->num_disassoc_cbs; i++) {
                 if (callbacks->disassoc_cb[i] != NULL) {
-                    callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str), reason);
+                    if (len < IEEE80211_HDRLEN + sizeof(mgmt->u.disassoc)) {
+                        wifi_hal_dbg_print("handle_disassoc - too short payload (len=%lu)",(unsigned long) len);
+                        reasoncode = reason;
+                    }
+                    else {
+                        reasoncode = le_to_host16(mgmt->u.disassoc.reason_code);
+                    }
+		    mgmt_type = WIFI_MGMT_FRAME_TYPE_DISASSOC;
+                    callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(mgmt->sa, sta_mac_str), to_mac_str(mgmt->da, frame_da_str), mgmt_type, reasoncode);
                 }
             }
         } else {
@@ -1345,8 +1367,6 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
             }
         }
     }
-
-    //mgmt_frame_received_callback(vap->vap_index, sta, mgmt, len, mgmt_type, dir);
 
     /* if frame wasn't completely handled by this function, call the hostapd code */
     if (forward_frame) {
@@ -1414,7 +1434,6 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
     }
 
 #endif
-
     return -1;
 }
 
@@ -1431,7 +1450,6 @@ int process_mgmt_frame(struct nl_msg *msg, void *arg)
 #ifdef CMXB7_PORT
     int snr = 0;
 #endif
-
     gnlh = nlmsg_data(nlmsg_hdr(msg));
     nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL);
 
@@ -1501,7 +1519,6 @@ int process_mgmt_frame(struct nl_msg *msg, void *arg)
         return NL_SKIP;
     }
 #endif
-
     return NL_SKIP;
 }
 
@@ -9893,7 +9910,7 @@ int wifi_drv_sta_disassoc(void *priv, const u8 *own_addr, const u8 *addr, u16 re
 
     for (int i = 0; i < callbacks->num_disassoc_cbs; i++) {
         if (callbacks->disassoc_cb[i] != NULL) {
-            callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(addr, mac_str), 0);
+            callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(addr, mac_str), to_mac_str(interface->mac, mac_str), WIFI_MGMT_FRAME_TYPE_DISASSOC, reason);
         }
     }
 #endif
@@ -9938,7 +9955,7 @@ int wifi_drv_sta_notify_deauth(void *priv, const u8 *own_addr, const u8 *addr, u
 
     for (int i = 0; i < callbacks->num_apDeAuthEvent_cbs; i++) {
         if (callbacks->apDeAuthEvent_cb[i] != NULL) {
-            callbacks->apDeAuthEvent_cb[i](vap->vap_index, to_mac_str(addr, mac_str), reason);
+            callbacks->apDeAuthEvent_cb[i](vap->vap_index, to_mac_str(addr, mac_str), to_mac_str(addr, mac_str),5,reason);
         }
     }
 
@@ -10002,7 +10019,7 @@ int wifi_drv_sta_deauth(void *priv, const u8 *own_addr, const u8 *addr, u16 reas
 
     for (int i = 0; i < callbacks->num_apDeAuthEvent_cbs; i++) {
         if (callbacks->apDeAuthEvent_cb[i] != NULL) {
-            callbacks->apDeAuthEvent_cb[i](vap->vap_index, to_mac_str(addr, mac_str), reason);
+            callbacks->apDeAuthEvent_cb[i](vap->vap_index, to_mac_str(addr, mac_str),to_mac_str(addr, mac_str),5,reason);
         }
     }
 #endif
@@ -10336,7 +10353,6 @@ int wifi_drv_hapd_send_eapol(
     memcpy(eth_hdr->dest, addr, sizeof(mac_address_t));
     eth_hdr->ethertype = host_to_be16(ETH_P_EAPOL);
     memcpy(buff + sizeof(struct ieee8023_hdr), data, data_len);
-
 #ifdef WIFI_EMULATOR_CHANGE
     if ((access(ONEWIFI_TESTSUITE_TMPFILE, R_OK)) == 0) {
         if (fd_c < 0) {
@@ -15181,7 +15197,6 @@ int wifi_drv_get_sta_auth_type(void *priv, const u8 *addr, int auth_key,int fram
         key_mgmt = -1;
     }
     interface = (wifi_interface_info_t *)priv;
-
     if(interface == NULL) {
         wifi_hal_error_print("%s:%d interface is null\n", __func__, __LINE__);
         return RETURN_ERR;
@@ -15191,8 +15206,8 @@ int wifi_drv_get_sta_auth_type(void *priv, const u8 *addr, int auth_key,int fram
     memcpy(sta, addr, sizeof(mac_address_t));
     band = vap->radio_index;
     callbacks = get_hal_device_callbacks();
-
     if (callbacks == NULL) {
+        wifi_hal_info_print("%s:%d callbacks is null \n", __func__, __LINE__);
         return -1;
     }
 
@@ -15219,7 +15234,6 @@ int wifi_drv_get_sta_auth_type(void *priv, const u8 *addr, int auth_key,int fram
              callbacks->stamode_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str), key_mgmt, frame_type, band, mode);
          }
      }
-
     return RETURN_OK;
 }
 

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -286,7 +286,9 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
     union wpa_event_data event;
     const struct ieee80211_hdr *hdr;
     mac_addr_str_t  sta_mac_str;
+    mac_addr_str_t  frame_da_str;
     u16 reason = 0;
+    u16 status = 0;
     u16 fc;
     struct sta_info *station = NULL;
     wifi_device_callbacks_t *callbacks = NULL;
@@ -302,7 +304,6 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
     wifi_direction_t dir;
     mac_address_t   sta, bmac = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
     callbacks = get_hal_device_callbacks();
-
     if ((frame = tb[NL80211_ATTR_FRAME]) == NULL) {
         wifi_hal_dbg_print("%s:%d: frame attribute not present\n", __func__, __LINE__);
         return;
@@ -357,7 +358,7 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
 #if HOSTAPD_VERSION >= 211
     event.tx_status.link_id = NL80211_DRV_LINK_ID_NA;
 #endif /* HOSTAPD_VERSION >= 211 */
-
+   const struct ieee80211_mgmt *mgmt = (const struct ieee80211_mgmt *)event.tx_status.data;
    if (event.tx_status.type  == WLAN_FC_TYPE_MGMT &&
      (event.tx_status.stype == WLAN_FC_STYPE_AUTH ||
         event.tx_status.stype == WLAN_FC_STYPE_ASSOC_RESP ||
@@ -369,15 +370,44 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
 
         switch(event.tx_status.stype) {
          case WLAN_FC_STYPE_AUTH:
-            mgmt_type = WIFI_MGMT_FRAME_TYPE_AUTH;
+            mgmt_type = WIFI_MGMT_FRAME_TYPE_AUTH_RSP;
+
+            for (int i = 0; i < callbacks->num_statuscode_cbs; i++) {
+                if (callbacks->statuscode_cb[i] != NULL) {
+                    status = le_to_host16(mgmt->u.auth.status_code);
+                    callbacks->statuscode_cb[i](vap->vap_index, to_mac_str(hdr->addr2, sta_mac_str), to_mac_str(hdr->addr1, frame_da_str), mgmt_type, status);
+                }
+            }
             break;
 
         case WLAN_FC_STYPE_ASSOC_RESP:
             mgmt_type = WIFI_MGMT_FRAME_TYPE_ASSOC_RSP;
+            wifi_hal_dbg_print("%s:%d: Received assoc response frame from: %s\n", __func__, __LINE__,
+                           to_mac_str(sta, sta_mac_str));
+
+            for (int i = 0; i < callbacks->num_statuscode_cbs; i++) {
+                if (callbacks->statuscode_cb[i] != NULL) {
+                    status = le_to_host16(mgmt->u.assoc_resp.status_code);
+                    //wifi_hal_dbg_print("%s:%d:assocrp status code is %d and status is %d \n", __func__, __LINE__,le_to_host16(mgmt->u.assoc_resp.status_code),status);
+                    callbacks->statuscode_cb[i](vap->vap_index, to_mac_str(hdr->addr2, sta_mac_str), to_mac_str(hdr->addr1, frame_da_str), mgmt_type, status);
+                    wifi_hal_dbg_print("%s:%d: status code callback is called for assoc resp \n", __func__, __LINE__);
+                }
+            }
             break;
 
         case WLAN_FC_STYPE_REASSOC_RESP:
             mgmt_type = WIFI_MGMT_FRAME_TYPE_REASSOC_RSP;
+            wifi_hal_dbg_print("%s:%d: Received Reassoc response frame from: %s\n", __func__, __LINE__,
+                           to_mac_str(sta, sta_mac_str));
+
+            for (int i = 0; i < callbacks->num_statuscode_cbs; i++) {
+                if (callbacks->statuscode_cb[i] != NULL) {
+                    status = le_to_host16(mgmt->u.reassoc_resp.status_code);
+                    //wifi_hal_dbg_print("%s:%d:Reassocrp status code is %d and status is %d \n", __func__, __LINE__,le_to_host16(mgmt->u.reassoc_resp.status_code),status);
+                    callbacks->statuscode_cb[i](vap->vap_index, to_mac_str(hdr->addr2, sta_mac_str), to_mac_str(hdr->addr1, frame_da_str), mgmt_type, status);
+                    wifi_hal_dbg_print("%s:%d: status code callback is called for reassoc resp \n", __func__, __LINE__);
+                }
+            }
             break;
 
         case WLAN_FC_STYPE_DISASSOC:
@@ -398,7 +428,7 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
 
             for (int i = 0; i < callbacks->num_disassoc_cbs; i++) {
                 if (callbacks->disassoc_cb[i] != NULL) {
-                    callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str), reason);
+                    callbacks->disassoc_cb[i](vap->vap_index, to_mac_str(hdr->addr2, sta_mac_str), to_mac_str(hdr->addr1, frame_da_str), mgmt_type, reason);
                 }
             }
 
@@ -443,7 +473,7 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
 
             for (int i = 0; i < callbacks->num_apDeAuthEvent_cbs; i++) {
                 if (callbacks->apDeAuthEvent_cb[i] != NULL) {
-                   callbacks->apDeAuthEvent_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str), reason);
+                   callbacks->apDeAuthEvent_cb[i](vap->vap_index, to_mac_str(hdr->addr2, sta_mac_str), to_mac_str(hdr->addr1, frame_da_str), mgmt_type, reason);
                 }
             }
 

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -722,11 +722,12 @@ INT wifi_hal_cancelRMBeaconRequest(UINT apIndex, UCHAR dialogToken);
 INT wifi_hal_configNeighborReports(UINT apIndex, bool enable, bool auto_resp);
 INT wifi_hal_setNeighborReports(UINT apIndex, UINT numNeighborReports, wifi_NeighborReport_t *neighborReports);
 void wifi_hal_newApAssociatedDevice_callback_register(wifi_newApAssociatedDevice_callback func);
-void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice_callback func);
+void wifi_hal_apDisassociatedDevice_callback_register(wifi_device_disassociated_callback func);
 void wifi_hal_stamode_callback_register(wifi_stamode_callback func);
+void wifi_hal_apStatusCode_callback_register(wifi_apStatusCode_callback func);
 void wifi_hal_radiusEapFailure_callback_register(wifi_radiusEapFailure_callback func);
 void wifi_hal_radiusFallback_failover_callback_register(wifi_radiusFallback_failover_callback func);
-void wifi_hal_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback func);
+void wifi_hal_apDeAuthEvent_callback_register(wifi_device_deauthenticated_callback func);
 void wifi_hal_ap_max_client_rejection_callback_register(wifi_apMaxClientRejection_callback func);
 INT wifi_hal_BTMQueryRequest_callback_register(UINT apIndex,
                                             wifi_BTMQueryRequest_callback btmQueryCallback,

--- a/src/wifi_hal_rdk_framework.h
+++ b/src/wifi_hal_rdk_framework.h
@@ -126,8 +126,10 @@ typedef struct {
     wifi_newApAssociatedDevice_callback     assoc_cb[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_assoc_cbs;
     wifi_apMaxClientRejection_callback      max_cli_rejection_cb;
-    wifi_apDisassociatedDevice_callback     disassoc_cb[MAX_REGISTERED_CB_NUM];
+    wifi_device_disassociated_callback      disassoc_cb[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_disassoc_cbs;
+    wifi_apStatusCode_callback              statuscode_cb[MAX_REGISTERED_CB_NUM];
+    unsigned int                            num_statuscode_cbs;
     unsigned int                            num_radius_eap_cbs;
     wifi_radiusEapFailure_callback          radius_eap_cb[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_radius_fallback_failover_cbs;
@@ -146,7 +148,7 @@ typedef struct {
     pthread_mutex_t                         lock;
     pthread_t                               notification_thread_id;
     bool                                    notification_framework_initialized;
-    wifi_apDeAuthEvent_callback             apDeAuthEvent_cb[MAX_REGISTERED_CB_NUM];
+    wifi_device_deauthenticated_callback    apDeAuthEvent_cb[MAX_REGISTERED_CB_NUM];
     wifi_vapstatus_callback                 vapstatus_cb[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_apDeAuthEvent_cbs;
     wifi_receivedMgmtFrame_callback         mgmt_frame_rx_callback;


### PR DESCRIPTION
Impacted Platforms:
All Onewifi Platforms

Reason for change: To monitor interop issues, added telemetry for reason ,status codes for client connectivity.

Test Procedure: connect the client ,disconnect and check the REASON_STATUS_COUNT in wifihealth.txt

Priority: P1

Risks: Low

Signed-off-by:Harshavardhan_Pulluru@comcast.com