### PR TITLE
RDKB-64205 Ignite Hotspot Connection Failure (#653)

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -2505,7 +2505,7 @@ INT wifi_hal_startScan(wifi_radio_index_t index, wifi_neighborScanMode_t scan_mo
     }
 #endif //FEATURE_SINGLE_PHY
 
-    return (nl80211_start_scan(interface, NL80211_SCAN_FLAG_COLOCATED_6GHZ, freq_num, freq_list, dwell_time, 1, ssid_list) == 0) ? RETURN_OK:RETURN_ERR;
+    return (nl80211_start_scan(interface, NL80211_SCAN_FLAG_COLOCATED_6GHZ | NL80211_SCAN_FLAG_FLUSH, freq_num, freq_list, dwell_time, 1, ssid_list) == 0) ? RETURN_OK:RETURN_ERR;
 }
 
 /*****************************/


### PR DESCRIPTION
RDKB-64205 Ignite Hotspot Connection Failure

Reason for change: Observed stale entries present in the scan results. Added "NL80211_SCAN_FLAG_FLUSH"
to flush the previous scan entries.
Test Procedure: Not observed stale entries in the scan results.
Risks: Low
Signed-off-by: Dharmalakshmi Annamalai [Dharmalakshmi_Annamalai@comcast.com]