### PR TITLE
RDKB-59818 : Enable Beacon protection for WPA3 encryption mode

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -511,6 +511,11 @@ int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     return RETURN_OK;
 }
 
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    return RETURN_OK;
+}
+
 INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
 {
     int res = wifi_hal_send_mgmt_frame(apIndex, MacAddr, frame, len, frequency, wait);

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -2218,6 +2218,32 @@ static int set_ap_bss_color_value(int apIndex, uint32_t bssColor)
     return 0;
 }
 
+static void set_ap_beacon_protection(wifi_radio_info_t *radio, int apIndex)
+{
+    wifi_interface_info_t *interface;
+    struct hostapd_data *hapd;
+
+    if (radio->driver_data.extended_capa == NULL ||
+        !(radio->driver_data.capa.flags & WPA_DRIVER_FLAGS_BEACON_PROTECTION))
+        return;
+
+    interface = get_interface_by_vap_index(apIndex);
+    if (interface == NULL) {
+        wifi_hal_error_print("%s:%d: Failed to get interface for ap index: %d\n", __func__,
+            __LINE__, apIndex);
+        return;
+    }
+    hapd = &interface->u.ap.hapd;
+    wifi_hal_dbg_print("%s:%d: %s: set beacon protection %d\n", __func__, __LINE__, interface->name, hapd->conf->beacon_prot);
+
+    if (hapd->conf->beacon_prot) {
+        radio->driver_data.extended_capa[10] |= 0x10; /* Bit 84 - Beacon Protection Enabled */
+    } else {
+        radio->driver_data.extended_capa[10] &= ~0x10; /* Bit 84 - Beacon Protection Enabled */
+    }
+    v_secure_system("wl -i %s bcnprot enable %d", interface->name, hapd->conf->beacon_prot);
+}
+
 int platform_create_vap(wifi_radio_index_t r_index, wifi_vap_info_map_t *map)
 {
     wifi_hal_dbg_print("%s:%d: Enter radio index:%d\n", __func__, __LINE__, r_index);
@@ -2468,6 +2494,7 @@ int platform_create_vap(wifi_radio_index_t r_index, wifi_vap_info_map_t *map)
             wifi_setApManagementFramePowerControl(map->vap_array[index].vap_index, map->vap_array[index].u.bss_info.mgmtPowerControl);
 
             set_ap_bss_color_value(map->vap_array[index].vap_index, iconf->he_op.he_bss_color_disabled ? 0 : iconf->he_op.he_bss_color);
+            set_ap_beacon_protection(radio, map->vap_array[index].vap_index);
         } else if (map->vap_array[index].vap_mode == wifi_vap_mode_sta) {
 
             prepare_param_name(param_name, interface_name, "_akm");
@@ -4228,6 +4255,8 @@ static void platform_get_radio_caps_2g(wifi_radio_info_t *radio, wifi_interface_
     radio->driver_data.extended_capa_mask = malloc(sizeof(ext_cap));
     memcpy(radio->driver_data.extended_capa_mask, ext_cap, sizeof(ext_cap));
     radio->driver_data.extended_capa_len = sizeof(ext_cap);
+
+    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_BEACON_PROTECTION;
 #endif // XB10_PORT || SCXER10_PORT || TCHCBRV2_PORT || SKYSR213_PORT || SCXF10_PORT
 
 // To reset the bss transition bit under extended capabilities, since its based on 2GHz vap configuration from OneWiFi.
@@ -4328,6 +4357,8 @@ static void platform_get_radio_caps_5g(wifi_radio_info_t *radio, wifi_interface_
     radio->driver_data.extended_capa_mask = malloc(sizeof(ext_cap));
     memcpy(radio->driver_data.extended_capa_mask, ext_cap, sizeof(ext_cap));
     radio->driver_data.extended_capa_len = sizeof(ext_cap);
+
+    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_BEACON_PROTECTION;
 #endif // XB10_PORT || SCXER10_PORT || TCHCBRV2_PORT || SKYSR213_PORT
 
 // To reset the bss transition bit under extended capabilities, since its based on 5GHz vap configuration from OneWiFi.
@@ -4417,7 +4448,7 @@ static void platform_get_radio_caps_6g(wifi_radio_info_t *radio, wifi_interface_
     static const u8 eht_mcs[] = { 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44 };
 #endif /* HOSTAPD_VERSION >= 211 */
     struct hostapd_iface *iface = &interface->u.ap.iface;
-    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_AP_UAPSD;
+    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_AP_UAPSD | WPA_DRIVER_FLAGS_BEACON_PROTECTION;
 
 #if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT)
     free(radio->driver_data.extended_capa);

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -2236,11 +2236,6 @@ static void set_ap_beacon_protection(wifi_radio_info_t *radio, int apIndex)
     hapd = &interface->u.ap.hapd;
     wifi_hal_dbg_print("%s:%d: %s: set beacon protection %d\n", __func__, __LINE__, interface->name, hapd->conf->beacon_prot);
 
-    if (hapd->conf->beacon_prot) {
-        radio->driver_data.extended_capa[10] |= 0x10; /* Bit 84 - Beacon Protection Enabled */
-    } else {
-        radio->driver_data.extended_capa[10] &= ~0x10; /* Bit 84 - Beacon Protection Enabled */
-    }
     v_secure_system("wl -i %s bcnprot enable %d", interface->name, hapd->conf->beacon_prot);
 }
 

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -2218,27 +2218,6 @@ static int set_ap_bss_color_value(int apIndex, uint32_t bssColor)
     return 0;
 }
 
-static void set_ap_beacon_protection(wifi_radio_info_t *radio, int apIndex)
-{
-    wifi_interface_info_t *interface;
-    struct hostapd_data *hapd;
-
-    if (radio->driver_data.extended_capa == NULL ||
-        !(radio->driver_data.capa.flags & WPA_DRIVER_FLAGS_BEACON_PROTECTION))
-        return;
-
-    interface = get_interface_by_vap_index(apIndex);
-    if (interface == NULL) {
-        wifi_hal_error_print("%s:%d: Failed to get interface for ap index: %d\n", __func__,
-            __LINE__, apIndex);
-        return;
-    }
-    hapd = &interface->u.ap.hapd;
-    wifi_hal_dbg_print("%s:%d: %s: set beacon protection %d\n", __func__, __LINE__, interface->name, hapd->conf->beacon_prot);
-
-    v_secure_system("wl -i %s bcnprot enable %d", interface->name, hapd->conf->beacon_prot);
-}
-
 int platform_create_vap(wifi_radio_index_t r_index, wifi_vap_info_map_t *map)
 {
     wifi_hal_dbg_print("%s:%d: Enter radio index:%d\n", __func__, __LINE__, r_index);
@@ -2489,7 +2468,6 @@ int platform_create_vap(wifi_radio_index_t r_index, wifi_vap_info_map_t *map)
             wifi_setApManagementFramePowerControl(map->vap_array[index].vap_index, map->vap_array[index].u.bss_info.mgmtPowerControl);
 
             set_ap_bss_color_value(map->vap_array[index].vap_index, iconf->he_op.he_bss_color_disabled ? 0 : iconf->he_op.he_bss_color);
-            set_ap_beacon_protection(radio, map->vap_array[index].vap_index);
         } else if (map->vap_array[index].vap_mode == wifi_vap_mode_sta) {
 
             prepare_param_name(param_name, interface_name, "_akm");
@@ -4250,8 +4228,6 @@ static void platform_get_radio_caps_2g(wifi_radio_info_t *radio, wifi_interface_
     radio->driver_data.extended_capa_mask = malloc(sizeof(ext_cap));
     memcpy(radio->driver_data.extended_capa_mask, ext_cap, sizeof(ext_cap));
     radio->driver_data.extended_capa_len = sizeof(ext_cap);
-
-    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_BEACON_PROTECTION;
 #endif // XB10_PORT || SCXER10_PORT || TCHCBRV2_PORT || SKYSR213_PORT || SCXF10_PORT
 
 // To reset the bss transition bit under extended capabilities, since its based on 2GHz vap configuration from OneWiFi.
@@ -4352,8 +4328,6 @@ static void platform_get_radio_caps_5g(wifi_radio_info_t *radio, wifi_interface_
     radio->driver_data.extended_capa_mask = malloc(sizeof(ext_cap));
     memcpy(radio->driver_data.extended_capa_mask, ext_cap, sizeof(ext_cap));
     radio->driver_data.extended_capa_len = sizeof(ext_cap);
-
-    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_BEACON_PROTECTION;
 #endif // XB10_PORT || SCXER10_PORT || TCHCBRV2_PORT || SKYSR213_PORT
 
 // To reset the bss transition bit under extended capabilities, since its based on 5GHz vap configuration from OneWiFi.
@@ -4443,7 +4417,7 @@ static void platform_get_radio_caps_6g(wifi_radio_info_t *radio, wifi_interface_
     static const u8 eht_mcs[] = { 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44 };
 #endif /* HOSTAPD_VERSION >= 211 */
     struct hostapd_iface *iface = &interface->u.ap.iface;
-    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_AP_UAPSD | WPA_DRIVER_FLAGS_BEACON_PROTECTION;
+    radio->driver_data.capa.flags |= WPA_DRIVER_FLAGS_AP_UAPSD;
 
 #if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT)
     free(radio->driver_data.extended_capa);
@@ -4570,6 +4544,22 @@ int platform_get_radio_caps(wifi_radio_index_t index)
 
 int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
 {
+    return RETURN_OK;
+}
+
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    wifi_interface_info_t *interface;
+
+    interface = get_interface_by_vap_index(apIndex);
+    if (interface == NULL) {
+        wifi_hal_error_print("%s:%d: Failed to get interface for ap index: %d\n", __func__,
+            __LINE__, apIndex);
+        return RETURN_ERR;
+    }
+    wifi_hal_dbg_print("%s:%d: %s: set beacon protection %d\n", __func__, __LINE__, interface->name, isEnabled);
+
+    v_secure_system("wl -i %s bcnprot enable %d", interface->name, isEnabled);
     return RETURN_OK;
 }
 

--- a/platform/intel/platform.c
+++ b/platform/intel/platform.c
@@ -1656,6 +1656,11 @@ int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     return RETURN_OK;
 }
 
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    return RETURN_OK;
+}
+
 #ifdef CONFIG_IEEE80211BE
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
     struct wpa_driver_ap_params *params)

--- a/platform/qualcomm/platform_ext.c
+++ b/platform/qualcomm/platform_ext.c
@@ -1175,6 +1175,11 @@ int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     return RETURN_OK;
 }
 
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    return RETURN_OK;
+}
+
 static int qca_add_intf_to_bridge(wifi_interface_info_t *interface, bool is_mld)
 {
     char mld_ifname[32];

--- a/platform/qualcomm/platform_xer5.c
+++ b/platform/qualcomm/platform_xer5.c
@@ -1474,6 +1474,11 @@ int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     return RETURN_OK;
 }
 
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    return RETURN_OK;
+}
+
 static int qca_add_intf_to_bridge(wifi_interface_info_t *interface, bool is_mld)
 {
     char mld_ifname[32];

--- a/platform/raspberry-pi/platform_pi.c
+++ b/platform/raspberry-pi/platform_pi.c
@@ -438,6 +438,11 @@ int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     return RETURN_OK;
 }
 
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    return RETURN_OK;
+}
+
 INT wifi_getApDeviceRSSI(INT ap_index, CHAR *MAC, INT *output_RSSI)
 {
     return 0;

--- a/platform/wifi-emulator/platform_emulator.c
+++ b/platform/wifi-emulator/platform_emulator.c
@@ -383,6 +383,11 @@ int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     return RETURN_OK;
 }
 
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    return RETURN_OK;
+}
+
 INT wifi_getApDeviceRSSI(INT ap_index, CHAR *MAC, INT *output_RSSI)
 {
     return 0;

--- a/platform/xle/platform_xle.c
+++ b/platform/xle/platform_xle.c
@@ -1002,6 +1002,10 @@ int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     return RETURN_OK;
 }
 
