### PR TITLE
RDKB-61540: Fix backhaul station connection

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1442,11 +1442,16 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
         memcpy((unsigned char *)&interface->vap_info, (unsigned char *)vap, sizeof(wifi_vap_info_t));
         interface_name = wifi_hal_get_interface_name(interface);
 
-#ifndef CONFIG_GENERIC_MLO
-        // VAP down removes MLO links
-        wifi_hal_info_print("%s:%d: interface:%s set down\n", __func__, __LINE__, interface->name);
-        nl80211_interface_enable(interface->name, false);
-#endif // CONFIG_GENERIC_MLO
+#ifdef CONFIG_GENERIC_MLO
+        // VAP down removes MLO links, so restrict down of interface to sta mode only
+        if (vap->vap_mode == wifi_vap_mode_sta) {
+#endif
+            wifi_hal_info_print("%s:%d: interface:%s set down\n", __func__, __LINE__, interface->name);
+            nl80211_interface_enable(interface->name, false);
+#ifdef CONFIG_GENERIC_MLO
+        }
+#endif
+
 #if  !defined(CONFIG_WIFI_EMULATOR) && !defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
         if (vap->vap_mode == wifi_vap_mode_sta) {
             bool sta_4addr = 0;

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -41,6 +41,12 @@
 #ifdef CONFIG_WIFI_EMULATOR
 #include "config_supplicant.h"
 #endif
+
+#if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
+extern void supplicant_event(void *ctx, enum wpa_event_type event,
+     union wpa_event_data *data);
+#endif
+
 int no_seq_check(struct nl_msg *msg, void *arg)
 {
     return NL_OK;
@@ -227,7 +233,7 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
             }
             event.assoc_reject.status_code = status;
 #if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
-            wpa_supplicant_event(&interface->wpa_s, EVENT_ASSOC_REJECT, &event);
+            supplicant_event(&interface->wpa_s, EVENT_ASSOC_REJECT, &event);
 #else
             wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_ASSOC_REJECT, &event);
 #endif // BANANA_PI_PORT
@@ -263,7 +269,7 @@ static void nl80211_associate_event(wifi_interface_info_t *interface, struct nla
     }
 
 #if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
-    wpa_supplicant_event(&interface->wpa_s, EVENT_ASSOC, &event);
+    supplicant_event(&interface->wpa_s, EVENT_ASSOC, &event);
 #else
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_ASSOC, &event);
 #endif // BANANA_PI_PORT
@@ -293,7 +299,7 @@ static void nl80211_authenticate_event(wifi_interface_info_t *interface, struct 
     }
 
 #if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
-    wpa_supplicant_event(&interface->wpa_s, EVENT_AUTH, &event);
+    supplicant_event(&interface->wpa_s, EVENT_AUTH, &event);
 #else
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_AUTH, &event);
 #endif // BANANA_PI_PORT
@@ -807,7 +813,7 @@ static void nl80211_disconnect_event(wifi_interface_info_t *interface, struct nl
     wpa_supplicant_cancel_auth_timeout(&interface->wpa_s);
     interface->wpa_s.disconnected = 1;
 #if defined(BANANA_PI_PORT) && (HOSTAPD_VERSION >= 211)
-    wpa_supplicant_event(&interface->wpa_s, EVENT_DISASSOC, NULL);
+    supplicant_event(&interface->wpa_s, EVENT_DISASSOC, NULL);
 #else
     wpa_supplicant_event_wpa(&interface->wpa_s, EVENT_DISASSOC, NULL);
 #endif // BANANA_PI_PORT


### PR DESCRIPTION
Reason for change: For station connection in createVAP bring down of interface is required, address this only for STA mode so as not to impact MLO connection.
Call the right supplicant event callback to handle supplicant events.

Risks: Low
Priority: P1