### PR TITLE
RDKB-61540: MLO link reconfiguration for BPi-R4

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -25,11 +25,12 @@
 * Licensed under the BSD-3 License
 **************************************************************************/
 
-#include <stddef.h>
-#include <string.h>
-#include <stdlib.h>
-#include "wifi_hal_priv.h"
 #include "wifi_hal.h"
+#include "wifi_hal_priv.h"
+#include <net/if.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define NULL_CHAR '\0'
 #define NEW_LINE '\n'
@@ -44,6 +45,7 @@
 
 int wifi_nvram_defaultRead(char *in,char *out);
 int _syscmd(char *cmd, char *retBuf, int retBufSize);
+int dealloc_mld(wifi_interface_info_t *interface);
 
 typedef struct {
     mac_address_t *macs;
@@ -150,7 +152,7 @@ int platform_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             continue;
         }
 
-        if (!wifi_hal_is_mld_enabled(interface)) {
+        if (!wifi_hal_is_mld_enabled(interface) || !vap->u.bss_info.enabled) {
             continue;
         }
 
@@ -286,12 +288,191 @@ int nvram_get_current_ssid(char *l_ssid, int vap_index)
     return 0;
 }
 
+static bool has_config_changed(wifi_vap_info_t *current_config, wifi_vap_info_t *new_config)
+{
+    return ((current_config->u.bss_info.mld_info.common_info.mld_enable !=
+                new_config->u.bss_info.mld_info.common_info.mld_enable) ||
+        (current_config->u.bss_info.enabled != new_config->u.bss_info.enabled));
+}
+
+#ifdef CONFIG_GENERIC_MLO
+static int teardown_mlo_vap(wifi_interface_info_t *interface)
+{
+    wifi_interface_info_t *first_interface = NULL;
+    unsigned int ifidx = 0;
+
+    if (nl80211_enable_ap(interface, false) < 0) {
+        wifi_hal_error_print("%s:%d: interface:%s link id:%d failed to disable AP\n", __func__,
+            __LINE__, interface->mld_name, wifi_hal_get_mld_link_id(interface));
+        return -1;
+    }
+
+    if (hostapd_mld_is_first_bss(&interface->u.ap.hapd)) {
+        // We are removing the first link.
+        // First interface pointer could point to invalid data
+        // for shared resources if removed first.
+        // Clearing all other links first
+        struct hostapd_data *link;
+        struct hostapd_data *hapd = &interface->u.ap.hapd;
+        for_each_mld_link(link, hapd) {
+            if (hapd == link)
+                continue;
+            hostapd_bss_deinit_no_free(link);
+            hostapd_free_hapd_data(link);
+        }
+
+        pthread_mutex_lock(&g_wifi_hal.hapd_lock);
+        deinit_bss(&interface->u.ap.hapd);
+        if (interface->u.ap.hapd.conf->ssid.wpa_psk != NULL &&
+            interface->u.ap.hapd.conf->ssid.wpa_psk->next == NULL) {
+            hostapd_config_clear_wpa_psk(&interface->u.ap.hapd.conf->ssid.wpa_psk);
+        }
+        pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
+
+        if (dealloc_mld(interface) != 0) {
+            wifi_hal_error_print("%s:%d: Failed to deinitialize VAP %d from MLD %s\n", __func__,
+                __LINE__, interface->vap_info.vap_index, interface->mld_name);
+            return -1;
+        }
+
+        if (interface->mgmt_frames_registered) {
+            nl80211_unregister_mgmt_frames(interface);
+        }
+        if (interface->spurious_frames_registered) {
+            nl80211_unregister_spurious_frames(interface);
+        }
+        if (interface->data_frames_registered) {
+            unregister_data_frame_socket(interface);
+        }
+
+        first_interface = wifi_hal_get_first_mld_interface(interface);
+        if (first_interface != NULL && hostapd_mld_is_first_bss(&first_interface->u.ap.hapd)) {
+            first_interface->vap_configured = false;
+            wifi_drv_set_operstate(first_interface, 1);
+        }
+    } else {
+        pthread_mutex_lock(&g_wifi_hal.hapd_lock);
+        deinit_bss(&interface->u.ap.hapd);
+        if (interface->u.ap.hapd.conf->ssid.wpa_psk != NULL &&
+            interface->u.ap.hapd.conf->ssid.wpa_psk->next == NULL) {
+            hostapd_config_clear_wpa_psk(&interface->u.ap.hapd.conf->ssid.wpa_psk);
+        }
+        pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
+
+        if (dealloc_mld(interface) != 0) {
+            wifi_hal_error_print("%s:%d: Failed to deinitialize VAP %d from MLD %s\n", __func__,
+                __LINE__, interface->vap_info.vap_index, interface->mld_name);
+            return -1;
+        }
+
+        first_interface = wifi_hal_get_first_mld_interface(interface);
+    }
+
+    // Necessary in case of readding
+    nl80211_remove_from_bridge(interface->name);
+
+    // Remove MLD mac address
+    if (wifi_hal_set_mld_mac_address(interface, interface->mac) < 0) {
+        wifi_hal_error_print("%s:%d: Failed to set MAC address for interface %s\n", __func__,
+            __LINE__, interface->mld_name);
+        return -1;
+    }
+
+    ifidx = if_nametoindex(interface->name);
+    if (ifidx == 0) {
+        wifi_hal_error_print("%s:%d: Failed to get ifindex for switching from MLD interface %s\n",
+            __func__, __LINE__, interface->mld_name);
+        return -1;
+    }
+    interface->index = ifidx;
+
+    if (wifi_hal_set_mld_enabled(interface, false) < 0) {
+        wifi_hal_error_print("%s: %d: Failed to disable MLD %s on VAP idx %d\n", __func__, __LINE__,
+            interface->mld_name, interface->vap_info.vap_index);
+        return -1;
+    }
+
+    interface->bss_started = false;
+    interface->vap_initialized = false;
+    interface->vap_configured = false;
+
+    // Reload to update MLD
+    if (first_interface != NULL && hostapd_mld_is_first_bss(&first_interface->u.ap.hapd)) {
+        reload_vap_configuration(first_interface);
+    }
+    return 0;
+}
+
+static int setup_mlo_vap(wifi_interface_info_t *interface, wifi_vap_info_t *new_vap_config)
+{
+    unsigned int if_idx;
+
+    if (wifi_hal_set_mld_enabled(interface, true) < 0) {
+        wifi_hal_error_print("%s:%d: Failed to set mld_enable:%d on VAP idx %d\n", __func__,
+            __LINE__, new_vap_config->u.bss_info.mld_info.common_info.mld_enable,
+            interface->vap_info.vap_index);
+        return -1;
+    }
+
+    if (wifi_hal_set_mld_id(interface, new_vap_config->u.bss_info.mld_info.common_info.mld_id) <
+        0) {
+        wifi_hal_error_print("%s:%d: Failed to set MLD id %d on VAP idx %d\n", __func__, __LINE__,
+            new_vap_config->u.bss_info.mld_info.common_info.mld_id, interface->vap_info.vap_index);
+        return -1;
+    }
+
+    if_idx = if_nametoindex(interface->mld_name);
+    if (if_idx == 0) {
+        wifi_hal_error_print("%s:%d: Failed to find interface %s for MLD setup\n", __func__,
+            __LINE__, interface->mld_name);
+        return -1;
+    }
+
+    pthread_mutex_lock(&g_wifi_hal.hapd_lock);
+    deinit_bss(&interface->u.ap.hapd);
+    if (interface->u.ap.hapd.conf->ssid.wpa_psk != NULL &&
+        interface->u.ap.hapd.conf->ssid.wpa_psk->next == NULL) {
+        hostapd_config_clear_wpa_psk(&interface->u.ap.hapd.conf->ssid.wpa_psk);
+    }
+    pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
+
+    nl80211_unregister_mgmt_frames(interface);
+    nl80211_unregister_spurious_frames(interface);
+    unregister_data_frame_socket(interface);
+
+    if (new_vap_config->u.bss_info.mld_info.common_info.mld_enable &&
+        if_nametoindex(interface->name) != 0 &&
+        nl80211_interface_enable(interface->name, false) < 0) {
+        wifi_hal_error_print("%s:%d: failed to disable interface %s\n", __func__, __LINE__,
+            interface->name);
+        return -1;
+    }
+
+    // Necessary in case of readding
+    nl80211_remove_from_bridge(interface->mld_name);
+
+    // This will enforce:
+    // Security reload
+    // BSS restart
+    // netlink handlers registration if applicable
+    interface->bss_started = false;
+    interface->vap_initialized = false;
+    interface->vap_configured = false;
+
+    interface->index = if_idx;
+    return 0;
+}
+#endif // CONFIG_GENERIC_MLO
+
 int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
 {
-    char output_val[BPI_LEN_32];
-    int i;
-    wifi_vap_info_t *vap;
-    wifi_interface_info_t *interface;
+    char output_val[BPI_LEN_32] = { 0 };
+    int i = 0;
+    wifi_vap_info_t *vap = NULL;
+    wifi_interface_info_t *interface = NULL;
+
+    char *mld_name = NULL;
+    mac_address_t mld_mac = { 0 };
 
     wifi_hal_dbg_print("%s:%d \n",__func__,__LINE__);
 
@@ -321,33 +502,92 @@ int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
         if (vap->vap_mode != wifi_vap_mode_ap) {
             continue;
         }
+
         interface = get_interface_by_vap_index(vap->vap_index);
         if (interface == NULL) {
             wifi_hal_error_print("%s:%d: failed to get interface for vap_index %d\n", __func__,
                 __LINE__, vap->vap_index);
+            // TODO: change to return when creating interfaces via
+            // netlink is fixed
+            continue;
+        }
+
+#ifdef CONFIG_GENERIC_MLO
+        // TODO: resolve wifi-hal driven changes
+        // Because of DML cache, even if we update those values, the DML
+        // cache used with i.e. TR-181 stays the same and will keep
+        // trying to push it's cached values on us as we have no means to
+        // update it. We need to either:
+        //- force cache to resync with db after change, as db has proper
+        // values
+        //- have a feedback mechanism, i.e. a callback for DML to fetch
+        // the VAP status and do the updates
+        if (interface->u.ap.hapd.mld != NULL) {
+            interface->vap_info.u.bss_info.mld_info.common_info.mld_link_id =
+                interface->u.ap.hapd.mld_link_id;
+            vap->u.bss_info.mld_info.common_info.mld_link_id = interface->u.ap.hapd.mld_link_id;
+            wifi_hal_info_print("%s:%d: interface:%s link id:%d\n", __func__, __LINE__,
+                interface->name, wifi_hal_get_mld_link_id(interface));
+        }
+
+        mld_name = wifi_hal_get_mld_name_by_interface_name(interface->name);
+        if (mld_name == NULL) {
+            wifi_hal_error_print(
+                "%s:%d: MLD interface is enabled, but interface name is unset - skipping\n",
+                __func__, __LINE__);
             return -1;
         }
-        // Override MLO configuration because MLD enabled on the boot.
-        // TODO: dynamic configuration
-        vap->u.bss_info.mld_info.common_info.mld_enable =
-            interface->vap_info.u.bss_info.mld_info.common_info.mld_enable;
-        memcpy(vap->u.bss_info.mld_info.common_info.mld_addr,
-            interface->vap_info.u.bss_info.mld_info.common_info.mld_addr,
-            sizeof(vap->u.bss_info.mld_info.common_info.mld_addr));
-        vap->u.bss_info.mld_info.common_info.mld_link_id =
-            interface->vap_info.u.bss_info.mld_info.common_info.mld_link_id;
-        vap->u.bss_info.mld_info.common_info.mld_id =
-            interface->vap_info.u.bss_info.mld_info.common_info.mld_id;
 
-        // Disable non-MLD interface so it's MAC can be reused for MLD link
-        if (vap->u.bss_info.mld_info.common_info.mld_enable &&
-            nl80211_interface_enable(interface->name, false) < 0) {
-            wifi_hal_error_print("%s:%d: failed to disable interface %s\n", __func__, __LINE__,
-                interface->name);
-            return -1;
+        if (vap->u.bss_info.mld_info.common_info.mld_enable) {
+            strncpy(interface->mld_name, mld_name, sizeof(interface->mld_name) - 1);
+            if (wifi_hal_get_mac_address(mld_name, mld_mac) < 0) {
+                wifi_hal_error_print("%s:%d: Failed to get MAC address for interface %s\n",
+                    __func__, __LINE__, mld_name);
+                return -1;
+            }
+
+            if (wifi_hal_set_mld_mac_address(interface, mld_mac) < 0) {
+                wifi_hal_error_print("%s: %d: Failed to set MAC on MLD id %d on VAP idx %d\n",
+                    __func__, __LINE__, vap->u.bss_info.mld_info.common_info.mld_id,
+                    vap->vap_index);
+                return -1;
+            }
+
+            // This is feedback info to datamodel on MLD address.
+            memcpy(vap->u.bss_info.mld_info.common_info.mld_addr,
+                interface->vap_info.u.bss_info.mld_info.common_info.mld_addr,
+                sizeof(vap->u.bss_info.mld_info.common_info.mld_addr));
+        }
+
+        if (has_config_changed(&interface->vap_info, vap) == false) {
+            continue;
+        }
+
+        if (vap->u.bss_info.mld_info.common_info.mld_enable == false ||
+            vap->u.bss_info.enabled == false) {
+            if (teardown_mlo_vap(interface) != 0) {
+                wifi_hal_error_print("%s:%d: Failed to teardown link for MLD ID %d on VAP idx %d\n",
+                    __func__, __LINE__, vap->u.bss_info.mld_info.common_info.mld_id,
+                    vap->vap_index);
+                return -1;
+            }
+
+            // Set link_id to NA in DML
+            vap->u.bss_info.mld_info.common_info.mld_link_id = NL80211_DRV_LINK_ID_NA;
+            interface->vap_info.u.bss_info.mld_info.common_info.mld_link_id =
+                NL80211_DRV_LINK_ID_NA;
+
+            continue;
+        } else {
+            if (setup_mlo_vap(interface, vap) != 0) {
+                wifi_hal_error_print("%s:%d: Failed to setup link for MLD ID %d with VAP idx %d\n",
+                    __func__, __LINE__, vap->u.bss_info.mld_info.common_info.mld_id,
+                    vap->vap_index);
+                return -1;
+            }
         }
     }
-
+#endif // CONFIG_GENERIC_MLO
     return 0;
 }
 