+int platform_set_beacon_prot(uint apIndex, bool isEnabled)
+{
+    return RETURN_OK;
+}
 
 INT wifi_sendActionFrameExt(INT apIndex, mac_address_t MacAddr, UINT frequency, UINT wait, UCHAR *frame, UINT len)
 {

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1962,14 +1962,10 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                     __LINE__, vap->vap_index, vap->u.bss_info.mgmtPowerControl);
             }
 
-            {FILE *out = fopen("/tmp/log11.txt", "a");fprintf(out, "%s:%d radio %s is BEACON CAPA FLAGS???? %llX\n", __func__, __LINE__,
-                    radio->name, interface->u.ap.iface.drv_flags & WPA_DRIVER_FLAGS_BEACON_PROTECTION); fflush(out);}
             if ((set_vap_beacon_prot_fn = get_platform_set_beacon_prot_fn()) != NULL &&
                     interface->u.ap.iface.drv_flags & WPA_DRIVER_FLAGS_BEACON_PROTECTION) {
                 wifi_hal_info_print("%s:%d: vap index:%d set beacon prot: %d\n", __func__, __LINE__,
                         vap->vap_index, interface->u.ap.conf.beacon_prot);
-                {FILE *out = fopen("/tmp/log11.txt", "a");fprintf(out, "%s:%d: vap index:%d set beacon prot: %d\n", __func__, __LINE__,
-                        vap->vap_index, interface->u.ap.conf.beacon_prot); fflush(out);}
                 set_vap_beacon_prot_fn(vap->vap_index, interface->u.ap.conf.beacon_prot);
             }
         }

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1618,6 +1618,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
     wifi_vap_info_t *vap;
     platform_pre_create_vap_t pre_set_vap_params_fn;
     platform_create_vap_t set_vap_params_fn;
+    platform_set_beacon_prot_t set_vap_beacon_prot_fn;
     unsigned int i;
     char msg[2048];
     int ret = RETURN_OK;
@@ -1952,14 +1953,24 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             }
 #endif // NL80211_ACL
             re_configure_steering_mac_list(interface);
-        }
-        if (vap->vap_mode == wifi_vap_mode_ap) {
+
             wifi_hal_info_print("%s:%d: vap index:%d set power:%d\n",  __func__, __LINE__,
                 vap->vap_index, vap->u.bss_info.mgmtPowerControl);
             if (wifi_setApManagementFramePowerControl(vap->vap_index,
                 vap->u.bss_info.mgmtPowerControl) != RETURN_OK) {
                 wifi_hal_error_print("%s:%d: vap index:%d failed to set power %d\n", __func__,
                     __LINE__, vap->vap_index, vap->u.bss_info.mgmtPowerControl);
+            }
+
+            {FILE *out = fopen("/tmp/log11.txt", "a");fprintf(out, "%s:%d radio %s is BEACON CAPA FLAGS???? %llX\n", __func__, __LINE__,
+                    radio->name, interface->u.ap.iface.drv_flags & WPA_DRIVER_FLAGS_BEACON_PROTECTION); fflush(out);}
+            if ((set_vap_beacon_prot_fn = get_platform_set_beacon_prot_fn()) != NULL &&
+                    interface->u.ap.iface.drv_flags & WPA_DRIVER_FLAGS_BEACON_PROTECTION) {
+                wifi_hal_info_print("%s:%d: vap index:%d set beacon prot: %d\n", __func__, __LINE__,
+                        vap->vap_index, interface->u.ap.conf.beacon_prot);
+                {FILE *out = fopen("/tmp/log11.txt", "a");fprintf(out, "%s:%d: vap index:%d set beacon prot: %d\n", __func__, __LINE__,
+                        vap->vap_index, interface->u.ap.conf.beacon_prot); fflush(out);}
+                set_vap_beacon_prot_fn(vap->vap_index, interface->u.ap.conf.beacon_prot);
             }
         }
 #if defined(CONFIG_WIFI_EMULATOR) || defined(BANANA_PI_PORT)

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -618,6 +618,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
 
 #ifdef CONFIG_IEEE80211W
     conf->ieee80211w = (enum mfp_options)sec->mfp;
+    conf->beacon_prot = 0;
     switch (conf->ieee80211w) {
         case MGMT_FRAME_PROTECTION_REQUIRED:
             conf->wpa_key_mgmt &= ~(WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_IEEE8021X);
@@ -637,6 +638,11 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
                 case wifi_security_mode_wpa_wpa2_enterprise:
                     conf->wpa_key_mgmt |= WPA_KEY_MGMT_IEEE8021X_SHA256;
                     break;
+                case wifi_security_mode_wpa3_compatibility:
+                case wifi_security_mode_wpa3_enterprise:
+                case wifi_security_mode_wpa3_personal:
+                case wifi_security_mode_wpa3_transition:
+                    conf->beacon_prot = 1;
                 default:
                     break;
             }
@@ -667,8 +673,8 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
     }
 #endif
 
-    wifi_hal_dbg_print("%s:%d: security:%d mfp:%d wpa_key_mgmt:%d 11w:%d\n",
-                       __func__, __LINE__, sec->mode, sec->mfp, conf->wpa_key_mgmt, conf->ieee80211w);
+    wifi_hal_dbg_print("%s:%d: security:%d mfp:%d wpa_key_mgmt:%d 11w:%d beacon_prot: %d\n",
+                       __func__, __LINE__, sec->mode, sec->mfp, conf->wpa_key_mgmt, conf->ieee80211w, conf->beacon_prot);
   
     if (conf->wpa_key_mgmt != -1) {
         const int is_ieee802_1x = !!((WPA_KEY_MGMT_IEEE8021X | WPA_KEY_MGMT_IEEE8021X_SHA256) & conf->wpa_key_mgmt);

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1207,6 +1207,13 @@ int update_hostap_bss(wifi_interface_info_t *interface)
         wifi_hal_error_print("%s:%d:update_security_config failed \n", __func__, __LINE__);
         return RETURN_ERR;
     }
+    if (radio->driver_data.extended_capa) {
+        if (conf->beacon_prot) {
+            radio->driver_data.extended_capa[10] |= 0x10; /* Bit 84 - Beacon Protection Enabled */
+        } else {
+            radio->driver_data.extended_capa[10] &= ~0x10; /* Bit 84 - Beacon Protection Enabled */
+        }
+    }
 #if 0
 #ifdef CONFIG_IEEE80211W
     bss->ieee80211w = vap->u.bss_info.mfp;

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1207,13 +1207,6 @@ int update_hostap_bss(wifi_interface_info_t *interface)
         wifi_hal_error_print("%s:%d:update_security_config failed \n", __func__, __LINE__);
         return RETURN_ERR;
     }
-    if (radio->driver_data.extended_capa) {
-        if (conf->beacon_prot) {
-            radio->driver_data.extended_capa[10] |= 0x10; /* Bit 84 - Beacon Protection Enabled */
-        } else {
-            radio->driver_data.extended_capa[10] &= ~0x10; /* Bit 84 - Beacon Protection Enabled */
-        }
-    }
 #if 0
 #ifdef CONFIG_IEEE80211W
     bss->ieee80211w = vap->u.bss_info.mfp;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17195,12 +17195,16 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     size_t seq_len = params->seq_len;
     const u8 *key = params->key;
     size_t key_len = params->key_len;
