### PR TITLE
RDKB-63511: Send additional deauth

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -12403,6 +12403,8 @@ int wifi_drv_sta_deauth(void *priv, const u8 *own_addr, const u8 *addr, u16 reas
     }
 #endif
     if (drv->device_ap_sme) {
+        for (int i = 0; i < 2; i++)
+            wifi_sta_remove(interface, addr, 1, reason);
         return wifi_sta_remove(interface, addr, 1, reason);
     }
 


### PR DESCRIPTION
Reason for change: To be sure sta received our deauth
	send additional 2 messages
Test Procedure:
Risks: Low
Priority: P1