### PR TITLE
RDKB-64619 Fix PR0270(BPI connectivity) failure on first iteration

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -4423,7 +4423,7 @@ static void platform_get_radio_caps_6g(wifi_radio_info_t *radio, wifi_interface_
         radio->driver_data.extended_capa[2] &= 0xF7;
     }
     for (int i = 0; i < iface->num_hw_features; i++) {
-#if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || \
+#if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT) || \
     defined(SCXF10_PORT)
         memcpy(iface->hw_features[i].he_capab[IEEE80211_MODE_AP].mac_cap, he_mac_cap,
             sizeof(he_mac_cap));
@@ -4432,7 +4432,7 @@ static void platform_get_radio_caps_6g(wifi_radio_info_t *radio, wifi_interface_
         memcpy(iface->hw_features[i].he_capab[IEEE80211_MODE_AP].mcs, he_mcs, sizeof(he_mcs));
         memcpy(iface->hw_features[i].he_capab[IEEE80211_MODE_AP].ppet, he_ppet, sizeof(he_ppet));
         iface->hw_features[i].he_capab[IEEE80211_MODE_AP].he_6ghz_capa = 0x06bd;
-#endif // TCXB7_PORT || TCXB8_PORT || XB10_PORT || SCXER10_PORT
+#endif // TCXB8_PORT || XB10_PORT || SCXER10_PORT
 
 // XER-10 uses old kernel that does not support EHT cap NL parameters
 #if defined(SCXER10_PORT)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -56,6 +56,7 @@
 #endif
 #include <linux/filter.h>
 #include <fcntl.h>
+#include <linux/sched.h>
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
 #include <sys/mman.h>
@@ -4017,6 +4018,22 @@ int get_vap_state(const char *ifname, short *flags)
     ifr.ifr_name[IFNAMSIZ - 1] = '\0';
     wifi_hal_dbg_print("%s:%d interface name = '%s'\n", __func__, __LINE__, ifr.ifr_name);
 
+#if defined(BANANA_PI_PORT)
+    int current_ns_fd = -1;
+    int target_ns_fd = -1;
+    int result = -1;
+    current_ns_fd = open("/proc/self/ns/net", O_RDONLY);
+
+    target_ns_fd = open("/var/run/netns/default", O_RDONLY);
+    if (current_ns_fd == -1 || target_ns_fd == -1) {
+        perror("Failed to open namespace handles");
+        goto cleanup;
+    }
+    if (setns(target_ns_fd, CLONE_NEWNET) != 0) {
+        perror("Failed to setns to default");
+        goto cleanup;
+    }
+#endif
     if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
         wifi_hal_error_print("%s %d socket error %s\n", __func__, __LINE__, strerror(errno));
         return -1;
@@ -4028,7 +4045,16 @@ int get_vap_state(const char *ifname, short *flags)
         wifi_hal_error_print("%s:%d ioctl failed: (%d) %s\n", __func__, __LINE__, res, strerror(errno));
     }
     close(fd);
-
+#if defined(BANANA_PI_PORT)
+cleanup:
+    if (current_ns_fd != -1) {
+        setns(current_ns_fd, CLONE_NEWNET);
+        close(current_ns_fd);
+    }
+    if (target_ns_fd != -1) {
+        close(target_ns_fd);
+    }
+#endif
     *flags = ifr.ifr_flags;
 
     return res;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -56,7 +56,9 @@
 #endif
 #include <linux/filter.h>
 #include <fcntl.h>
+#if defined(BANANA_PI_PORT)
 #include <linux/sched.h>
+#endif
 
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
 #include <sys/mman.h>
@@ -4012,7 +4014,7 @@ error:
 int get_vap_state(const char *ifname, short *flags)
 {
     struct ifreq ifr;
-    int fd, res;
+    int fd, res = -1;
 
     strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
     ifr.ifr_name[IFNAMSIZ - 1] = '\0';
@@ -4021,16 +4023,15 @@ int get_vap_state(const char *ifname, short *flags)
 #if defined(BANANA_PI_PORT)
     int current_ns_fd = -1;
     int target_ns_fd = -1;
-    int result = -1;
     current_ns_fd = open("/proc/self/ns/net", O_RDONLY);
 
     target_ns_fd = open("/var/run/netns/default", O_RDONLY);
     if (current_ns_fd == -1 || target_ns_fd == -1) {
-        perror("Failed to open namespace handles");
+        wifi_hal_error_print("%s:%d Failed to open namespace handles\n", __func__, __LINE__);
         goto cleanup;
     }
     if (setns(target_ns_fd, CLONE_NEWNET) != 0) {
-        perror("Failed to setns to default");
+        wifi_hal_error_print("%s:%d Failed to setns to default\n", __func__, __LINE__);
         goto cleanup;
     }
 #endif


### PR DESCRIPTION
Impacted Platforms:
All RDKB Platforms

Reason for change: Enter into proper namespace for iperf tests

Test Procedure: Run PR0270 testcase and check the status

Risks: None

Priority: P1

Signed-off-by:Pavithra_Sundaravadivel@comcast.com