### PR TITLE
RDKB-61227:  Facing crash reboot after triggering onewifi cases.

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -7228,7 +7228,8 @@ static int wifi_hal_emu_set_assoc_clients_stats_data(unsigned int vap_index, boo
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_FAILED_RETRIES, cli_FailedRetransCount) < 0 ||
             nla_put_u32(msg, RDK_VENDOR_ATTR_STA_INFO_ASSOC_NUM, stats[i].cli_Associations) < 0 ||
             nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_TX_RETRIES, cli_RetryCount) < 0 ||
-            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 ) {
+            nla_put_u64(msg, RDK_VENDOR_ATTR_STA_INFO_RX_ERRORS, stats[i].cli_RxErrors) < 0 ||
+            nla_put(msg, RDK_VENDOR_ATTR_STA_INFO_MLD_MAC, ETH_ALEN, stats[i].cli_MLDAddr) < 0 ) {
 
             nla_nest_cancel(msg, nlattr_sta_info);
             nlmsg_free(msg);


### PR DESCRIPTION
Impacted Platforms: All RDKB platforms.

Reason for change: As nl attribute not being set from CCI, the null pointer gets dereferenced and gets crashed.

Test Procedure:
1. Load the above mentioned image 2.After the device got boot up , run the test trigger from vb and check
   for kernel panic and test results.
3. If KP occurs or the test trigger got failed, issue reproduced.

Risks: Medium
Priority: P0
Signed-off-by: sanjayvenkatesan1902@gmail.com