@@ -896,6 +1136,7 @@ static int alloc_mld(wifi_interface_info_t *interface)
         wifi_hal_dbg_print("%s:%d hapd->mld was found for interface %s\n", __func__, __LINE__,
             interface->name);
         hapd->mld = mld;
+        mld->refcount++;
         return 0;
     }
 
@@ -919,13 +1160,87 @@ static int alloc_mld(wifi_interface_info_t *interface)
     mld->ctrl_sock = -1;
     memcpy(mld->mld_addr, wifi_hal_get_mld_mac_address(interface), ETH_ALEN);
 
-    mld->refcount++;
-
     new_mld_array[g_wifi_hal.mld_count] = mld;
     hapd->mld = mld;
-    g_wifi_hal.mld_array = new_mld_array;
+    mld->refcount++;
+    mld->num_links = 0;
+    mld->next_link_id = 0;
 
+    g_wifi_hal.mld_array = new_mld_array;
     g_wifi_hal.mld_count++;
+
+    return 0;
+}
+
+static void remove_mld_from_array(struct hostapd_mld *mld)
+{
+    unsigned int idx = 0;
+    for (; idx < g_wifi_hal.mld_count; ++idx) {
+        if (g_wifi_hal.mld_array[idx] == mld) {
+            free(g_wifi_hal.mld_array[idx]);
+            g_wifi_hal.mld_array[idx] = NULL;
+            break;
+        }
+    }
+
+    // Reorder remaining MLDs
+    while (idx + 1 < g_wifi_hal.mld_count) {
+        g_wifi_hal.mld_array[idx] = g_wifi_hal.mld_array[idx + 1];
+        ++idx;
+    }
+}
+
+int dealloc_mld(wifi_interface_info_t *interface)
+{
+    struct hostapd_data *hapd;
+    struct hostapd_mld **new_mld_array;
+    hapd = &interface->u.ap.hapd;
+
+    if (hapd->mld == NULL) {
+        wifi_hal_info_print("%s:%d hapd->mld empty, nothing to free \n", __func__, __LINE__);
+        return 0;
+    }
+
+    if (hostapd_if_link_remove(hapd, WPA_IF_AP_BSS, hapd->conf->iface, hapd->mld_link_id) != 0) {
+        wifi_hal_error_print("%s:%d Failed to remove link from driver ! Link id: %d, MLD: %s\n",
+            __func__, __LINE__, hapd->mld_link_id, interface->mld_name);
+        return -1;
+    }
+
+    if (hostapd_mld_remove_link(hapd) != 0) {
+        wifi_hal_error_print(
+            "%s:%d Failed to remove link from hostapd_mld ! Link id: %d, MLD: %s\n", __func__,
+            __LINE__, hapd->mld_link_id, interface->mld_name);
+        return -1;
+    }
+
+    if (hapd->mld->refcount > 0) {
+        hapd->mld->refcount--;
+    }
+
+    if (hapd->mld->refcount == 0) {
+        remove_mld_from_array(hapd->mld);
+
+        if (g_wifi_hal.mld_count > 1) {
+            // There are still other MLDs in the current config
+            new_mld_array = realloc(g_wifi_hal.mld_array,
+                (g_wifi_hal.mld_count - 1) * sizeof(struct hostapd_mld *));
+            if (new_mld_array == NULL) {
+                wifi_hal_error_print("%s:%d Failed to reallocate MLD array\n", __func__, __LINE__);
+                return -1;
+            }
+        } else {
+            new_mld_array = NULL;
+            free(g_wifi_hal.mld_array);
+        }
+
+        g_wifi_hal.mld_count--;
+        g_wifi_hal.mld_array = new_mld_array;
+    }
+
+    hapd->mld = NULL;
+    hapd->conf->mld_ap = 0;
+    hapd->conf->okc = 0;
 
     return 0;
 }
