### PR TITLE
RDKB-63631 [CAC] [SPRINT]Beacons show "Unknown Rate" after trying to …

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1512,11 +1512,19 @@ int update_hostap_iface(wifi_interface_info_t *interface)
         interface->name, vap->u.bss_info.preassoc.basic_data_transmit_rates, vap->u.bss_info.preassoc.supported_data_transmit_rates);
     if ((strlen (vap->u.bss_info.preassoc.basic_data_transmit_rates) > 0) && strcmp(vap->u.bss_info.preassoc.basic_data_transmit_rates, "disabled")) {
         snprintf(basic_buf, sizeof(basic_buf), "%s", vap->u.bss_info.preassoc.basic_data_transmit_rates);
-        convert_string_to_int(&preassoc_basic_rates,basic_buf);
+     if (convert_string_to_int(&preassoc_basic_rates, basic_buf) < 0) {
+         wifi_hal_info_print("%s:%d: Failed to convert basic rates, using defaults\n",
+             __func__, __LINE__);
+         preassoc_basic_rates = NULL;
+     }
     }
     if ((strlen (vap->u.bss_info.preassoc.supported_data_transmit_rates) > 0) && strcmp(vap->u.bss_info.preassoc.supported_data_transmit_rates, "disabled")) {
       snprintf(supp_buf, sizeof(supp_buf), "%s", vap->u.bss_info.preassoc.supported_data_transmit_rates);
-      convert_string_to_int(&preassoc_supp_rates,supp_buf);
+       if (convert_string_to_int(&preassoc_supp_rates, supp_buf) < 0) {
+           wifi_hal_info_print("%s:%d: Failed to convert supported rates, using defaults\n",
+               __func__, __LINE__);
+           preassoc_supp_rates = NULL;
+       }
     }
     
     switch (radio->oper_param.band) {
@@ -1593,6 +1601,9 @@ int update_hostap_iface(wifi_interface_info_t *interface)
             }
             return RETURN_ERR;
         }
+       /* current_rates must always be valid — if convert failed and
+        * preassoc_supp_rates is NULL, the rate loop falls back to current_rates */
+       iface->current_rates = iface->current_cac_rates;   
     }
     else {
         if (iface->current_cac_rates) {

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1578,6 +1578,7 @@ int update_hostap_iface(wifi_interface_info_t *interface)
     if ((strlen (vap->u.bss_info.preassoc.supported_data_transmit_rates) > 0) && strcmp(vap->u.bss_info.preassoc.supported_data_transmit_rates, "disabled")) {
         if(iface->current_cac_rates) {
             os_free(iface->current_cac_rates);
+            iface->current_cac_rates = NULL;
         }
         iface->current_cac_rates = os_calloc(mode->num_rates, sizeof(struct hostapd_rate_data));
         if (!iface->current_cac_rates) {
@@ -1594,6 +1595,10 @@ int update_hostap_iface(wifi_interface_info_t *interface)
         }
     }
     else {
+         if (iface->current_cac_rates) {
+             os_free(iface->current_cac_rates);
+             iface->current_cac_rates = NULL;
+         }        
         iface->current_rates = radio->rate_data[band];
     }
     wifi_hal_info_print("%s:%d: Interface: %s band: %d mode:%p (%d) has %d rates\n", __func__,

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1595,10 +1595,10 @@ int update_hostap_iface(wifi_interface_info_t *interface)
         }
     }
     else {
-         if (iface->current_cac_rates) {
-             os_free(iface->current_cac_rates);
-             iface->current_cac_rates = NULL;
-         }        
+        if (iface->current_cac_rates) {
+            os_free(iface->current_cac_rates);
+            iface->current_cac_rates = NULL;
+        }
         iface->current_rates = radio->rate_data[band];
     }
     wifi_hal_info_print("%s:%d: Interface: %s band: %d mode:%p (%d) has %d rates\n", __func__,


### PR DESCRIPTION
…disable MBR parameter

Reason for change:  When rates are set to "disabled", the old custom rates buffer (current_cac_rates) was never freed Test Procedure: check in pcap
Risks:
Priority: P1
Signed-off-by: poornakumar_mezhiselvam@comcast.com