### PR TITLE
XB10-2247 : Wi-Fi 7 RSN IE Group Cipher suite and Group Management Cipher Suite

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -724,7 +724,11 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
             case wifi_security_mode_wpa3_transition:
             case wifi_security_mode_wpa3_enterprise:
             case wifi_security_mode_enhanced_open:
-                conf->wpa_pairwise |= (conf->disable_11be ? 0 : WPA_CIPHER_GCMP_256);
+                if (!conf->disable_11be) {
+                    conf->wpa_pairwise |= WPA_CIPHER_GCMP_256;
+                    conf->group_cipher = WPA_CIPHER_GCMP_256;
+                    conf->group_mgmt_cipher = WPA_CIPHER_BIP_GMAC_256;
+                }
                 break;
             case wifi_security_mode_wpa3_compatibility:
                 /* GCMP-256 is advertised via rsn_pairwise_rsno_2 in RSNO2 IE only;

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -721,10 +721,23 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
             conf->wpa_pairwise = WPA_CIPHER_CCMP;
             switch (sec->mode) {
             case wifi_security_mode_wpa3_personal:
-            case wifi_security_mode_wpa3_transition:
             case wifi_security_mode_wpa3_enterprise:
             case wifi_security_mode_enhanced_open:
-                conf->wpa_pairwise |= (conf->disable_11be ? 0 : WPA_CIPHER_GCMP_256);
+                if (!conf->disable_11be) {
+                    conf->wpa_pairwise |= WPA_CIPHER_GCMP_256;
+                    conf->group_cipher = WPA_CIPHER_GCMP_256;
+                    conf->group_mgmt_cipher = WPA_CIPHER_BIP_GMAC_256;
+                } else {
+                    conf->group_cipher = WPA_CIPHER_CCMP;
+                    conf->group_mgmt_cipher = WPA_CIPHER_AES_128_CMAC;
+                }
+                break;
+            case wifi_security_mode_wpa3_transition:
+                if (!conf->disable_11be) {
+                    conf->wpa_pairwise |= WPA_CIPHER_GCMP_256;
+                }
+                conf->group_cipher = WPA_CIPHER_CCMP;
+                conf->group_mgmt_cipher = WPA_CIPHER_AES_128_CMAC;
                 break;
             case wifi_security_mode_wpa3_compatibility:
                 /* GCMP-256 is advertised via rsn_pairwise_rsno_2 in RSNO2 IE only;


### PR DESCRIPTION
Reason for change: group and management group ciphers should be WPA_CIPHER_GCMP_256 accoring to WFA Wi-Fi 7 certification plan

Test procedure:
1. Configure Wi-Fi 7
2. Make sure that WPA3 capable encryption mode is active (except WPA3-Compatibility)
3. Make sure that Beacon and Probe response contain RSN IE with Group Cipher Cipher Suite equal to 00-0F-AC-09 and Group Management Cipher Suite equal to 00-0F-AC-12

Risk: Medium
Priority: Low