-    // int vlan_id = params->vlan_id;
     enum key_flag key_flag = params->key_flag;
-#ifdef CONFIG_GENERIC_MLO
+#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
     int link_id = params->link_id;
 #endif // CONFIG_GENERIC_MLO
 #endif // HOSTAPD_VERSION >= 210
+
+    if (check_key_flag(key_flag)) {
+        wifi_hal_dbg_print("%s:%d: invalid key_flag", __func__, __LINE__);
+        return -EINVAL;
+    }
 
     interface = (wifi_interface_info_t *)priv;
     vap = &interface->vap_info;
@@ -17210,60 +17214,58 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     //wifi_hal_dbg_print("%s:%d: key Info: index:%d length:%d alg:%s\n", __func__, __LINE__, key_idx, key_len, wpa_alg_to_string(alg));
     //my_print_hex_dump(key_len, key);
 
-    ret = -ENOBUFS;
+    ret = -ENOMEM;
     key_msg = nlmsg_alloc();
     if (!key_msg)
         return ret;
 
 #if HOSTAPD_VERSION >= 210
-	if ((key_flag & KEY_FLAG_PAIRWISE_MASK) ==
-	    KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
-		wpa_printf(MSG_DEBUG,
-			   "nl80211: SET_KEY (pairwise RX/TX modify)");
+    if ((key_flag & KEY_FLAG_PAIRWISE_MASK) ==
+        KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
         msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
         if (msg == NULL) {
             wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-            goto fail2;
+            goto free_key_msg;
         }
-	} else if (alg == WPA_ALG_NONE && (key_flag & KEY_FLAG_RX_TX)) {
-		wifi_hal_dbg_print("%s:%d invalid key_flag to delete key", __func__, __LINE__);
-		ret = -EINVAL;
-		goto fail2;
-	} else
+    } else if (alg == WPA_ALG_NONE && (key_flag & KEY_FLAG_RX_TX)) {
+        wifi_hal_dbg_print("%s:%d invalid key_flag to delete key", __func__, __LINE__);
+        ret = -EINVAL;
+        goto free_key_msg;
+    } else
 #endif// HOSTAPD_VERSION >= 210
     if (alg == WPA_ALG_NONE) {
         msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_DEL_KEY);
         if (msg == NULL) {
             wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-            goto fail2;
+            goto free_key_msg;
         }
-	} else {
+    } else {
         suite = wpa_alg_to_cipher_suite(alg, key_len);
         if (suite == 0) {
             wifi_hal_error_print("%s:%d: Failed to get cipher suite for alg:%s\n", __func__, __LINE__, wpa_alg_to_string(alg));
             ret = -EINVAL;
-            goto fail2;
+            goto free_key_msg;
         }
 
         msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
         if (msg == NULL) {
             wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-            goto fail2;
+            goto free_key_msg;
         }
 
         if (nla_put(key_msg, NL80211_KEY_DATA, key_len, key) ||
             nla_put_u32(key_msg, NL80211_KEY_CIPHER, suite))
-            goto fail;
+            goto free_msg;
 
         if (seq && seq_len) {
             if (nla_put(key_msg, NL80211_KEY_SEQ, seq_len, seq))
-                goto fail;
+                goto free_msg;
         }
     }
 
     if (addr && !is_broadcast_ether_addr(addr)) {
         if (nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, addr))
-            goto fail;
+            goto free_msg;
 
 #if HOSTAPD_VERSION >= 210
         if ((key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX ||
@@ -17271,14 +17273,14 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
             if (nla_put_u8(key_msg, NL80211_KEY_MODE, key_flag == KEY_FLAG_PAIRWISE_RX
                                ? NL80211_KEY_NO_TX
                                : NL80211_KEY_SET_TX))
-                goto fail;
+                goto free_msg;
         } else if ((key_flag & KEY_FLAG_GROUP_MASK) == KEY_FLAG_GROUP_RX) {
             if (nla_put_u32(key_msg, NL80211_KEY_TYPE, NL80211_KEYTYPE_GROUP))
-                goto fail;
+                goto free_msg;
         } else if (!(key_flag & KEY_FLAG_PAIRWISE)) {
             wifi_hal_dbg_print("%s:%d: key_flag missing PAIRWISE when setting " "a pairwise key\n", __func__, __LINE__);
             ret = -EINVAL;
-            goto fail;
+            goto free_msg;
         } else if (alg == WPA_ALG_WEP && (key_flag & KEY_FLAG_RX_TX) == KEY_FLAG_RX_TX) {
             wifi_hal_dbg_print("%s:%d:unicast WEP key\n", __func__, __LINE__);
             skip_set_key = 0;
@@ -17293,7 +17295,7 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     } else if ((key_flag & KEY_FLAG_PAIRWISE) || !(key_flag & KEY_FLAG_GROUP)) {
         wifi_hal_dbg_print("%s:%d:invalid key_flag for a broadcast key\n", __func__, __LINE__);
         ret = -EINVAL;
-        goto fail;
+        goto free_msg;
     } else {
         wifi_hal_dbg_print("%s:%d:Broadcast key\n", __func__, __LINE__);
         if (key_flag & KEY_FLAG_DEFAULT)
@@ -17302,7 +17304,7 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
 
     if (nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx) ||
         nla_put_nested(msg, NL80211_ATTR_KEY, key_msg))
-        goto fail;
+        goto free_msg;
     nl80211_nlmsg_clear(key_msg);
     nlmsg_free(key_msg);
     key_msg = NULL;
@@ -17312,12 +17314,6 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
         nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, link_id);
     }
 #endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
-
-    // if (vlan_id) {
-    // 	wpa_printf(MSG_DEBUG, "nl80211: VLAN ID %d", vlan_id);
-    // 	if (nla_put_u16(msg, NL80211_ATTR_VLAN_ID, vlan_id))
-    // 		goto fail;
-    // }
 
     if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
         wifi_hal_error_print("%s:%d: Failed new key: %d (%s)\n", __func__, __LINE__, ret, strerror(-ret));
@@ -17340,10 +17336,10 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
 
     msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_SET_KEY);
     if (!msg)
-        goto fail2;
+        goto free_key_msg;
 
     if (nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx))
-        goto fail;
+        goto free_msg;
 #if HOSTAPD_VERSION >= 210
     if (nla_put_flag(key_msg, wpa_alg_bip(alg)
                                   ? (key_idx == 6 || key_idx == 7
@@ -17357,26 +17353,26 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
                               ? NL80211_ATTR_KEY_DEFAULT_MGMT
                               : NL80211_ATTR_KEY_DEFAULT))
 #endif //HOSTAPD_VERSION >= 210
-        goto fail;
+        goto free_msg;
 
     if (addr && is_broadcast_ether_addr(addr)) {
         struct nlattr *types;
 
         types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
         if (!types || nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST))
-            goto fail;
+            goto free_msg;
         nla_nest_end(key_msg, types);
     } else if (addr) {
         struct nlattr *types;
 
         types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
         if (!types || nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_UNICAST))
-            goto fail;
+            goto free_msg;
         nla_nest_end(key_msg, types);
     }
 
     if (nla_put_nested(msg, NL80211_ATTR_KEY, key_msg))
-        goto fail;
+        goto free_msg;
     nl80211_nlmsg_clear(key_msg);
     nlmsg_free(key_msg);
     key_msg = NULL;
@@ -17388,12 +17384,6 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     }
 #endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
 
-    // if (vlan_id) {
-    // 	wpa_printf(MSG_DEBUG, "nl80211: VLAN ID %d", vlan_id);
-    // 	if (nla_put_u16(msg, NL80211_ATTR_VLAN_ID, vlan_id))
-    // 		goto fail;
-    // }
-
     if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
         wifi_hal_error_print("%s:%d: Failed to set key: %d (%s)\n", __func__, __LINE__, ret, strerror(-ret));
         return ret;
@@ -17403,10 +17393,10 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
 
     return 0;
 
-fail:
+free_msg:
     nl80211_nlmsg_clear(msg);
     nlmsg_free(msg);
-fail2:
+free_key_msg:
     nl80211_nlmsg_clear(key_msg);
     nlmsg_free(key_msg);
     return ret;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17186,26 +17186,6 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     int ret;
     wifi_vap_info_t *vap;
 
-#if HOSTAPD_VERSION >= 210 // 2.10
-    int skip_set_key = 1;
-    enum wpa_alg alg = params->alg;
-    const u8 *addr = params->addr;
-    int key_idx = params->key_idx;
-    const u8 *seq = params->seq;
-    size_t seq_len = params->seq_len;
-    const u8 *key = params->key;
-    size_t key_len = params->key_len;
-    enum key_flag key_flag = params->key_flag;
-#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
-    int link_id = params->link_id;
-#endif // CONFIG_GENERIC_MLO
-#endif // HOSTAPD_VERSION >= 210
-
-    if (check_key_flag(key_flag)) {
-        wifi_hal_dbg_print("%s:%d: invalid key_flag", __func__, __LINE__);
-        return -EINVAL;
-    }
-
     interface = (wifi_interface_info_t *)priv;
     vap = &interface->vap_info;
 
@@ -17214,107 +17194,67 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     //wifi_hal_dbg_print("%s:%d: key Info: index:%d length:%d alg:%s\n", __func__, __LINE__, key_idx, key_len, wpa_alg_to_string(alg));
     //my_print_hex_dump(key_len, key);
 
