### PR TITLE
BCOMB-3033: mlo re-configuration enhancements correction

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -976,6 +976,7 @@ int platform_post_init(wifi_vap_info_map_t *vap_map)
 
 #if defined(CONFIG_IEEE80211BE) && defined(XB10_PORT) && defined(MLO_ENAB)
     platform_mlo_post_init();
+    platform_radio_up(-1, TRUE);		/* Bring all radios up */
     _platform_init_done = TRUE;
 #endif /* CONFIG_IEEE80211BE && XB10_PORT */
 


### PR DESCRIPTION
Reason for change: Private VAPs were not up correctly when mlo was enabled

Test Procedure: Verify that all private VAPs are up and have the correct MLO address and BSSID after boot.

Risks: Low
Priority: P1