### PR TITLE
RDKB-61364 : unsupported rate print in hal

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8137,6 +8137,10 @@ static void parse_supprates(const uint8_t type, uint8_t len,
             case 54*2:
                 rates = WIFI_BITRATE_54MBPS;
                 break;
+            case 123:
+                //membership selector for SAE-H2E
+                //Ignoring to update the rates
+                continue;
             default:
                 wifi_hal_error_print("%s:%d: [SCAN] Unsupported bitrate value: 0x%02X (%u.%u Mbps)\n",
                     __func__, __LINE__, r, r/2, 5*(r & 1)); 


### PR DESCRIPTION
Reason for change: added the check for membership selector 0xFB
Test Procedure: refer to the ticket.
Risks: None
Priority: P1

Signed-off-by: Ramakanth Taraka <ramakanth.taraka@sky.uk>