-    ret = -ENOMEM;
-    key_msg = nlmsg_alloc();
-    if (!key_msg)
-        return ret;
-
-#if HOSTAPD_VERSION >= 210
-    if ((key_flag & KEY_FLAG_PAIRWISE_MASK) ==
-        KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
-        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
-        if (msg == NULL) {
-            wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-            goto free_key_msg;
-        }
-    } else if (alg == WPA_ALG_NONE && (key_flag & KEY_FLAG_RX_TX)) {
-        wifi_hal_dbg_print("%s:%d invalid key_flag to delete key", __func__, __LINE__);
-        ret = -EINVAL;
-        goto free_key_msg;
-    } else
-#endif// HOSTAPD_VERSION >= 210
+#if HOSTAPD_VERSION < 210 //2.10
     if (alg == WPA_ALG_NONE) {
-        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_DEL_KEY);
-        if (msg == NULL) {
-            wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-            goto free_key_msg;
-        }
-    } else {
-        suite = wpa_alg_to_cipher_suite(alg, key_len);
-        if (suite == 0) {
-            wifi_hal_error_print("%s:%d: Failed to get cipher suite for alg:%s\n", __func__, __LINE__, wpa_alg_to_string(alg));
-            ret = -EINVAL;
-            goto free_key_msg;
-        }
+        return -1;
+    }
 
-        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
-        if (msg == NULL) {
-            wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-            goto free_key_msg;
-        }
+    suite = wpa_alg_to_cipher_suite(alg, key_len);
+    if (suite == 0) {
+        wifi_hal_error_print("%s:%d: Failed to get cipher suite for alg:%s\n", __func__, __LINE__, wpa_alg_to_string(alg));
+        return -1;
+    }
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
+    if (msg == NULL) {
+        wifi_hal_error_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
+        return -1;
+    }
 
-        if (nla_put(key_msg, NL80211_KEY_DATA, key_len, key) ||
-            nla_put_u32(key_msg, NL80211_KEY_CIPHER, suite))
-            goto free_msg;
+    key_msg = nlmsg_alloc();
+    if (!key_msg) {
+        wifi_hal_error_print("%s:%d:Failed to allocate nl80211 key message\n", __func__, __LINE__);
+        nl80211_nlmsg_clear(msg);
+        nlmsg_free(msg);
+        return -1;
+    }
 
-        if (seq && seq_len) {
-            if (nla_put(key_msg, NL80211_KEY_SEQ, seq_len, seq))
-                goto free_msg;
-        }
+    nla_put(key_msg, NL80211_ATTR_KEY_DATA, key_len, key);
+    nla_put_u32(key_msg, NL80211_ATTR_KEY_CIPHER, suite);
+    if (seq && seq_len) {
+        nla_put(key_msg, NL80211_ATTR_KEY_SEQ, seq_len, seq);
     }
 
     if (addr && !is_broadcast_ether_addr(addr)) {
-        if (nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, addr))
-            goto free_msg;
-
-#if HOSTAPD_VERSION >= 210
-        if ((key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX ||
-            (key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
-            if (nla_put_u8(key_msg, NL80211_KEY_MODE, key_flag == KEY_FLAG_PAIRWISE_RX
-                               ? NL80211_KEY_NO_TX
-                               : NL80211_KEY_SET_TX))
-                goto free_msg;
-        } else if ((key_flag & KEY_FLAG_GROUP_MASK) == KEY_FLAG_GROUP_RX) {
-            if (nla_put_u32(key_msg, NL80211_KEY_TYPE, NL80211_KEYTYPE_GROUP))
-                goto free_msg;
-        } else if (!(key_flag & KEY_FLAG_PAIRWISE)) {
-            wifi_hal_dbg_print("%s:%d: key_flag missing PAIRWISE when setting " "a pairwise key\n", __func__, __LINE__);
-            ret = -EINVAL;
-            goto free_msg;
-        } else if (alg == WPA_ALG_WEP && (key_flag & KEY_FLAG_RX_TX) == KEY_FLAG_RX_TX) {
-            wifi_hal_dbg_print("%s:%d:unicast WEP key\n", __func__, __LINE__);
-            skip_set_key = 0;
-        } else {
-            wifi_hal_dbg_print("%s:%d:pairwise key\n", __func__, __LINE__);
-        }
-#else
+        nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, addr);
         if (alg != WPA_ALG_WEP && key_idx && !set_tx) {
             nla_put_u32(msg, NL80211_ATTR_KEY_TYPE, NL80211_KEYTYPE_GROUP);
         }
-#endif //HOSTAPD_VERSION >= 210
-    } else if ((key_flag & KEY_FLAG_PAIRWISE) || !(key_flag & KEY_FLAG_GROUP)) {
-        wifi_hal_dbg_print("%s:%d:invalid key_flag for a broadcast key\n", __func__, __LINE__);
-        ret = -EINVAL;
-        goto free_msg;
-    } else {
-        wifi_hal_dbg_print("%s:%d:Broadcast key\n", __func__, __LINE__);
-        if (key_flag & KEY_FLAG_DEFAULT)
-            skip_set_key = 0;
+    } else if (addr && is_broadcast_ether_addr(addr)) {
+        struct nlattr *types;
+
+        types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
+        if (!types) {
+            nl80211_nlmsg_clear(msg);
+            nlmsg_free(msg);
+            nl80211_nlmsg_clear(key_msg);
+            nlmsg_free(key_msg);
+        }
+        nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
+        nla_nest_end(key_msg, types);
     }
 
-    if (nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx) ||
-        nla_put_nested(msg, NL80211_ATTR_KEY, key_msg))
-        goto free_msg;
+    if (nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, key_idx) ||
+            nla_put_nested(msg, NL80211_ATTR_KEY, key_msg)) {
+        nl80211_nlmsg_clear(msg);
+        nlmsg_free(msg);
+        nl80211_nlmsg_clear(key_msg);
+        nlmsg_free(key_msg);
+        return -1;
+    }
+
     nl80211_nlmsg_clear(key_msg);
     nlmsg_free(key_msg);
     key_msg = NULL;
-
-#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
-    if (link_id != NL80211_DRV_LINK_ID_NA) {
-        nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, link_id);
-    }
-#endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
-
     if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
         wifi_hal_error_print("%s:%d: Failed new key: %d (%s)\n", __func__, __LINE__, ret, strerror(-ret));
         return -1;
@@ -17322,84 +17262,201 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
 
     wifi_hal_dbg_print("%s:%d: new key success for ifname:%s vap_index:%d\n", __func__, __LINE__, interface->name, vap->vap_index);
 
-#if HOSTAPD_VERSION >= 210
-    if (skip_set_key)
-#else
-    if ((addr && !is_broadcast_ether_addr(addr)) && (vap->vap_mode != wifi_vap_mode_sta))
-#endif //HOSTAPD_VERSION >= 210
-        return 0;
-
-    ret = -ENOBUFS;
-    key_msg = nlmsg_alloc();
-    if (!key_msg)
-        return ret;
+     if ((addr && !is_broadcast_ether_addr(addr)) && (vap->vap_mode != wifi_vap_mode_sta))
+          return 0;
 
     msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_SET_KEY);
-    if (!msg)
-        goto free_key_msg;
+    if (!msg) {
+        wifi_hal_error_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
+        return -1;
+    }
 
-    if (nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx))
-        goto free_msg;
-#if HOSTAPD_VERSION >= 210
-    if (nla_put_flag(key_msg, wpa_alg_bip(alg)
-                                  ? (key_idx == 6 || key_idx == 7
-                                         ? NL80211_KEY_DEFAULT_BEACON
-                                         : NL80211_KEY_DEFAULT_MGMT)
-                                  : NL80211_KEY_DEFAULT))
-#else
-    if (nla_put_flag(msg, (alg == WPA_ALG_IGTK || alg == WPA_ALG_BIP_GMAC_128 ||
-                           alg == WPA_ALG_BIP_GMAC_256 ||
-                           alg == WPA_ALG_BIP_CMAC_256)
-                              ? NL80211_ATTR_KEY_DEFAULT_MGMT
-                              : NL80211_ATTR_KEY_DEFAULT))
-#endif //HOSTAPD_VERSION >= 210
-        goto free_msg;
+    key_msg = nlmsg_alloc();
+    if (!key_msg) {
+        wifi_hal_error_print("%s:%d:Failed to allocate nl80211 key message\n", __func__, __LINE__);
+        nl80211_nlmsg_clear(msg);
+        nlmsg_free(msg);
+        return -1;
+    }
+
+    nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, key_idx);
+    nla_put_flag(key_msg, (alg == WPA_ALG_IGTK ||
+                alg == WPA_ALG_BIP_GMAC_128 ||
+                alg == WPA_ALG_BIP_GMAC_256 ||
+                alg == WPA_ALG_BIP_CMAC_256) ?
+            NL80211_ATTR_KEY_DEFAULT_MGMT :
+            NL80211_ATTR_KEY_DEFAULT);
 
     if (addr && is_broadcast_ether_addr(addr)) {
         struct nlattr *types;
 
         types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
-        if (!types || nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST))
-            goto free_msg;
+        if (!types) {
+            nl80211_nlmsg_clear(msg);
+            nlmsg_free(msg);
+            nl80211_nlmsg_clear(key_msg);
+            nlmsg_free(key_msg);
+        }
+        nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
         nla_nest_end(key_msg, types);
     } else if (addr) {
-        struct nlattr *types;
-
-        types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
-        if (!types || nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_UNICAST))
-            goto free_msg;
-        nla_nest_end(key_msg, types);
+#else //hostapd 2.10
+      int skip_set_key = 1;
+    if (params->alg == WPA_ALG_NONE) {
+        return -1;
+    }
+    suite = wpa_alg_to_cipher_suite(params->alg, params->key_len);
+    if (suite == 0) {
+        wifi_hal_dbg_print("%s:%d: Failed to get cipher suite for alg:%s\n", __func__, __LINE__, wpa_alg_to_string(params->alg));
+        return -1;
+    }
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
+    if (msg == NULL) {
+        wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
+        return -1;
     }
 
