### PR TITLE
RDKB-63816 2g/5g LnF status is down at driver level after reboot

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -767,7 +767,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
     conf->rdkb_eap_request_timeout = sec->eap_req_timeout;
     conf->rdkb_eap_request_retries = sec->eap_req_retries;
 #endif
-    if (conf->ieee802_1x || is_open_sec_radius_auth(sec) || conf->mdu) {
+    if (conf->ieee802_1x || is_open_sec_radius_auth(sec) || (conf->mdu && sec->repurposed_radius.ip[0] != '\0')) {
         wifi_radius_settings_t *radius_cfg;
         if (conf->mdu) {
             radius_cfg = &sec->repurposed_radius;


### PR DESCRIPTION
RDKB-63816 2g/5g LnF status is down at driver level after reboot

Reason for change:

lnf_psk_* VAP's with MDU enabled fail initial wifi_hal_createVAP, when repurposed RADIUS IP is empty (waiting for Hotspot RFC to populate it)

Test Procedure:

1. Load the device with image having the fix

2. Push the Hotspot Blob and the Managed Wi-Fi Blob from postman to the CPE.

3. Verify the bridge creation for secure hotspot VAPs and lnf_psk_* VAPs

4. Check if wl0.4, wl1.4, wl0.6, wl1.6 VAP's are UP at the driver level as well as TR-181 level

5. Trigger the reboot

6. Wait for uptime of around approximately 5 minutes and verify the brctl show output in step 3 and check if wl0.4, wl1.4, wl0.6, wl1.6 VAP's are UP at the driver level as well as TR-181 level

Risks: Low
Priority: P1

Signed-off-by: Signed-off-by: Sake Victor Daniel (victordaniel_sake@comcast.com)