@@ -935,6 +1250,10 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
 #if (HOSTAPD_VERSION >= 211)
     struct hostapd_bss_config *conf;
     struct hostapd_data *hapd, *first_link, *link_bss;
+
+    if (!interface->vap_info.u.bss_info.enabled) {
+        return 0;
+    }
 
     if (interface->u.ap.conf.disable_11be) {
         return 0;
@@ -960,12 +1279,15 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
 
     conf->mld_ap = 1;
     conf->okc = 1;
-    hapd->mld_link_id = wifi_hal_get_mld_link_id(interface);
 
-    if (!wifi_hal_is_mld_link_exists(hapd) && hostapd_mld_add_link(hapd) != 0) {
-        wifi_hal_error_print("%s:%d: Failed to add link %d in MLD %s\n", __func__, __LINE__,
-            hapd->mld_link_id, hapd->conf->iface);
-        return -1;
+    if (!wifi_hal_is_mld_link_exists(hapd)) {
+        hapd->mld_link_id = hapd->mld->next_link_id++;
+        if (hostapd_mld_add_link(hapd)) {
+            wifi_hal_error_print("%s:%d: Failed to add link %d in MLD %s\n", __func__, __LINE__,
+                hapd->mld_link_id, hapd->conf->iface);
+            return -1;
+        }
+        interface->vap_info.u.bss_info.mld_info.common_info.mld_link_id = hapd->mld_link_id;
     }
 
     /* Links have been removed due to interface down-up. Re-add all links and enable them,

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1381,208 +1381,6 @@ int get_sta_4addr_status(bool *sta_4addr)
     return json_parse_boolean(EM_CFG_FILE, "sta_4addr_mode_enabled", sta_4addr);
 }
 
-static int reload_single_vap_configuration(wifi_interface_info_t *interface)
-{
-    char *interface_name = wifi_hal_get_interface_name(interface);
-    wifi_radio_info_t *radio = get_radio_by_rdk_index(interface->rdk_radio_index);
-
-    if (radio == NULL) {
-        wifi_hal_error_print("%s:%d: interface:%s failed to get radio for index:%d\n", __func__,
-            __LINE__, interface_name, interface->rdk_radio_index);
-        return -1;
-    }
-
-    wifi_hal_info_print("%s:%d: interface:%s reload hostapd config\n", __func__, __LINE__,
-        interface_name);
-
-#ifndef CONFIG_GENERIC_MLO
-    interface->beacon_set = 0;
-#endif /* CONFIG_GENERIC_MLO */
-
-    pthread_mutex_lock(&g_wifi_hal.hapd_lock);
-    if (hostapd_reload_config(interface->u.ap.hapd.iface) < 0) {
-        wifi_hal_error_print("%s:%d: interface:%s failed to reload VAP configuration\n", __func__,
-            __LINE__, interface_name);
-        pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
-        return -1;
-    }
-#ifdef CONFIG_SAE
-    if (interface->u.ap.conf.sae_groups != NULL) {
-        interface->u.ap.conf.sae_groups = NULL;
-    }
-#endif
-    pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
-
-    /* Prevent hostap calling set_ap when client is removed due to VAP disable before
-     * start_bss */
-    interface->in_reconf = true;
-
-    wifi_hal_info_print("%s:%d: interface:%s disable AP\n", __func__, __LINE__, interface_name);
-    nl80211_enable_ap(interface, false);
-    interface->bss_started = false;
-
-    wifi_hal_info_print("%s:%d: interface:%s free hostapd data\n", __func__, __LINE__,
-        interface_name);
-    pthread_mutex_lock(&g_wifi_hal.hapd_lock);
-    deinit_bss(&interface->u.ap.hapd);
-    if (interface->u.ap.hapd.conf->ssid.wpa_psk != NULL &&
-        interface->u.ap.hapd.conf->ssid.wpa_psk->next == NULL) {
-        hostapd_config_clear_wpa_psk(&interface->u.ap.hapd.conf->ssid.wpa_psk);
-    }
-    pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
-
-    wifi_hal_info_print("%s:%d: interface:%s update hostapd params\n", __func__, __LINE__,
-        interface_name);
-    if (update_hostap_interface_params(interface) < 0) {
-        wifi_hal_error_print("%s:%d: interface:%s failed to update hostapd params\n", __func__,
-            __LINE__, interface_name);
-        return -1;
-    }
-
-    interface->in_reconf = false;
-
-    if (interface->vap_info.u.bss_info.enabled && radio->configured && radio->oper_param.enable) {
-        wifi_hal_info_print("%s:%d: interface:%s enable ap\n", __func__, __LINE__, interface_name);
-        interface->beacon_set = 0;
-        if (start_bss(interface) < 0) {
-            wifi_hal_error_print("%s:%d: interface:%s failed to start BSS\n", __func__, __LINE__,
-                interface_name);
-            return -1;
-        }
-        interface->bss_started = true;
-    }
-
-    return 0;
-}
-
-#ifdef CONFIG_GENERIC_MLO
-static int reload_mlo_vap_configuration(wifi_interface_info_t *interface)
-{
-    char *interface_name = wifi_hal_get_interface_name(interface);
-    int link_id = wifi_hal_get_mld_link_id(interface);
-
-    wifi_hal_info_print("%s:%d: interface:%s link id:%d reload hostapd config\n", __func__,
-        __LINE__, interface_name, link_id);
-
-    pthread_mutex_lock(&g_wifi_hal.hapd_lock);
-    if (hostapd_reload_config(interface->u.ap.hapd.iface) < 0) {
-        wifi_hal_error_print("%s:%d: interface:%s link id:%d failed to reload VAP configuration\n",
-            __func__, __LINE__, interface_name, link_id);
-        pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
-        return -1;
-    }
-#ifdef CONFIG_SAE
-    if (interface->u.ap.conf.sae_groups != NULL) {
-        interface->u.ap.conf.sae_groups = NULL;
-    }
-#endif
-    pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
-
-    for (int i = g_wifi_hal.num_radios - 1; i >= 0; i--) {
-        wifi_interface_info_t *interface_iter = NULL;
-        wifi_radio_info_t *radio = get_radio_by_rdk_index(i);
-
-        if (radio == NULL) {
-            wifi_hal_error_print("%s:%d: Failed to get radio for index:%d\n", __func__, __LINE__,
-                i);
-            continue;
-        }
-
-        hash_map_foreach(radio->interface_map, interface_iter) {
-            char *interface_iter_name;
-            int interface_iter_link_id;
-
-            if (!wifi_hal_is_mld_enabled(interface_iter)) {
-                continue;
-            }
-
-            if (interface_iter->index != interface->index) {
-                continue;
-            }
-
-            /* Prevent hostap calling set_ap when client is removed due to VAP disable before
-             * start_bss */
-            interface_iter->in_reconf = true;
-
-            interface_iter_name = wifi_hal_get_interface_name(interface_iter);
-            interface_iter_link_id = wifi_hal_get_mld_link_id(interface_iter);
-            wifi_hal_info_print("%s:%d: interface:%s link id:%d disable AP\n", __func__, __LINE__,
-                interface_iter_name, interface_iter_link_id);
-            nl80211_enable_ap(interface_iter, false);
-            interface_iter->bss_started = false;
-
-            wifi_hal_info_print("%s:%d: interface:%s link id:%d free hostapd data\n", __func__,
-                __LINE__, interface_iter_name, interface_iter_link_id);
-            pthread_mutex_lock(&g_wifi_hal.hapd_lock);
-            deinit_bss(&interface_iter->u.ap.hapd);
-            if (interface_iter->u.ap.hapd.conf->ssid.wpa_psk != NULL &&
-                interface_iter->u.ap.hapd.conf->ssid.wpa_psk->next == NULL) {
-                hostapd_config_clear_wpa_psk(&interface_iter->u.ap.hapd.conf->ssid.wpa_psk);
-            }
-            pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
-        }
-    }
-
-    for (unsigned int i = 0; i < g_wifi_hal.num_radios; i++) {
-        wifi_interface_info_t *interface_iter = NULL;
-        wifi_radio_info_t *radio = get_radio_by_rdk_index(i);
-
-        hash_map_foreach(radio->interface_map, interface_iter) {
-            char *interface_iter_name;
-            int interface_iter_link_id;
-
-            if (!wifi_hal_is_mld_enabled(interface_iter)) {
-                continue;
-            }
-
-            if (interface_iter->index != interface->index) {
-                continue;
-            }
-
-            interface_iter_name = wifi_hal_get_interface_name(interface_iter);
-            interface_iter_link_id = wifi_hal_get_mld_link_id(interface_iter);
-
-            wifi_hal_info_print("%s:%d: interface:%s link id:%d update hostapd params\n", __func__,
-                __LINE__, interface_iter_name, interface_iter_link_id);
-            if (update_hostap_interface_params(interface_iter) < 0) {
-                wifi_hal_error_print("%s:%d: interface:%s link id:%d failed to update hostapd "
-                                     "params\n",
-                    __func__, __LINE__, interface_iter_name, interface_iter_link_id);
-                return -1;
-            }
-
-            interface_iter->in_reconf = false;
-
-            if (interface->vap_info.u.bss_info.enabled && radio->configured &&
-                radio->oper_param.enable) {
-                wifi_hal_info_print("%s:%d: interface:%s link id:%d enable AP\n", __func__,
-                    __LINE__, interface_iter_name, interface_iter_link_id);
-                if (start_bss(interface_iter) < 0) {
-                    wifi_hal_error_print("%s:%d: interface:%s link id:%d failed to start BSS\n",
-                        __func__, __LINE__, interface_iter_name, interface_iter_link_id);
-                    return -1;
-                }
-                interface_iter->bss_started = true;
-            }
-        }
-    }
-
-    return 0;
-}
-
-#endif /* CONFIG_GENERIC_MLO */
-
-static int reload_vap_configuration(wifi_interface_info_t *interface)
-{
-#ifdef CONFIG_GENERIC_MLO
-    if (wifi_hal_is_mld_enabled(interface)) {
-        return reload_mlo_vap_configuration(interface);
-    }
-#endif /* CONFIG_GENERIC_MLO */
-
-    return reload_single_vap_configuration(interface);
-}
-
 #if defined(SCXER10_PORT) && defined(CONFIG_IEEE80211BE) && defined(KERNEL_NO_320MHZ_SUPPORT)
 INT _wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map);
 