-    if (nla_put_nested(msg, NL80211_ATTR_KEY, key_msg))
-        goto free_msg;
-    nl80211_nlmsg_clear(key_msg);
-    nlmsg_free(key_msg);
-    key_msg = NULL;
+    key_msg = nlmsg_alloc();
+    if (!key_msg) {
+        wifi_hal_error_print("%s:%d:Failed to allocate nl80211 key message\n", __func__, __LINE__);
+        nl80211_nlmsg_clear(msg);
+        nlmsg_free(msg);
+        return -1;
+    }
 
-#if HOSTAPD_VERSION >= 210 && defined(CONFIG_GENERIC_MLO)
-    if (link_id != NL80211_DRV_LINK_ID_NA) {
-        if (nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, link_id))
-            goto fail;
+#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
+    if (params->link_id != NL80211_DRV_LINK_ID_NA) {
+        nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, params->link_id);
     }
 #endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
 
+    nla_put(key_msg, NL80211_ATTR_KEY_DATA, params->key_len, params->key);
+    nla_put_u32(key_msg, NL80211_ATTR_KEY_CIPHER, suite);
+    if (params->seq && params->seq_len) {
+        nla_put(key_msg, NL80211_ATTR_KEY_SEQ, params->seq_len, params->seq);
+    }
+
+    if (params->addr && !is_broadcast_ether_addr(params->addr)) {
+        nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, params->addr);
+        if ((params->key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX || (params->key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
+          nla_put_u8(key_msg, NL80211_KEY_MODE, params->key_flag == KEY_FLAG_PAIRWISE_RX ? NL80211_KEY_NO_TX : NL80211_KEY_SET_TX);
+        }
+        else if ((params->key_flag & KEY_FLAG_GROUP_MASK) == KEY_FLAG_GROUP_RX) {
+          nla_put_u32(key_msg, NL80211_KEY_TYPE, NL80211_KEYTYPE_GROUP);
+        }
+        else if (!(params->key_flag & KEY_FLAG_PAIRWISE)) {
+          wifi_hal_dbg_print("%s:%d: key_flag missing PAIRWISE when setting a pairwise key\n",__func__,__LINE__);
+      	  ret = -EINVAL;
+        }
+        else if (params->alg == WPA_ALG_WEP && (params->key_flag & KEY_FLAG_RX_TX) == KEY_FLAG_RX_TX) {
+          wifi_hal_dbg_print("%s:%d:unicast WEP key\n",__func__,__LINE__);
+          skip_set_key = 0;
+        }
+        else {
+          wifi_hal_dbg_print("%s:%d:pairwise key\n",__func__,__LINE__);
+        }
+    }
+    else if ((params->key_flag & KEY_FLAG_PAIRWISE) || !(params->key_flag & KEY_FLAG_GROUP)) {
+      wifi_hal_dbg_print("%s:%d:invalid key_flag for a broadcast key\n",__func__,__LINE__);
+      ret = -EINVAL;
+    }
+    else {
+      wifi_hal_dbg_print("%s:%d:Broadcast key\n",__func__,__LINE__);
+      if (params->key_flag & KEY_FLAG_DEFAULT)
+        skip_set_key = 0;
+    }
+    if (nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, params->key_idx) ||
+            nla_put_nested(msg, NL80211_ATTR_KEY, key_msg)) {
+        nl80211_nlmsg_clear(msg);
+        nlmsg_free(msg);
+        nl80211_nlmsg_clear(key_msg);
+        nlmsg_free(key_msg);
+        return -1;
+    }
+
+    nl80211_nlmsg_clear(key_msg);
+    nlmsg_free(key_msg);
+    key_msg = NULL;
+    if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
+        wifi_hal_dbg_print("%s:%d: Failed new key: %d(%s)\n", __func__, __LINE__, ret, strerror(-ret));
+        return -1;
+    }
+
+    wifi_hal_dbg_print("%s:%d: new key success for ifname:%s vap_index:%d\n", __func__, __LINE__, interface->name, vap->vap_index);
+    if (skip_set_key)
+      return 0;
+
+    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_SET_KEY);
+    if (msg == NULL) {
+        wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
+        return -1;
+    }
+
+    key_msg = nlmsg_alloc();
+    if (!key_msg) {
+        wifi_hal_error_print("%s:%d:Failed to allocate nl80211 key message\n", __func__, __LINE__);
+        nl80211_nlmsg_clear(msg);
+        nlmsg_free(msg);
+        return -1;
+    }
+#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
+    if (params->link_id != NL80211_DRV_LINK_ID_NA) {
+        nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, params->link_id);
+    }
+#endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
+
+    nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, params->key_idx);
+    nla_put_flag(key_msg, wpa_alg_bip(params->alg) ?
+                 (params->key_idx == 6 || params->key_idx == 7 ?
+                  NL80211_KEY_DEFAULT_BEACON :
+                  NL80211_ATTR_KEY_DEFAULT_MGMT) :
+                 NL80211_ATTR_KEY_DEFAULT);
+
+    if (params->addr && is_broadcast_ether_addr(params->addr)) {
+        struct nlattr *types;
+
+        types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
+        if (!types) {
+            nl80211_nlmsg_clear(msg);
+            nlmsg_free(msg);
+            nl80211_nlmsg_clear(key_msg);
+            nlmsg_free(key_msg);
+        }
+        nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
+        nla_nest_end(key_msg, types);
+    } else if (params->addr) {
+#endif
+        struct nlattr *types;
+
+        types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
+        if (!types) {
+            nl80211_nlmsg_clear(msg);
+            nlmsg_free(msg);
+            nl80211_nlmsg_clear(key_msg);
+            nlmsg_free(key_msg);
+        }
+        nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
+        nla_nest_end(key_msg, types);
+    }
+
+    if (nla_put_nested(msg, NL80211_ATTR_KEY, key_msg)) {
+        nl80211_nlmsg_clear(msg);
+        nlmsg_free(msg);
+        nl80211_nlmsg_clear(key_msg);
+        nlmsg_free(key_msg);
+        return -1;
+    }
+    nl80211_nlmsg_clear(key_msg);
+    nlmsg_free(key_msg);
+    key_msg = NULL;
     if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
         wifi_hal_error_print("%s:%d: Failed to set key: %d (%s)\n", __func__, __LINE__, ret, strerror(-ret));
-        return ret;
+        return -1;
     }
 
     wifi_hal_info_print("%s:%d:key set success for ifname:%s vap_index:%d\n", __func__, __LINE__, interface->name, vap->vap_index);
 
     return 0;
-
-free_msg:
-    nl80211_nlmsg_clear(msg);
-    nlmsg_free(msg);
-free_key_msg:
-    nl80211_nlmsg_clear(key_msg);
-    nlmsg_free(key_msg);
-    return ret;
 }
 
 int wifi_drv_set_authmode(void *priv, int auth_algs)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17184,6 +17184,7 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     struct nl_msg *key_msg = NULL;
     unsigned int suite;
     int ret;
+    int key_type;
     wifi_vap_info_t *vap;
 
     interface = (wifi_interface_info_t *)priv;
@@ -17218,10 +17219,10 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
         return -1;
     }
 
-    nla_put(key_msg, NL80211_ATTR_KEY_DATA, key_len, key);
-    nla_put_u32(key_msg, NL80211_ATTR_KEY_CIPHER, suite);
+    nla_put(key_msg, NL80211_KEY_DATA, key_len, key);
+    nla_put_u32(key_msg, NL80211_KEY_CIPHER, suite);
     if (seq && seq_len) {
-        nla_put(key_msg, NL80211_ATTR_KEY_SEQ, seq_len, seq);
+        nla_put(key_msg, NL80211_KEY_SEQ, seq_len, seq);
     }
 
     if (addr && !is_broadcast_ether_addr(addr)) {
@@ -17238,12 +17239,13 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
             nlmsg_free(msg);
             nl80211_nlmsg_clear(key_msg);
             nlmsg_free(key_msg);
+            return -1;
         }
         nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
         nla_nest_end(key_msg, types);
     }
 
-    if (nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, key_idx) ||
+    if (nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx) ||
             nla_put_nested(msg, NL80211_ATTR_KEY, key_msg)) {
         nl80211_nlmsg_clear(msg);
         nlmsg_free(msg);
@@ -17279,13 +17281,13 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
         return -1;
     }
 
-    nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, key_idx);
+    nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx);
     nla_put_flag(key_msg, (alg == WPA_ALG_IGTK ||
                 alg == WPA_ALG_BIP_GMAC_128 ||
                 alg == WPA_ALG_BIP_GMAC_256 ||
                 alg == WPA_ALG_BIP_CMAC_256) ?
-            NL80211_ATTR_KEY_DEFAULT_MGMT :
-            NL80211_ATTR_KEY_DEFAULT);
+            NL80211_KEY_DEFAULT_MGMT :
+            NL80211_KEY_DEFAULT);
 
     if (addr && is_broadcast_ether_addr(addr)) {
         struct nlattr *types;
@@ -17296,6 +17298,7 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
             nlmsg_free(msg);
             nl80211_nlmsg_clear(key_msg);
             nlmsg_free(key_msg);
+            return -1;
         }
         nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
         nla_nest_end(key_msg, types);
