### PR TITLE
RDKBACCL-1067 : bpi default ssid names got changed in latest tip code

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -268,7 +268,11 @@ int platform_get_ssid_default(char *ssid, int vap_index)
         }
     }
     wifi_hal_dbg_print("%s:%d, read SSID from jSON file failed:%d\n", __func__, __LINE__, ret);
+#ifdef CONFIG_GENERIC_MLO
     snprintf(ssid, BPI_LEN_16, "BPI-RDKB-MLO-AP");
+#else    
+    snprintf(ssid,BPI_LEN_16,"BPI_RDKB-AP%d",vap_index);
+#endif    
     return 0;
 }
 
@@ -303,7 +307,11 @@ int nvram_get_current_password(char *l_password, int vap_index)
 int nvram_get_current_ssid(char *l_ssid, int vap_index)
 {
     wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
+#ifdef CONFIG_GENERIC_MLO    
     snprintf(l_ssid, BPI_LEN_16, "BPI-RDKB-MLO-AP");
+#else    
+    snprintf(l_ssid,BPI_LEN_16,"BPI_RDKB-AP%d",vap_index);
+#endif    
     return 0;
 }
 


### PR DESCRIPTION
Reason for change: Updated bpi default ssid name in platform layer
Test Procedure: Compilation and build checked.
Risks: Low