### PR TITLE
Mlo hostapmgmtframectrl connetion fix

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -12801,7 +12801,7 @@ int wifi_drv_hapd_send_eapol(
 
     //my_print_hex_dump(data_len + sizeof(struct ieee8023_hdr), buff);
     if ((ret = send((vap->vap_mode == wifi_vap_mode_ap) ? interface->u.ap.br_sock_fd:interface->u.sta.sta_sock_fd,
-            buff, data_len + sizeof(struct ieee8023_hdr), flags)) < 0) {
+            buff, data_len + sizeof(struct ieee8023_hdr), 0)) < 0) {
         wifi_hal_error_print("%s:%d: eapol send failed ret=%d\n", __func__, __LINE__,ret);
 
         if (vap->vap_mode == wifi_vap_mode_ap) {


### PR DESCRIPTION
as it was discovered, broadcom platform requires to have **split_assoc_req=2** only for the link with mld_id=0. Otherwise, the driver will try to treet all links as main one and MLO connection won't be established.

 It shouldn't break any other logic sine this flag is related only to handling of Assoc Request content, but Assoc Resp content is still filled by the hostapd if the **split_assoc_req** is set to 0

Also, another bug with the STA driver flags passed to send() function found. Fix it by setting 0 as a last argument for send() function