@@ -17330,10 +17333,10 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     }
 #endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
 
-    nla_put(key_msg, NL80211_ATTR_KEY_DATA, params->key_len, params->key);
-    nla_put_u32(key_msg, NL80211_ATTR_KEY_CIPHER, suite);
+    nla_put(key_msg, NL80211_KEY_DATA, params->key_len, params->key);
+    nla_put_u32(key_msg, NL80211_KEY_CIPHER, suite);
     if (params->seq && params->seq_len) {
-        nla_put(key_msg, NL80211_ATTR_KEY_SEQ, params->seq_len, params->seq);
+        nla_put(key_msg, NL80211_KEY_SEQ, params->seq_len, params->seq);
     }
 
     if (params->addr && !is_broadcast_ether_addr(params->addr)) {
@@ -17365,7 +17368,7 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
       if (params->key_flag & KEY_FLAG_DEFAULT)
         skip_set_key = 0;
     }
-    if (nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, params->key_idx) ||
+    if (nla_put_u8(key_msg, NL80211_KEY_IDX, params->key_idx) ||
             nla_put_nested(msg, NL80211_ATTR_KEY, key_msg)) {
         nl80211_nlmsg_clear(msg);
         nlmsg_free(msg);
@@ -17405,12 +17408,15 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     }
 #endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
 
-    nla_put_u8(key_msg, NL80211_ATTR_KEY_IDX, params->key_idx);
-    nla_put_flag(key_msg, wpa_alg_bip(params->alg) ?
-                 (params->key_idx == 6 || params->key_idx == 7 ?
-                  NL80211_KEY_DEFAULT_BEACON :
-                  NL80211_ATTR_KEY_DEFAULT_MGMT) :
-                 NL80211_ATTR_KEY_DEFAULT);
+    nla_put_u8(key_msg, NL80211_KEY_IDX, params->key_idx);
+
+    if (interface->u.ap.iface.drv_flags & WPA_DRIVER_FLAGS_BEACON_PROTECTION &&
+            (params->key_idx == 6 || params->key_idx == 7)) {
+        key_type = NL80211_KEY_DEFAULT_BEACON;
+    } else {
+        key_type = wpa_alg_bip(params->alg) ? NL80211_KEY_DEFAULT_MGMT : NL80211_KEY_DEFAULT;
+    }
+    nla_put_flag(key_msg, key_type);
 
     if (params->addr && is_broadcast_ether_addr(params->addr)) {
         struct nlattr *types;
@@ -17421,6 +17427,7 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
             nlmsg_free(msg);
             nl80211_nlmsg_clear(key_msg);
             nlmsg_free(key_msg);
+            return -1;
         }
         nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
         nla_nest_end(key_msg, types);
@@ -17434,8 +17441,9 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
             nlmsg_free(msg);
             nl80211_nlmsg_clear(key_msg);
             nlmsg_free(key_msg);
+            return -1;
         }
-        nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
+        nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_UNICAST);
         nla_nest_end(key_msg, types);
     }
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17181,9 +17181,26 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
 {
     wifi_interface_info_t *interface;
     struct nl_msg *msg = NULL;
+    struct nl_msg *key_msg = NULL;
     unsigned int suite;
     int ret;
     wifi_vap_info_t *vap;
+
+#if HOSTAPD_VERSION >= 210 // 2.10
+    int skip_set_key = 1;
+    enum wpa_alg alg = params->alg;
+    const u8 *addr = params->addr;
+    int key_idx = params->key_idx;
+    const u8 *seq = params->seq;
+    size_t seq_len = params->seq_len;
+    const u8 *key = params->key;
+    size_t key_len = params->key_len;
+    // int vlan_id = params->vlan_id;
+    enum key_flag key_flag = params->key_flag;
+#ifdef CONFIG_GENERIC_MLO
+    int link_id = params->link_id;
+#endif // CONFIG_GENERIC_MLO
+#endif // HOSTAPD_VERSION >= 210
 
     interface = (wifi_interface_info_t *)priv;
     vap = &interface->vap_info;
@@ -17193,46 +17210,114 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     //wifi_hal_dbg_print("%s:%d: key Info: index:%d length:%d alg:%s\n", __func__, __LINE__, key_idx, key_len, wpa_alg_to_string(alg));
     //my_print_hex_dump(key_len, key);
 
-#if HOSTAPD_VERSION < 210 //2.10
+    ret = -ENOBUFS;
+    key_msg = nlmsg_alloc();
+    if (!key_msg)
+        return ret;
+
+#if HOSTAPD_VERSION >= 210
+	if ((key_flag & KEY_FLAG_PAIRWISE_MASK) ==
+	    KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
+		wpa_printf(MSG_DEBUG,
+			   "nl80211: SET_KEY (pairwise RX/TX modify)");
+        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
+        if (msg == NULL) {
+            wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
+            goto fail2;
+        }
+	} else if (alg == WPA_ALG_NONE && (key_flag & KEY_FLAG_RX_TX)) {
+		wifi_hal_dbg_print("%s:%d invalid key_flag to delete key", __func__, __LINE__);
+		ret = -EINVAL;
+		goto fail2;
+	} else
+#endif// HOSTAPD_VERSION >= 210
     if (alg == WPA_ALG_NONE) {
-        return -1;
-    }
+        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_DEL_KEY);
+        if (msg == NULL) {
+            wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
+            goto fail2;
+        }
+	} else {
+        suite = wpa_alg_to_cipher_suite(alg, key_len);
+        if (suite == 0) {
+            wifi_hal_error_print("%s:%d: Failed to get cipher suite for alg:%s\n", __func__, __LINE__, wpa_alg_to_string(alg));
+            ret = -EINVAL;
+            goto fail2;
+        }
 
-    suite = wpa_alg_to_cipher_suite(alg, key_len);
-    if (suite == 0) {
-        wifi_hal_error_print("%s:%d: Failed to get cipher suite for alg:%s\n", __func__, __LINE__, wpa_alg_to_string(alg));
-        return -1;
-    }
-    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
-    if (msg == NULL) {
-        wifi_hal_error_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-        return -1;
-    }
+        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
+        if (msg == NULL) {
+            wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
+            goto fail2;
+        }
 
-    nla_put(msg, NL80211_ATTR_KEY_DATA, key_len, key);
-    nla_put_u32(msg, NL80211_ATTR_KEY_CIPHER, suite);
-    if (seq && seq_len) {
-        nla_put(msg, NL80211_ATTR_KEY_SEQ, seq_len, seq);
+        if (nla_put(key_msg, NL80211_KEY_DATA, key_len, key) ||
+            nla_put_u32(key_msg, NL80211_KEY_CIPHER, suite))
+            goto fail;
+
+        if (seq && seq_len) {
+            if (nla_put(key_msg, NL80211_KEY_SEQ, seq_len, seq))
+                goto fail;
+        }
     }
 
     if (addr && !is_broadcast_ether_addr(addr)) {
-        nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, addr);
+        if (nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, addr))
+            goto fail;
+
+#if HOSTAPD_VERSION >= 210
+        if ((key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX ||
+            (key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
+            if (nla_put_u8(key_msg, NL80211_KEY_MODE, key_flag == KEY_FLAG_PAIRWISE_RX
+                               ? NL80211_KEY_NO_TX
+                               : NL80211_KEY_SET_TX))
+                goto fail;
+        } else if ((key_flag & KEY_FLAG_GROUP_MASK) == KEY_FLAG_GROUP_RX) {
+            if (nla_put_u32(key_msg, NL80211_KEY_TYPE, NL80211_KEYTYPE_GROUP))
+                goto fail;
+        } else if (!(key_flag & KEY_FLAG_PAIRWISE)) {
+            wifi_hal_dbg_print("%s:%d: key_flag missing PAIRWISE when setting " "a pairwise key\n", __func__, __LINE__);
+            ret = -EINVAL;
+            goto fail;
+        } else if (alg == WPA_ALG_WEP && (key_flag & KEY_FLAG_RX_TX) == KEY_FLAG_RX_TX) {
+            wifi_hal_dbg_print("%s:%d:unicast WEP key\n", __func__, __LINE__);
+            skip_set_key = 0;
+        } else {
+            wifi_hal_dbg_print("%s:%d:pairwise key\n", __func__, __LINE__);
+        }
+#else
         if (alg != WPA_ALG_WEP && key_idx && !set_tx) {
             nla_put_u32(msg, NL80211_ATTR_KEY_TYPE, NL80211_KEYTYPE_GROUP);
         }
-    } else if (addr && is_broadcast_ether_addr(addr)) {
-        struct nlattr *types;
-
-        types = nla_nest_start(msg, NL80211_ATTR_KEY_DEFAULT_TYPES);
-        if (!types) {
-            nl80211_nlmsg_clear(msg);
-            nlmsg_free(msg);
-        }
-        nla_put_flag(msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
-        nla_nest_end(msg, types);
+#endif //HOSTAPD_VERSION >= 210
+    } else if ((key_flag & KEY_FLAG_PAIRWISE) || !(key_flag & KEY_FLAG_GROUP)) {
+        wifi_hal_dbg_print("%s:%d:invalid key_flag for a broadcast key\n", __func__, __LINE__);
+        ret = -EINVAL;
+        goto fail;
+    } else {
+        wifi_hal_dbg_print("%s:%d:Broadcast key\n", __func__, __LINE__);
+        if (key_flag & KEY_FLAG_DEFAULT)
+            skip_set_key = 0;
     }
 
-    nla_put_u8(msg, NL80211_ATTR_KEY_IDX, key_idx);
+    if (nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx) ||
+        nla_put_nested(msg, NL80211_ATTR_KEY, key_msg))
+        goto fail;
+    nl80211_nlmsg_clear(key_msg);
+    nlmsg_free(key_msg);
+    key_msg = NULL;
+
+#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
+    if (link_id != NL80211_DRV_LINK_ID_NA) {
+        nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, link_id);
+    }
+#endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
+
+    // if (vlan_id) {
+    // 	wpa_printf(MSG_DEBUG, "nl80211: VLAN ID %d", vlan_id);
+    // 	if (nla_put_u16(msg, NL80211_ATTR_VLAN_ID, vlan_id))
+    // 		goto fail;
+    // }
 
     if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
         wifi_hal_error_print("%s:%d: Failed new key: %d (%s)\n", __func__, __LINE__, ret, strerror(-ret));