@@ -1806,6 +1604,13 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                 return RETURN_ERR;
             }
 
+#ifdef CONFIG_GENERIC_MLO
+            // TODO: We need better way in case of updating from
+            // rdk-wifi-hal to OneWifi
+            // Update the link id back in datamodel
+            vap->u.bss_info.mld_info.common_info.mld_link_id = interface->u.ap.hapd.mld_link_id;
+#endif
+
             wifi_hal_info_print("%s:%d: interface:%s vap_initialized:%d\n", __func__, __LINE__,
                 interface_name, interface->vap_initialized);
             if (interface->vap_initialized == true) {
@@ -1861,6 +1666,17 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             if (mbssid_tx_interface != NULL && mbssid_tx_interface != interface) {
                 wifi_hal_configure_mbssid(radio);
             }
+#ifdef CONFIG_GENERIC_MLO
+            // For any change done to MLD group, reload.
+            // This has to be done here as at pre_create we:
+            // - do not have yet link in the driver (update_hostap_mlo)
+            // - below assumes that BSS is currently started and
+            // operational, which is not the case after preinitializing
+            // some fields in pre_create
+            if (wifi_hal_is_mld_enabled(interface) && vap->u.bss_info.enabled) {
+                reload_vap_configuration(interface);
+            }
+#endif
 
         } else if (vap->vap_mode == wifi_vap_mode_sta) {
 #if defined(CONFIG_WIFI_EMULATOR)

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -2250,6 +2250,9 @@ int update_hostap_config_params(wifi_radio_info_t *radio)
 int update_hostap_interface_params(wifi_interface_info_t *interface)
 {
     int ret = RETURN_ERR;
+    if (unlikely(interface == NULL)) {
+        return ret;
+    }
 
 #ifdef CONFIG_GENERIC_MLO
     if (wifi_hal_is_mld_enabled(interface)) {

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -103,7 +103,6 @@ static unsigned char llc_info[] = {0xaa, 0xaa, 0x03, 0x00,0x00,0x00,0x88,0x8e};
 #endif // defined(WIFI_EMULATOR_CHANGE) ||  defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 
 static int scan_info_handler(struct nl_msg *msg, void *arg);
-static void nl80211_unregister_mgmt_frames(wifi_interface_info_t *interface);
 int wifi_drv_link_add(void *priv, u8 link_id, const u8 *addr, void *bss_ctx);
 
 #ifndef WIFI_EMULATOR_CHANGE
@@ -1878,7 +1877,7 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
     unsigned char cat;
     unsigned short fc, stype;
     mac_address_t   sta, bmac = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-    mac_addr_str_t  sta_mac_str, interface_mac_str, frame_da_str;
+    mac_addr_str_t sta_mac_str, interface_mac_str, frame_da_str;
     wifi_vap_info_t *vap;
     bool drop = false;
     wifi_device_callbacks_t *callbacks;
@@ -1898,6 +1897,7 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
 #endif
 #ifdef CONFIG_GENERIC_MLO
     uint8_t *mld_mac = NULL;
+    mac_addr_str_t mld_mac_str = { 0 };
 #endif // CONFIG_GENERIC_MLO
 
 #if defined(EASY_MESH_NODE) && defined(_PLATFORM_BANANAPI_R4_)
@@ -1945,9 +1945,19 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
         to_mac_str(interface->mac, interface_mac_str);
         to_mac_str(mgmt->sa, sta_mac_str);
         to_mac_str(mgmt->da, frame_da_str);
+#ifdef CONFIG_GENERIC_MLO
+        if (wifi_hal_is_mld_enabled(interface)) {
+            to_mac_str(mld_mac, mld_mac_str);
+        }
+        wifi_hal_error_print("%s:%d: interface:%s dropping mgmt frame, interface mac:%s sta mac:%s"
+                             " frame da:%s, mld_mac_str:%s\n",
+            __func__, __LINE__, interface->name, interface_mac_str, sta_mac_str, frame_da_str,
+            mld_mac_str);
+#else
         wifi_hal_error_print("%s:%d: interface:%s dropping mgmt frame, interface mac:%s sta mac:%s"
                              " frame da:%s\n",
             __func__, __LINE__, interface->name, interface_mac_str, sta_mac_str, frame_da_str);
+#endif
         if ((callbacks != NULL) && (callbacks->analytics_callback != NULL)) {
             callbacks->analytics_callback("Dropping mgmt frame from interface:%s sta mac:%s frame da:%s",
                 interface_mac_str, sta_mac_str, frame_da_str);
@@ -6154,10 +6164,7 @@ int interface_info_handler(struct nl_msg *msg, void *arg)
     wifi_vap_info_t *vap;
     struct nlattr *tb[NL80211_ATTR_MAX + 1];
     struct genlmsghdr *gnlh;
-#ifdef CONFIG_GENERIC_MLO
-    char *mld_name;
-    static unsigned int link_id = 0;
-#endif // CONFIG_GENERIC_MLO
+
 #ifdef FEATURE_SINGLE_PHY
     int rdk_radio_index_of_intf = -1;
 
@@ -6234,32 +6241,6 @@ int interface_info_handler(struct nl_msg *msg, void *arg)
                 interface_free(interface);
                 return NL_SKIP;
             }
-
-#ifdef CONFIG_GENERIC_MLO
-            mld_name = wifi_hal_get_mld_name_by_interface_name(interface->name);
-            if (mld_name != NULL) {
-                mac_address_t mld_mac = {};
-
-                strncpy(interface->mld_name, mld_name, sizeof(interface->mld_name) - 1);
-                if ((interface->index = if_nametoindex(mld_name)) == 0) {
-                    wifi_hal_error_print("%s:%d: Failed to get ifindex for MLD interface %s: %s\n",
-                        __func__, __LINE__, mld_name, strerror(errno));
-                    return NL_SKIP;
-                }
-                if (wifi_hal_get_mac_address(mld_name, mld_mac) < 0) {
-                    wifi_hal_error_print("%s:%d: Failed to get MAC address for interface %s\n",
-                        __func__, __LINE__, mld_name);
-                    return NL_SKIP;
-                }
-
-                // TODO: get MLD configuration from DB
-                wifi_hal_set_mld_enabled(interface, true);
-                wifi_hal_set_mld_mac_address(interface, mld_mac);
-                wifi_hal_set_mld_link_id(interface, interface->rdk_radio_index);
-                wifi_hal_set_mld_link_id(interface, link_id);
-                link_id++;
-            }
-#endif // CONFIG_GENERIC_MLO
 
             wifi_hal_dbg_print("%s:%d: phy index: %d radio index: %d interface index: %d name: %s "
                                "type: %d mac:" MACSTR " vap index: %d vap name: %s mld name: %s\n",
@@ -8348,9 +8329,7 @@ int nl80211_register_mgmt_frames(wifi_interface_info_t *interface)
     struct nl_msg *msg;
     unsigned int i;
     int ret;
-#if defined(EASY_MESH_NODE) && defined(_PLATFORM_BANANAPI_R4_)
-    int err;
-#endif
+    const unsigned int wait_usec = 500000;
 
     /**
      * While stations are able to register for Action, Probe Request, and Authentication frames,
@@ -8409,7 +8388,7 @@ int nl80211_register_mgmt_frames(wifi_interface_info_t *interface)
 
     if (interface->mgmt_frames_registered == 1) {
         wifi_hal_dbg_print("%s:%d: Mgmt frames already registered for %s\n", __func__, __LINE__,
-            wifi_hal_get_interface_name(interface));
+            interface->name);
         return 0;
     }
 
@@ -8431,11 +8410,11 @@ int nl80211_register_mgmt_frames(wifi_interface_info_t *interface)
     }
 
 #if defined(EASY_MESH_NODE) && defined(_PLATFORM_BANANAPI_R4_)
-    err = nl_socket_set_buffer_size((struct nl_sock *)interface->nl_event, NL_SOCKET_RX_BUFFER_SIZE,
+    ret = nl_socket_set_buffer_size((struct nl_sock *)interface->nl_event, NL_SOCKET_RX_BUFFER_SIZE,
         0);
-    if (err < 0) {
+    if (ret < 0) {
         wifi_hal_info_print("%s:%d:nl80211: Could not set nl_socket RX buffer size: %s", __func__,
-            __LINE__, nl_geterror(err));
+            __LINE__, nl_geterror(ret));
         /* continue anyway with the default (smaller) buffer */
     }
 #endif
@@ -8445,56 +8424,76 @@ int nl80211_register_mgmt_frames(wifi_interface_info_t *interface)
         wifi_hal_get_interface_name(interface), interface->index, interface->nl_event_fd);
 
     for (i = 0; i < num_stypes; i++) {
-        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, NULL, 0, NL80211_CMD_REGISTER_FRAME);
-        if (msg == NULL) {
-            return -1;
-        }
+        // For Banana Pi in case of reconfiguration it was noticed that
+        // this operation can fail as it takes time after deregistration
+        // of the handlers to clean them up. Do best effort to succeed.
+        for (int retry = 3; retry > 0; retry--) {
+            msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, NULL, 0, NL80211_CMD_REGISTER_FRAME);
+            if (msg == NULL) {
+                goto error;
+            }
 
-        if (nla_put_u32(msg, NL80211_ATTR_IFINDEX, interface->index) < 0) {
-            nlmsg_free(msg);
-            return -1;
-        }
+            if (nla_put_u32(msg, NL80211_ATTR_IFINDEX, interface->index) < 0) {
+                goto error;
+            }
 
-        frame_type = (WLAN_FC_TYPE_MGMT << 2) | (stypes[i] << 4);
+            frame_type = (WLAN_FC_TYPE_MGMT << 2) | (stypes[i] << 4);
 
-        if (nla_put_u16(msg, NL80211_ATTR_FRAME_TYPE, frame_type) < 0) {
-            nlmsg_free(msg);
-            return -1;
-        }
+            if (nla_put_u16(msg, NL80211_ATTR_FRAME_TYPE, frame_type) < 0) {
+                goto error;
+            }
 
-        if (nla_put(msg, NL80211_ATTR_FRAME_MATCH, 0, NULL) < 0) {
-            nlmsg_free(msg);
-            return -1;
-        }
+            if (nla_put(msg, NL80211_ATTR_FRAME_MATCH, 0, NULL) < 0) {
+                goto error;
+            }
 
-        if ((ret = execute_send_and_recv(interface->nl_cb, interface->nl_event, msg, mgmt_frame_register_handler, interface, NULL, NULL))) {
-            if ((-ret) == EALREADY) {
-                wifi_hal_dbg_print("%s:%d: Mgmt frames already registered\n", __func__, __LINE__);
+            ret = execute_send_and_recv(interface->nl_cb, interface->nl_event, msg,
+                mgmt_frame_register_handler, interface, NULL, NULL);
+
+            if (ret == 0) {
+                wifi_hal_info_print(
+                    "%s:%d: Mgmt frames have been registered for %s frame type %d\n", __func__,
+                    __LINE__, wifi_hal_get_interface_name(interface), frame_type);
+                break;
+            } else if ((-ret) == EALREADY) {
+                wifi_hal_info_print(
+                    "%s:%d: Mgmt frames already registered for %s and frame_type %d \n", __func__,
+                    __LINE__, wifi_hal_get_interface_name(interface), frame_type);
+                usleep(wait_usec);
             } else {
                 wifi_hal_error_print("%s:%d: Error registering for management frames on interface "
                                      "%s error: %d (%s)\n",
                     __func__, __LINE__, wifi_hal_get_interface_name(interface), ret,
                     strerror(-ret));
-                return -1;
+                goto error;
             }
         }
     }
 
     interface->mgmt_frames_registered = 1;
-
     return 0;
+
+error:
+    if (interface->nl_event != NULL) {
+        nl_destroy_handles(&interface->nl_event);
+        interface->nl_event = NULL;
+        interface->nl_event_fd = -1;
+    }
+
+    if (interface->nl_cb != NULL) {
+        nl_cb_put(interface->nl_cb);
+        interface->nl_cb = NULL;
+    }
+
+    if (msg != NULL) {
+        nlmsg_free(msg);
+    }
+
+    return -1;
 }
 
-static void nl80211_unregister_mgmt_frames(wifi_interface_info_t *interface)
+void nl80211_unregister_mgmt_frames(wifi_interface_info_t *interface)
 {
-#if defined(CONFIG_GENERIC_MLO)
-    interface = wifi_hal_get_first_mld_interface(interface);
-    if (interface == NULL) {
-        wifi_hal_error_print("%s:%d: Failed to get first MLD interface\n", __func__, __LINE__);
-        return;
-    }
-#endif // CONFIG_GENERIC_MLO
-
     if (interface->mgmt_frames_registered == 0) {
         wifi_hal_dbg_print("%s:%d: interface:%s mgmt frames not registered\n", __func__, __LINE__,
             wifi_hal_get_interface_name(interface));
@@ -8669,9 +8668,8 @@ int nl80211_create_interface(wifi_radio_info_t *radio, wifi_vap_info_t *vap, wif
     }
 
     if ((intf = get_interface_by_vap_index(vap->vap_index)) != NULL) {
-        wifi_hal_dbg_print("%s:%d:interface for vap index:%d already exists\n", __func__, __LINE__, 
+        wifi_hal_dbg_print("%s:%d:interface for vap index:%d already exists\n", __func__, __LINE__,
             vap->vap_index);
-
         memcpy(&intf->vap_info, vap, sizeof(wifi_vap_info_t));
         nl80211_interface_enable(intf->name, true);
     }
@@ -16227,6 +16225,14 @@ int nl80211_register_bss_frames(wifi_interface_info_t *interface)
 {
     int err = 1;
 
+#if defined(CONFIG_GENERIC_MLO)
+    interface = wifi_hal_get_first_mld_interface(interface);
+    if (interface == NULL) {
+        wifi_hal_error_print("%s:%d: Failed to get first MLD interface\n", __func__, __LINE__);
+        return -1;
+    }
+#endif // CONFIG_GENERIC_MLO
+
     if (interface->bss_frames_registered == 1) {
         wifi_hal_info_print("%s:%d: bss frames handler already registered for %s\n", __func__,
                 __LINE__, wifi_hal_get_interface_name(interface));
@@ -16291,10 +16297,31 @@ error:
 }
 #endif
 
+void nl80211_unregister_spurious_frames(wifi_interface_info_t *interface)
+{
+    if (interface->spurious_frames_registered == 0) {
+        wifi_hal_dbg_print("%s:%d: interface:%s spurious frames not registered\n", __func__,
+            __LINE__, wifi_hal_get_interface_name(interface));
+        return;
+    }
+
+    wifi_hal_info_print("%s:%d: interface:%s ifindex:%d nl sock:%d\n", __func__, __LINE__,
+        wifi_hal_get_interface_name(interface), interface->index, interface->spurious_nl_event_fd);
+
+    nl_cb_put(interface->spurious_nl_cb);
+    interface->spurious_nl_cb = NULL;
+    nl_destroy_handles(&interface->spurious_nl_event);
+    interface->spurious_nl_event = NULL;
+    interface->spurious_nl_event_fd = -1;
+
+    interface->spurious_frames_registered = 0;
+}
+
 int nl80211_register_spurious_frames(wifi_interface_info_t *interface)
 {
     struct nl_msg *msg = NULL;
     int ret = 0;
+    const unsigned int wait_usec = 300000;
 
 #if defined(CONFIG_GENERIC_MLO)
     interface = wifi_hal_get_first_mld_interface(interface);
@@ -16330,26 +16357,40 @@ int nl80211_register_spurious_frames(wifi_interface_info_t *interface)
         goto error;
     }
 
-    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, NULL, 0, NL80211_CMD_UNEXPECTED_FRAME);
-    if (msg == NULL) {
-        wifi_hal_error_print("%s:%d: failed to create message for %s interface\n", __func__,
-            __LINE__, wifi_hal_get_interface_name(interface));
-        goto error;
-    }
+    for (int retry = 3; retry > 0; retry--) {
+        // For Banana Pi in case of reconfiguration it was noticed that
+        // this operation can fail as it takes time after deregistration
+        // of the handlers to clean them up. Do best effort to succeed.
+        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, NULL, 0, NL80211_CMD_UNEXPECTED_FRAME);
+        if (msg == NULL) {
+            wifi_hal_error_print("%s:%d: failed to create message for %s interface\n", __func__,
+                __LINE__, wifi_hal_get_interface_name(interface));
+            goto error;
+        }
 
-    if (nla_put_u32(msg, NL80211_ATTR_IFINDEX, interface->index) < 0) {
-        wifi_hal_error_print("%s:%d: failed set interface index in message for %s interface\n",
-            __func__, __LINE__, wifi_hal_get_interface_name(interface));
-        goto error;
-    }
+        if (nla_put_u32(msg, NL80211_ATTR_IFINDEX, interface->index) < 0) {
+            wifi_hal_error_print("%s:%d: failed set interface index in message for %s interface\n",
+                __func__, __LINE__, wifi_hal_get_interface_name(interface));
+            nlmsg_free(msg);
+            goto error;
+        }
 
-    ret = execute_send_and_recv(interface->spurious_nl_cb, interface->spurious_nl_event, msg,
-        spurious_frame_register_handler, interface, NULL, NULL);
-    if (ret) {
-        wifi_hal_error_print("%s:%d: failed to register for spurious frames on interface %s, "
-                             "error: %d (%s)\n",
-            __func__, __LINE__, wifi_hal_get_interface_name(interface), ret, strerror(-ret));
-        goto error;
+        ret = execute_send_and_recv(interface->spurious_nl_cb, interface->spurious_nl_event, msg,
+            spurious_frame_register_handler, interface, NULL, NULL);
+        if (ret == 0) {
+            wifi_hal_info_print("%s:%d: Spurious frames have been registered for %s\n", __func__,
+                __LINE__, wifi_hal_get_interface_name(interface));
+            break;
+        } else if ((-ret) == EALREADY) {
+            wifi_hal_info_print("%s:%d: Spurious frame handler already registered for %s\n",
+                __func__, __LINE__, wifi_hal_get_interface_name(interface));
+            usleep(wait_usec);
+        } else {
+            wifi_hal_error_print("%s:%d: failed to register for spurious frames on interface %s, "
+                                 "error: %d (%s)\n",
+                __func__, __LINE__, wifi_hal_get_interface_name(interface), ret, strerror(-ret));
+            goto error;
+        }
     }
 
     interface->spurious_nl_event_fd = nl_socket_get_fd((struct nl_sock *)
@@ -16404,7 +16445,32 @@ static bool is_interface_in_bridge(const char *iface, const char *bridge_name)
 }
 #endif
 
-static int register_data_frame_socket(wifi_interface_info_t *interface)
+void unregister_data_frame_socket(wifi_interface_info_t *interface)
+{
+    if (interface->data_frames_registered == 0) {
+        wifi_hal_dbg_print("%s:%d: interface:%s data frames not registered\n", __func__, __LINE__,
+            wifi_hal_get_interface_name(interface));
+        return;
+    }
+
+    wifi_hal_info_print("%s:%d: interface:%s ifindex:%d nl sock sta:%d, nl sock br_sock:%d\n",
+        __func__, __LINE__, interface->name, interface->index, interface->u.sta.sta_sock_fd,
+        interface->u.ap.br_sock_fd);
+
+    if (interface->vap_info.vap_mode == wifi_vap_mode_sta && interface->u.sta.sta_sock_fd >= 0) {
+        close(interface->u.sta.sta_sock_fd);
+        interface->u.sta.sta_sock_fd = -1;
+    }
+
+    if (interface->vap_info.vap_mode == wifi_vap_mode_ap && interface->u.ap.br_sock_fd >= 0) {
+        close(interface->u.ap.br_sock_fd);
+        interface->u.ap.br_sock_fd = -1;
+    }
+
+    interface->data_frames_registered = 0;
+}
+
+int register_data_frame_socket(wifi_interface_info_t *interface)
 {
     wifi_vap_info_t *vap;
     struct sockaddr_ll sockaddr;

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -5745,9 +5745,16 @@ char *wifi_hal_get_interface_name(wifi_interface_info_t *interface)
         return NULL;
     }
 
+#ifdef CONFIG_GENERIC_MLO
+    if ((interface->vap_info.u.bss_info.enabled == false) ||
+        (wifi_hal_is_mld_enabled(interface) == false) || (interface->mld_name[0] == '\0')) {
+        return interface->name;
+    }
+#else
     if (interface->mld_name[0] == '\0') {
         return interface->name;
     }
+#endif
 
     if (interface->vap_info.vap_mode == wifi_vap_mode_ap &&
         interface->vap_info.u.bss_info.mld_info.common_info.mld_enable) {
@@ -5808,7 +5815,26 @@ int wifi_hal_get_mld_link_id(wifi_interface_info_t *interface)
     return NL80211_DRV_LINK_ID_NA;
 }
 
-int wifi_hal_set_mld_link_id(wifi_interface_info_t *interface, int link_id)
+int wifi_hal_get_mld_id(wifi_interface_info_t *interface)
+{
+    wifi_hal_dbg_print("%s:%d Entering\n", __func__, __LINE__);
+    if (interface == NULL) {
+        wifi_hal_error_print("%s:%d: NULL interface pointer\n", __func__, __LINE__);
+        return NL80211_DRV_LINK_ID_NA;
+    }
+
+    if (!wifi_hal_is_mld_enabled(interface)) {
+        return NL80211_DRV_LINK_ID_NA;
+    }
+
+    if (interface->vap_info.vap_mode != wifi_vap_mode_monitor) {
+        return interface->vap_info.u.bss_info.mld_info.common_info.mld_id;
+    }
+
+    return NL80211_DRV_LINK_ID_NA;
+}
+
+int wifi_hal_set_mld_id(wifi_interface_info_t *interface, int mld_id)
 {
     if (interface == NULL) {
         wifi_hal_error_print("%s:%d: NULL interface pointer\n", __func__, __LINE__);
@@ -5816,13 +5842,14 @@ int wifi_hal_set_mld_link_id(wifi_interface_info_t *interface, int link_id)
     }
 
     if (interface->vap_info.vap_mode == wifi_vap_mode_ap) {
-        interface->vap_info.u.bss_info.mld_info.common_info.mld_link_id = link_id;
+        interface->vap_info.u.bss_info.mld_info.common_info.mld_id = mld_id;
         return 0;
     }
 
     return -1;
 }
 
+#ifdef CONFIG_GENERIC_MLO
 wifi_interface_info_t *wifi_hal_get_first_mld_interface(wifi_interface_info_t *interface)
 {
     wifi_radio_info_t *radio;
@@ -5845,14 +5872,26 @@ wifi_interface_info_t *wifi_hal_get_first_mld_interface(wifi_interface_info_t *i
                 continue;
             }
 
-            if (interface_iter->index == interface->index) {
-                return interface_iter;
+            if (interface_iter->vap_info.u.bss_info.mld_info.common_info.mld_id !=
+                interface->vap_info.u.bss_info.mld_info.common_info.mld_id) {
+                continue;
+            }
+
+            if (interface_iter->u.ap.hapd.mld != NULL) {
+                if (hostapd_mld_is_first_bss(&interface_iter->u.ap.hapd)) {
+                    return interface_iter;
+                }
             }
         }
     }
 
+    // TODO: because currently we configure MLD in VAP pre_create but add
+    // to driver in update_hostap(), we might encounter a situation where mld is
+    // already enabled but not fully configured. Only when these get
+    // merged into one place, this can return NULL.
     return interface;
 }
+#endif // CONFIG_GENERIC_MLO
 
 uint8_t *wifi_hal_get_mld_mac_address(wifi_interface_info_t *interface)
 {
@@ -5915,7 +5954,8 @@ wifi_interface_info_t *wifi_hal_get_mld_interface_by_link_id(wifi_interface_info
                 continue;
             }
 
-            if (interface_iter->index != interface->index) {
+            if (interface_iter->vap_info.u.bss_info.mld_info.common_info.mld_id !=
+                interface->vap_info.u.bss_info.mld_info.common_info.mld_id) {
                 continue;
             }
 
@@ -5955,7 +5995,8 @@ wifi_interface_info_t *wifi_hal_get_mld_interface_by_freq(wifi_interface_info_t 
                 continue;
             }
 
-            if (interface_iter->index != interface->index) {
+            if (interface_iter->vap_info.u.bss_info.mld_info.common_info.mld_id !=
+                interface->vap_info.u.bss_info.mld_info.common_info.mld_id) {
                 continue;
             }
 
@@ -6077,4 +6118,197 @@ uint16_t freq_to_primary(uint16_t freq, wifi_channelBandwidth_t chwid)
     }
 
     return freq;
+}
+
+static int reload_interface(wifi_interface_info_t *interface)
+{
+    char *interface_name = wifi_hal_get_interface_name(interface);
+
+    wifi_hal_dbg_print("%s:%d: interface:%s reload hostapd config\n", __func__, __LINE__,
+        interface_name);
+
+#ifndef CONFIG_GENERIC_MLO
+    interface->beacon_set = 0;
+#endif /* CONFIG_GENERIC_MLO */
+
+    pthread_mutex_lock(&g_wifi_hal.hapd_lock);
+    if (hostapd_reload_config(interface->u.ap.hapd.iface) < 0) {
+        wifi_hal_error_print("%s:%d: interface:%s failed to reload VAP configuration\n", __func__,
+            __LINE__, interface_name);
+        pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
+        return -1;
+    }
+#ifdef CONFIG_SAE
+    if (interface->u.ap.conf.sae_groups != NULL) {
+        interface->u.ap.conf.sae_groups = NULL;
+    }
+#endif
+    pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
+
+    /* Prevent hostap calling set_ap when client is removed due to VAP disable before
+     * start_bss */
+    interface->in_reconf = true;
+
+    wifi_hal_info_print("%s:%d: interface:%s disable AP\n", __func__, __LINE__, interface_name);
+    if (nl80211_enable_ap(interface, false) != 0) {
+        wifi_hal_error_print("%s:%d: interface:%s disable AP failed - try to deinitialize anyway\n",
+            __func__, __LINE__, interface_name);
+    }
+    interface->bss_started = false;
+
+    wifi_hal_dbg_print("%s:%d: interface:%s free hostapd data\n", __func__, __LINE__,
+        interface_name);
+    pthread_mutex_lock(&g_wifi_hal.hapd_lock);
+    deinit_bss(&interface->u.ap.hapd);
+    if (interface->u.ap.hapd.conf->ssid.wpa_psk != NULL &&
+        interface->u.ap.hapd.conf->ssid.wpa_psk->next == NULL) {
+        hostapd_config_clear_wpa_psk(&interface->u.ap.hapd.conf->ssid.wpa_psk);
+    }
+    pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
+
+    return 0;
+}
+
+static int restart_interface(wifi_interface_info_t *interface)
+{
+    char *interface_name = wifi_hal_get_interface_name(interface);
+    wifi_radio_info_t *radio = get_radio_by_rdk_index(interface->rdk_radio_index);
+    if (unlikely(radio == NULL)) {
+        wifi_hal_error_print("%s:%d: interface:%s failed to get radio for index:%d\n", __func__,
+            __LINE__, interface_name, interface->rdk_radio_index);
+        return -1;
+    }
+
+    wifi_hal_dbg_print("%s:%d: interface:%s update hostapd params\n", __func__, __LINE__,
+        interface_name);
+
+    if (update_hostap_interface_params(interface) < 0) {
+        wifi_hal_error_print("%s:%d: interface:%s failed to update hostapd params\n", __func__,
+            __LINE__, interface_name);
+        return -1;
+    }
+
+    interface->in_reconf = false;
+
+    if (interface->vap_info.u.bss_info.enabled && radio->configured && radio->oper_param.enable) {
+        wifi_hal_info_print("%s:%d: interface:%s enable ap\n", __func__, __LINE__, interface_name);
+        interface->beacon_set = 0;
+        if (start_bss(interface) < 0) {
+            wifi_hal_error_print("%s:%d: interface:%s failed to start BSS\n", __func__, __LINE__,
+                interface_name);
+            return -1;
+        }
+        interface->bss_started = true;
+    }
+
+#if defined(CONFIG_GENERIC_MLO) && defined(_PLATFORM_BANANAPI_R4_)
+    if (wifi_hal_is_mld_enabled(interface)) {
+        // Deinit will cause removal of beacon - set it again before
+        // start_bss to enable broadcasting for BPi
+        if (ieee802_11_set_beacon(&interface->u.ap.hapd) != 0) {
+            wifi_hal_error_print("%s:%d: Failed to set beacon for interface: %s link id: %d\n",
+                __func__, __LINE__, interface_name, interface->u.ap.hapd.mld_link_id);
+            return -1;
+        }
+    }
+#endif
+
+    return 0;
+}
+
+#ifdef CONFIG_GENERIC_MLO
+static int reload_mlo_vap_configuration(wifi_interface_info_t *interface)
+{
+    wifi_hal_dbg_print("%s:%d Entering\n", __func__, __LINE__);
+    // MLO links share some resources (i.e. RADIUS settings) of the first
+    // link - first take care of it, then attempt to set the rest
+    wifi_interface_info_t *first_interface = wifi_hal_get_first_mld_interface(interface);
+    if (first_interface == NULL) {
+        wifi_hal_error_print("%s:%d: Trying to reload non-existing MLD\n", __func__, __LINE__);
+        return -1;
+    }
+
+    for (int i = g_wifi_hal.num_radios - 1; i >= 0; i--) {
+        wifi_interface_info_t *interface_iter = NULL;
+        wifi_radio_info_t *radio = get_radio_by_rdk_index(i);
+        if (unlikely(radio == NULL)) {
+            wifi_hal_error_print("%s:%d: interface:%s failed to get radio for index:%d\n", __func__,
+                __LINE__, interface->mld_name, interface->rdk_radio_index);
+            return -1;
+        }
+
+        hash_map_foreach(radio->interface_map, interface_iter) {
+
+            if (!wifi_hal_is_mld_enabled(interface_iter)) {
+                continue;
+            }
+
+            if (interface_iter->vap_info.u.bss_info.mld_info.common_info.mld_id !=
+                interface->vap_info.u.bss_info.mld_info.common_info.mld_id) {
+                continue;
+            }
+
+            if (first_interface == interface_iter) {
+                continue;
+            }
+
+            if (reload_interface(interface_iter)) {
+                return -1;
+            }
+        }
+    }
+
+    if (reload_interface(first_interface) < 0) {
+        return -1;
+    }
+
+    if (restart_interface(first_interface) < 0) {
+        return -1;
+    }
+
+    for (unsigned int i = 0; i < g_wifi_hal.num_radios; i++) {
+        wifi_interface_info_t *interface_iter = NULL;
+        wifi_radio_info_t *radio = get_radio_by_rdk_index(i);
+
+        hash_map_foreach(radio->interface_map, interface_iter) {
+            if (!wifi_hal_is_mld_enabled(interface_iter)) {
+                continue;
+            }
+
+            if (interface_iter->vap_info.u.bss_info.mld_info.common_info.mld_id !=
+                interface->vap_info.u.bss_info.mld_info.common_info.mld_id) {
+                continue;
+            }
+
+            if (first_interface == interface_iter) {
+                continue;
+            }
+
+            if (restart_interface(interface_iter) < 0) {
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+#endif /* CONFIG_GENERIC_MLO */
+
+int reload_vap_configuration(wifi_interface_info_t *interface)
+{
+#ifdef CONFIG_GENERIC_MLO
+    if (wifi_hal_is_mld_enabled(interface)) {
+        return reload_mlo_vap_configuration(interface);
+    }
+#endif /* CONFIG_GENERIC_MLO */
+
+    if (reload_interface(interface)) {
+        return -1;
+    }
+
+    if (restart_interface(interface)) {
+        return -1;
+    }
+
+    return 0;
 }

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -261,6 +261,21 @@ typedef struct {
 #define CHANWIDTH_320MHZ CONF_OPER_CHWIDTH_320MHZ
 #endif /* HOSTAPD_VERSION >= 211 */
 
+#ifdef __GNUC__
+
+#ifndef likely
+#define likely(x) __builtin_expect(!!(x), 1)
+#endif
+
+#ifndef unlikely
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+
+#else
+#define likely(x) (x)
+#define unlikely(x) (x)
+#endif
+
 extern const struct wpa_driver_ops g_wpa_driver_nl80211_ops;
 #ifdef CONFIG_WIFI_EMULATOR
 extern const struct wpa_driver_ops g_wpa_supplicant_driver_nl80211_ops;
@@ -984,7 +999,13 @@ int     wifi_hal_emu_set_radio_diag_stats(unsigned int radio_index, bool emu_sta
 int     wifi_hal_emu_set_neighbor_stats(unsigned int radio_index, bool emu_state, wifi_neighbor_ap2_t *neighbor_stats, unsigned int count);
 #endif //CONFIG_WIFI_EMULATOR
 #endif
+int nl80211_register_spurious_frames(wifi_interface_info_t *interface);
 int     nl80211_register_mgmt_frames(wifi_interface_info_t *interface);
+int register_data_frame_socket(wifi_interface_info_t *interface);
+void nl80211_unregister_spurious_frames(wifi_interface_info_t *interface);
+void nl80211_unregister_mgmt_frames(wifi_interface_info_t *interface);
+void unregister_data_frame_socket(wifi_interface_info_t *interface);
+
 int     nl80211_start_scan(wifi_interface_info_t *interface, uint flags,
         unsigned int num_freq, unsigned int  *freq_list, unsigned int dwell_time,
         unsigned int num_ssid,  ssid_t *ssid_list);
@@ -1453,7 +1474,8 @@ unsigned int wifi_hal_get_interface_ifindex(wifi_interface_info_t *interface);
 bool wifi_hal_is_mld_enabled(wifi_interface_info_t *interface);
 int wifi_hal_set_mld_enabled(wifi_interface_info_t *interface, bool enabled);
 int wifi_hal_get_mld_link_id(wifi_interface_info_t *interface);
-int wifi_hal_set_mld_link_id(wifi_interface_info_t *interface, int link_id);
+int wifi_hal_get_mld_id(wifi_interface_info_t *interface);
+int wifi_hal_set_mld_id(wifi_interface_info_t *interface, int mld_id);
 wifi_interface_info_t *wifi_hal_get_first_mld_interface(wifi_interface_info_t *interface);
 uint8_t *wifi_hal_get_mld_mac_address(wifi_interface_info_t *interface);
 int wifi_hal_set_mld_mac_address(wifi_interface_info_t *interface, mac_address_t mac);
@@ -1467,4 +1489,5 @@ int wifi_hal_get_mac_address(const char *ifname, mac_address_t mac);
 unsigned int get_band_info_from_rdk_radio_index(unsigned int rdk_radio_index);
 int get_backhaul_sta_ifname_from_radio_index(wifi_radio_index_t index, char *ifname_out,
     size_t ifname_out_len);
+int reload_vap_configuration(wifi_interface_info_t *interface);
 #endif // WIFI_HAL_PRIV_H


### PR DESCRIPTION
Reason for change:Enable possibility of dynamically enabling/disabling MLO links for multiple MLD devices.
Test Procedure: Verify build, test MLO VAPs, enable/disable links in MLO VAPs, check if appropriate singular VAP gets reset properly, confirm connectivity with a client device.
Risks: None
Priority: P2