### PR TITLE
RDKB-58489: Support AES+GCMP256 encryption mode incoming configuratio…

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -721,18 +721,27 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
 
         case wifi_encryption_aes:
             conf->wpa_pairwise = WPA_CIPHER_CCMP;
+            break;
+
 #ifdef CONFIG_IEEE80211BE
+        case wifi_encryption_aes_gcmp256:
+            conf->wpa_pairwise = WPA_CIPHER_CCMP;
             switch (sec->mode) {
             case wifi_security_mode_wpa3_personal:
             case wifi_security_mode_wpa3_transition:
             case wifi_security_mode_wpa3_enterprise:
+            case wifi_security_mode_enhanced_open:
                 conf->wpa_pairwise |= (conf->disable_11be ? 0 : WPA_CIPHER_GCMP_256);
+                break;
+            case wifi_security_mode_wpa3_compatibility:
+                /* GCMP-256 is advertised via rsn_pairwise_rsno_2 in RSNO2 IE only;
+                 * must not appear in the main RSN IE pairwise list */
                 break;
             default:
                 break;
             }
-#endif /* CONFIG_IEEE80211BE */
             break;
+#endif /* CONFIG_IEEE80211BE */
 
         case wifi_encryption_aes_tkip:
             conf->wpa_pairwise = wpa_parse_cipher("TKIP CCMP");

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -2503,37 +2503,14 @@ int get_security_encryption_mode_str_from_int(wifi_encryption_method_t encryptio
         break;
 
     case wifi_encryption_aes:
-#ifdef CONFIG_IEEE80211BE
-        {
-            const wifi_interface_info_t * const interface = get_interface_by_vap_index(vap_index);
-            if (NULL == interface) {
-                wifi_hal_error_print("%s:%d NULL pointer!\n", __FUNCTION__, __LINE__);
-                return RETURN_ERR;
-            }
-            unsigned char has_gcmp256 = 0;
-            if (interface->vap_info.vap_mode == wifi_vap_mode_ap) {
-                const wifi_security_modes_t security_mode = interface->vap_info.u.bss_info.security.mode;
-                switch (security_mode) {
-                case wifi_security_mode_wpa3_personal:
-                case wifi_security_mode_wpa3_transition:
-                case wifi_security_mode_wpa3_enterprise:
-                case wifi_security_mode_wpa3_compatibility:
-                    has_gcmp256 = !interface->u.ap.conf.disable_11be;
-                    break;
-                default:
-                    break;
-                }
-            }
-            if (has_gcmp256) {
-                strcpy(encryption_mode_str, "aes+gcmp256");
-            } else {
-                strcpy(encryption_mode_str, "aes");
-            }
-        }
-#else
         strcpy(encryption_mode_str, "aes");
-#endif /* CONFIG_IEEE80211BE */
         break;
+
+#ifdef CONFIG_IEEE80211BE
+    case wifi_encryption_aes_gcmp256:
+        strcpy(encryption_mode_str, "aes+gcmp256");
+        break;
+#endif /* CONFIG_IEEE80211BE */
 
     case wifi_encryption_aes_tkip:
         strcpy(encryption_mode_str, "tkip+aes");

--- a/src/wifi_hal_rdk_util.c
+++ b/src/wifi_hal_rdk_util.c
@@ -390,6 +390,9 @@ int validate_wifi_interface_vap_info_params(wifi_vap_info_t *vap_info, char *msg
     case wifi_encryption_tkip:
     case wifi_encryption_aes:
     case wifi_encryption_aes_tkip:
+#ifdef CONFIG_IEEE80211BE
+    case wifi_encryption_aes_gcmp256:
+#endif /* CONFIG_IEEE80211BE */
         break;
     default:
         ret = RETURN_ERR;


### PR DESCRIPTION
…n (#632)

Reason for change: Making it possible to configure AES / AES+GCMP encryption method Test Procedure: dmcli eRT setv Device.WiFi.AccessPoint.2.Security.X_CISCO_COM_EncryptionMethod string "AES+GCMP" / "AES"
                dmcli eRT setv Device.WiFi.ApplyAccessPointSettings bool true

		Verify changes are reflected in beacon RSN IE

Risk: Medium
Priority: P1


(cherry picked from commit 301e7762cf53c00e8842e2712438318ab86e747a)