@@ -17241,138 +17326,90 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
 
     wifi_hal_dbg_print("%s:%d: new key success for ifname:%s vap_index:%d\n", __func__, __LINE__, interface->name, vap->vap_index);
 
-     if ((addr && !is_broadcast_ether_addr(addr)) && (vap->vap_mode != wifi_vap_mode_sta))
-          return 0;
+#if HOSTAPD_VERSION >= 210
+    if (skip_set_key)
+#else
+    if ((addr && !is_broadcast_ether_addr(addr)) && (vap->vap_mode != wifi_vap_mode_sta))
+#endif //HOSTAPD_VERSION >= 210
+        return 0;
+
+    ret = -ENOBUFS;
+    key_msg = nlmsg_alloc();
+    if (!key_msg)
+        return ret;
 
     msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_SET_KEY);
+    if (!msg)
+        goto fail2;
 
-    nla_put_u8(msg, NL80211_ATTR_KEY_IDX, key_idx);
-    nla_put_flag(msg, (alg == WPA_ALG_IGTK ||
-                alg == WPA_ALG_BIP_GMAC_128 ||
-                alg == WPA_ALG_BIP_GMAC_256 ||
-                alg == WPA_ALG_BIP_CMAC_256) ?
-            NL80211_ATTR_KEY_DEFAULT_MGMT :
-            NL80211_ATTR_KEY_DEFAULT);
+    if (nla_put_u8(key_msg, NL80211_KEY_IDX, key_idx))
+        goto fail;
+#if HOSTAPD_VERSION >= 210
+    if (nla_put_flag(key_msg, wpa_alg_bip(alg)
+                                  ? (key_idx == 6 || key_idx == 7
+                                         ? NL80211_KEY_DEFAULT_BEACON
+                                         : NL80211_KEY_DEFAULT_MGMT)
+                                  : NL80211_KEY_DEFAULT))
+#else
+    if (nla_put_flag(msg, (alg == WPA_ALG_IGTK || alg == WPA_ALG_BIP_GMAC_128 ||
+                           alg == WPA_ALG_BIP_GMAC_256 ||
+                           alg == WPA_ALG_BIP_CMAC_256)
+                              ? NL80211_ATTR_KEY_DEFAULT_MGMT
+                              : NL80211_ATTR_KEY_DEFAULT))
+#endif //HOSTAPD_VERSION >= 210
+        goto fail;
 
     if (addr && is_broadcast_ether_addr(addr)) {
         struct nlattr *types;
 
-        types = nla_nest_start(msg, NL80211_ATTR_KEY_DEFAULT_TYPES);
-        nla_put_flag(msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
-        nla_nest_end(msg, types);
+        types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
+        if (!types || nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST))
+            goto fail;
+        nla_nest_end(key_msg, types);
     } else if (addr) {
-#else //hostapd 2.10
-      int skip_set_key = 1;
-    if (params->alg == WPA_ALG_NONE) {
-        return -1;
-    }
-    suite = wpa_alg_to_cipher_suite(params->alg, params->key_len);
-    if (suite == 0) {
-        wifi_hal_dbg_print("%s:%d: Failed to get cipher suite for alg:%s\n", __func__, __LINE__, wpa_alg_to_string(params->alg));
-        return -1;
-    }
-    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_NEW_KEY);
-    if (msg == NULL) {
-        wifi_hal_dbg_print("%s:%d:Failed to allocate nl80211 message\n", __func__, __LINE__);
-        return -1;
+        struct nlattr *types;
+
+        types = nla_nest_start(key_msg, NL80211_KEY_DEFAULT_TYPES);
+        if (!types || nla_put_flag(key_msg, NL80211_KEY_DEFAULT_TYPE_UNICAST))
+            goto fail;
+        nla_nest_end(key_msg, types);
     }
 
-#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
-    if (params->link_id != NL80211_DRV_LINK_ID_NA) {
-        nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, params->link_id);
+    if (nla_put_nested(msg, NL80211_ATTR_KEY, key_msg))
+        goto fail;
+    nl80211_nlmsg_clear(key_msg);
+    nlmsg_free(key_msg);
+    key_msg = NULL;
+
+#if HOSTAPD_VERSION >= 210 && defined(CONFIG_GENERIC_MLO)
+    if (link_id != NL80211_DRV_LINK_ID_NA) {
+        if (nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, link_id))
+            goto fail;
     }
 #endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
 
-    nla_put(msg, NL80211_ATTR_KEY_DATA, params->key_len, params->key);
-    nla_put_u32(msg, NL80211_ATTR_KEY_CIPHER, suite);
-    if (params->seq && params->seq_len) {
-        nla_put(msg, NL80211_ATTR_KEY_SEQ, params->seq_len, params->seq);
-    }
-
-    if (params->addr && !is_broadcast_ether_addr(params->addr)) {
-        nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, params->addr);
-        if ((params->key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX || (params->key_flag & KEY_FLAG_PAIRWISE_MASK) == KEY_FLAG_PAIRWISE_RX_TX_MODIFY) {
-          nla_put_u8(msg, NL80211_KEY_MODE, params->key_flag == KEY_FLAG_PAIRWISE_RX ? NL80211_KEY_NO_TX : NL80211_KEY_SET_TX);
-        }
-        else if ((params->key_flag & KEY_FLAG_GROUP_MASK) == KEY_FLAG_GROUP_RX) {
-          nla_put_u32(msg, NL80211_KEY_TYPE, NL80211_KEYTYPE_GROUP);
-        }
-        else if (!(params->key_flag & KEY_FLAG_PAIRWISE)) {
-          wifi_hal_dbg_print("%s:%d: key_flag missing PAIRWISE when setting a pairwise key\n",__func__,__LINE__);
-      	  ret = -EINVAL;
-        }
-        else if (params->alg == WPA_ALG_WEP && (params->key_flag & KEY_FLAG_RX_TX) == KEY_FLAG_RX_TX) {
-          wifi_hal_dbg_print("%s:%d:unicast WEP key\n",__func__,__LINE__);
-          skip_set_key = 0;
-        }
-        else {
-          wifi_hal_dbg_print("%s:%d:pairwise key\n",__func__,__LINE__);
-        }
-    }
-    else if ((params->key_flag & KEY_FLAG_PAIRWISE) || !(params->key_flag & KEY_FLAG_GROUP)) {
-      wifi_hal_dbg_print("%s:%d:invalid key_flag for a broadcast key\n",__func__,__LINE__);
-      ret = -EINVAL;
-    }
-    else {
-      wifi_hal_dbg_print("%s:%d:Broadcast key\n",__func__,__LINE__);
-      if (params->key_flag & KEY_FLAG_DEFAULT)
-        skip_set_key = 0;
-    }
-    nla_put_u8(msg, NL80211_ATTR_KEY_IDX, params->key_idx);
-
-    if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
-        wifi_hal_dbg_print("%s:%d: Failed new key: %d(%s)\n", __func__, __LINE__, ret, strerror(-ret));
-        return -1;
-    }
-
-    wifi_hal_dbg_print("%s:%d: new key success for ifname:%s vap_index:%d\n", __func__, __LINE__, interface->name, vap->vap_index);
-    if (skip_set_key)
-      return 0;
-
-    msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, interface, 0, NL80211_CMD_SET_KEY);
-
-#if HOSTAPD_VERSION >= 211 && defined(CONFIG_GENERIC_MLO)
-    if (params->link_id != NL80211_DRV_LINK_ID_NA) {
-        nla_put_u8(msg, NL80211_ATTR_MLO_LINK_ID, params->link_id);
-    }
-#endif // HOSTAPD_VERSION >= 211 && CONFIG_GENERIC_MLO
-
-    nla_put_u8(msg, NL80211_ATTR_KEY_IDX, params->key_idx);
-#if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || defined (TCHCBRV2_PORT) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_) || defined(RDKB_ONE_WIFI_PROD)
-    // NL80211_KEY_DEFAULT_BEACON enum is not defined in broadcom nl80211.h header
-    nla_put_flag(msg, wpa_alg_bip(params->alg) ? NL80211_ATTR_KEY_DEFAULT_MGMT : NL80211_ATTR_KEY_DEFAULT);
-#else
-    // NL80211_KEY_DEFAULT_BEACON enum is defined in wave-drv nl80211.h header
-    nla_put_flag(msg, wpa_alg_bip(params->alg) ?
-                 (params->key_idx == 6 || params->key_idx == 7 ?
-                  NL80211_KEY_DEFAULT_BEACON :
-                  NL80211_ATTR_KEY_DEFAULT_MGMT) :
-                 NL80211_ATTR_KEY_DEFAULT);
-#endif
-
-    if (params->addr && is_broadcast_ether_addr(params->addr)) {
-        struct nlattr *types;
-
-        types = nla_nest_start(msg, NL80211_ATTR_KEY_DEFAULT_TYPES);
-        nla_put_flag(msg, NL80211_KEY_DEFAULT_TYPE_MULTICAST);
-        nla_nest_end(msg, types);
-    } else if (params->addr) {
-#endif
-        struct nlattr *types;
-
-        types = nla_nest_start(msg, NL80211_ATTR_KEY_DEFAULT_TYPES);
-        nla_put_flag(msg, NL80211_KEY_DEFAULT_TYPE_UNICAST);
-        nla_nest_end(msg, types);
-    }
+    // if (vlan_id) {
+    // 	wpa_printf(MSG_DEBUG, "nl80211: VLAN ID %d", vlan_id);
+    // 	if (nla_put_u16(msg, NL80211_ATTR_VLAN_ID, vlan_id))
+    // 		goto fail;
+    // }
 
     if ((ret = nl80211_send_and_recv(msg, NULL, (void *)-1, NULL, NULL))) {
         wifi_hal_error_print("%s:%d: Failed to set key: %d (%s)\n", __func__, __LINE__, ret, strerror(-ret));
-        return -1;
+        return ret;
     }
 
     wifi_hal_info_print("%s:%d:key set success for ifname:%s vap_index:%d\n", __func__, __LINE__, interface->name, vap->vap_index);
 
     return 0;
