### PR TITLE
Revert "RDKB-61233: Easymesh - WiFi 7 Integration (#346)"

### DIFF
--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -101,28 +101,6 @@ static int json_parse_backhaul_ssid(char *backhaul_ssid)
     return json_parse_string(EM_CFG_FILE, "Backhaul_SSID", backhaul_ssid, MAX_SSID_LEN);
 }
 
-static int json_parse_fronthaul_keypassphrase(char *fronthaul_keypassphrase)
-{
-    return json_parse_string(EM_CFG_FILE, "Fronthaul_KeyPassphrase", fronthaul_keypassphrase,
-        MAX_KEYPASSPHRASE_LEN);
-}
-
-static int json_parse_fronthaul_ssid(char *fronthaul_ssid)
-{
-    return json_parse_string(EM_CFG_FILE, "Fronthaul_SSID", fronthaul_ssid, MAX_SSID_LEN);
-}
-
-static int json_parse_iot_keypassphrase(char *iot_keypassphrase)
-{
-    return json_parse_string(EM_CFG_FILE, "Iot_KeyPassphrase", iot_keypassphrase,
-        MAX_KEYPASSPHRASE_LEN);
-}
-
-static int json_parse_iot_ssid(char *iot_ssid)
-{
-    return json_parse_string(EM_CFG_FILE, "Iot_SSID", iot_ssid, MAX_SSID_LEN);
-}
-
 int platform_pre_init()
 {
     wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);    
@@ -201,18 +179,7 @@ int platform_get_keypassphrase_default(char *password, int vap_index)
             wifi_hal_dbg_print("%s:%d, read password from jSON file\n", __func__, __LINE__);
             return 0;
         }
-    } else if(is_wifi_hal_vap_xhs(vap_index)) {
-        if (!json_parse_iot_keypassphrase(password)) {
-            wifi_hal_dbg_print("%s:%d, read password from jSON file\n", __func__, __LINE__);
-            return 0;
-        }
-    } else {
-        if (!json_parse_fronthaul_keypassphrase(password)) {
-            wifi_hal_dbg_print("%s:%d, read password from jSON file\n", __func__, __LINE__);
-            return 0;
-        }
     }
-    wifi_hal_dbg_print("%s:%d default password not found from json - Reading from nvram defaults\n",__func__,__LINE__);
     /*password is not sensitive,won't grant access to real devices*/
     wifi_nvram_defaultRead("rpi_wifi_password", password);
     if (strlen(password) == 0) {
@@ -232,25 +199,11 @@ int platform_get_ssid_default(char *ssid, int vap_index)
     /* if the vap_index is that of mesh STA or mesh backhaul then try to obtain the ssid from
        /nvram/EasymeshCfg.json file */
     if (is_wifi_hal_vap_mesh_sta(vap_index) || is_wifi_hal_vap_mesh_backhaul(vap_index)) {
-        ret = json_parse_backhaul_ssid(ssid);
-        if(!ret) {
-            wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
-            return 0;
-        }
-    } else if(is_wifi_hal_vap_xhs(vap_index)) {
-        ret = json_parse_iot_ssid(ssid);
-        if (!ret) {
-            wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
-            return 0;
-        }
-    } else {
-        ret = json_parse_fronthaul_ssid(ssid);
-        if (!ret) {
+        if (!json_parse_backhaul_ssid(ssid)) {
             wifi_hal_dbg_print("%s:%d, read SSID:%s from jSON file\n", __func__, __LINE__, ssid);
             return 0;
         }
     }
-    wifi_hal_dbg_print("%s:%d, read SSID from jSON file failed:%d\n", __func__, __LINE__, ret);
     sprintf(ssid, "RPI_RDKB-AP%d", vap_index);
     return 0;
 }


### PR DESCRIPTION
Reveting this commit as it was temporary change added to skip EM reconfiguration.

This reverts commit 5296b5b1470623f7bcdc53dc6bedefc5cc7434cb.