### PR TITLE
RDKBWIFI-386: Channel Scan Report - BSS Load element is wrong

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -3162,11 +3162,26 @@ static int decode_bss_info_to_neighbor_ap_info(wifi_neighbor_ap2_t *ap, const wi
 
     // - ap_DTIMPeriod
     ap->ap_DTIMPeriod = bss->dtim_period;
-    // - ap_ChannelUtilization
+  
+    /*
+     * Channel Utilization (CU) may be derived from multiple sources (e.g., BSS Load IE
+     * or other scan attributes like NL80211_BSS_CU). Populate ap_ChannelUtilization
+     * unconditionally to preserve legacy behavior and avoid dropping valid CU when
+     * the BSS Load IE is absent.
+     *
+     * Only BSS Load specific fields (bss_load_element_present, ap_StaCount) are gated
+     * on the presence of the BSS Load IE.
+     */
     ap->ap_ChannelUtilization = bss->chan_utilization;
 
-    wifi_hal_stats_dbg_print("%s:%d: [SCAN] bssid: %s, ssid: %s, channel: %d, noise: %d\n",
-        __func__, __LINE__, ap->ap_BSSID, ap->ap_SSID, ap->ap_Channel, ap->ap_Noise);
+    // - bss_load_element 
+    if (bss->bss_load_element_present) {
+        ap->bss_load_element_present = bss->bss_load_element_present;
+        ap->ap_StaCount = bss->station_cnt;
+    }
+
+    wifi_hal_stats_dbg_print("%s:%d: [SCAN] bssid: %s, ssid: %s, channel: %d, noise: %d station_cnt %u\n",
+        __func__, __LINE__, ap->ap_BSSID, ap->ap_SSID, ap->ap_Channel, ap->ap_Noise, ap->ap_StaCount);
 
     return ret;
 }

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -11354,7 +11354,9 @@ static void parse_bss_load(const uint8_t type, uint8_t len, const uint8_t *data,
     (void)len;
     (void)ie_buffer;
 
+    bss->bss_load_element_present = 1;
     bss->chan_utilization = ((unsigned)data[2] * 100) / 255;
+    bss->station_cnt = (unsigned)data[0] | ((unsigned)data[1] << 8);
 }
 
 static void parse_extension_tag(const uint8_t type, uint8_t len, const uint8_t *data,


### PR DESCRIPTION
Fetch the Station count from the IE element of Probe response and populated in the corresponding structure. This can be used to load the values as part of Channel Scan Result TLV in Channel Scan Report Message.