+
+fail:
+    nl80211_nlmsg_clear(msg);
+    nlmsg_free(msg);
+fail2:
+    nl80211_nlmsg_clear(key_msg);
+    nlmsg_free(key_msg);
+    return ret;
 }
 
 int wifi_drv_set_authmode(void *priv, int auth_algs)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -5203,7 +5203,10 @@ static void wiphy_info_ext_feature_flags(wifi_radio_info_t *radio,
 
     ext_features = nla_data(tb);
     len = nla_len(tb);
-
+    wifi_hal_dbg_print("%s:%d: ifname: %s ext_features len=%d features: \n", __func__, __LINE__, radio->name, len);
+    for (int i = 0; i < len; i++) {
+        wifi_hal_dbg_print("%s:%d: ifname: %s\t\t%02x\n", __func__, __LINE__, radio->name, ext_features[i]);
+    }
     if (ext_feature_isset(ext_features, len, NL80211_EXT_FEATURE_VHT_IBSS)) {
         capa->flags |= WPA_DRIVER_FLAGS_VHT_IBSS;
     }
@@ -5332,7 +5335,10 @@ static void wiphy_info_ext_feature_flags(wifi_radio_info_t *radio,
 
     if (ext_feature_isset(ext_features, len,
                   NL80211_EXT_FEATURE_BEACON_PROTECTION)) {
+        wifi_hal_dbg_print("%s:%d: ifname: %s NL80211_EXT_FEATURE_BEACON_PROTECTION is presented\n", __func__, __LINE__, radio->name);
         capa->flags |= WPA_DRIVER_FLAGS_BEACON_PROTECTION;
+    } else {
+        wifi_hal_dbg_print("%s:%d: ifname: %s NL80211_EXT_FEATURE_BEACON_PROTECTION is NOT presented\n", __func__, __LINE__, radio->name);
     }
 
     if (ext_feature_isset(ext_features, len,
@@ -17191,9 +17197,9 @@ int     wifi_drv_set_key(const char *ifname, void *priv, enum wpa_alg alg,
     vap = &interface->vap_info;
 
     wifi_hal_dbg_print("%s:%d: ifname:%s vap_index:%d\n", __func__, __LINE__, interface->name, vap->vap_index);
-    //wifi_hal_dbg_print("%s:%d: ifname: %s\n", __func__, __LINE__, interface->name);
-    //wifi_hal_dbg_print("%s:%d: key Info: index:%d length:%d alg:%s\n", __func__, __LINE__, key_idx, key_len, wpa_alg_to_string(alg));
-    //my_print_hex_dump(key_len, key);
+    wifi_hal_dbg_print("%s:%d: ifname: %s\n", __func__, __LINE__, interface->name);
+    wifi_hal_dbg_print("%s:%d: key Info: index:%d length:%ld alg:%s\n", __func__, __LINE__, params->key_idx, params->key_len, wpa_alg_to_string(params->alg));
+    // my_print_hex_dump(key_len, key);
 
 #if HOSTAPD_VERSION < 210 //2.10
     if (alg == WPA_ALG_NONE) {

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -492,6 +492,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef BANANA_PI_PORT // for reference device platforms
@@ -526,6 +527,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef TCXB7_PORT // for Broadcom based platforms
@@ -560,6 +562,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef VNTXER5_PORT // for Qualcomm based platforms
@@ -594,6 +597,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef TARGET_GEMINI7_2
@@ -628,6 +632,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif 
 
 #ifdef TCXB8_PORT // for Broadcom based platforms
@@ -662,6 +667,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 
@@ -697,6 +703,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef XB10_PORT // for Broadcom based platforms
@@ -736,6 +743,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef SCXER10_PORT // for Broadcom based platforms
@@ -770,6 +778,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef SCXF10_PORT // for Broadcom based platforms
@@ -804,6 +813,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
  
 #ifdef CMXB7_PORT
@@ -838,6 +848,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef XLE_PORT // for Broadcom XLE
@@ -872,6 +883,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 
 #ifdef SKYSR213_PORT // for Broadcom HUB6
@@ -906,6 +918,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
 #ifdef RDKB_ONE_WIFI_PROD // for Broadcom based platforms
     "rdkb",
@@ -939,6 +952,7 @@ const wifi_driver_info_t  driver_info = {
     platform_set_dfs,
     platform_get_radio_caps,
     platform_get_reg_domain,
+    platform_set_beacon_prot,
 #endif
     
 };
@@ -4517,6 +4531,11 @@ platform_get_radio_caps_t get_platform_get_radio_caps_fn()
 platform_get_RegDomain_t get_platform_get_RegDomain_fn()
 {
     return driver_info.platform_get_RegDomain_fn;
+}
+
+platform_set_beacon_prot_t get_platform_set_beacon_prot_fn()
+{
+    return driver_info.platform_set_beacon_prot_fn;
 }
 
 bool lsmod_by_name(const char *name)

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -719,6 +719,7 @@ typedef int    (* platform_get_radio_phytemperature_t)(wifi_radio_index_t index,
 typedef int    (* platform_set_dfs_t)(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam);
 typedef int    (* platform_get_radio_caps_t)(wifi_radio_index_t index);
 typedef int    (* platform_get_RegDomain_t)(wifi_radio_index_t index, uint *reg_domain);
+typedef int    (* platform_set_beacon_prot_t)(uint apIndex, bool enabled);
 
 int wifi_hal_parse_rrm_beacon_rep(wifi_interface_info_t *interface, char *buff,
         size_t len, struct rrm_measurement_beacon_report *meas_rep);
@@ -807,6 +808,7 @@ typedef struct {
     platform_set_dfs_t                platform_set_dfs_fn;
     platform_get_radio_caps_t         platform_get_radio_caps_fn;
     platform_get_RegDomain_t platform_get_RegDomain_fn;
+    platform_set_beacon_prot_t platform_set_beacon_prot_fn;
 } wifi_driver_info_t;
 
 typedef enum bm_sta_rssi_type {
@@ -1312,6 +1314,7 @@ extern int platform_get_sta_measurements(void *priv, const u8 *sta_addr, struct 
 #endif
 extern int platform_set_dfs(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam);
 extern int platform_get_reg_domain(wifi_radio_index_t radioIndex, UINT *reg_domain);
+extern int platform_set_beacon_prot(uint apIndex, bool isEnabled);
 
 #if defined(VNTXER5_PORT)
 INT platform_create_interface_attributes(struct nl_msg **msg_ptr, wifi_radio_info_t *radio,
@@ -1367,6 +1370,7 @@ platform_set_offload_mode_t         get_platform_set_offload_mode_fn();
 platform_set_dfs_t                  get_platform_dfs_set_fn();
 platform_get_radio_caps_t           get_platform_get_radio_caps_fn();
 platform_get_RegDomain_t get_platform_get_RegDomain_fn();
+platform_set_beacon_prot_t get_platform_set_beacon_prot_fn();
 
 INT wifi_hal_wps_event(wifi_wps_event_t data);
 INT wifi_hal_get_default_wps_pin(char *pin);


### PR DESCRIPTION
Reason for change: WPA3 security requires to have the properly working Beacon Protection mechanism. So, in case the MFP is Optional or Disabled, we should enable the Beacon Protection.

WPA_DRIVER_FLAGS_BEACON_PROTECTION flag required and it's enabled for certain projects for 2.4 and 5 GHz VAPs, but for 6 GHz it should always be enabled (but
    let me know if you have objections)

Also, to be able to set default BIGTK (Beacon Integrity Group Temporal Key) key, wifi HAL should implement new API for setting such keys (see this comment:
https://github.com/rdkcentral/rdk-wifi-hal/pull/648#issuecomment-4171294579)

Test Procedure:

If Device.WiFi.AccessPoint.x.Security.MFPConfig is set to Optional or Required the Beacon Frame protection should be enabled Otherwise, disabled.

To check if enabled:
1. Check that Beacon frames contain Management MIC IE
2. Check that Beacons and Probe Responses has Extended Capabilities Beacon Protection Enabled flag set to 1

Risks: High
Priority: P1