### PR TITLE
DTMESH-729: Add PreCAC state mapping (#621)

### DIFF
--- a/platform/qualcomm/platform_ext.c
+++ b/platform/qualcomm/platform_ext.c
@@ -1595,10 +1595,12 @@ static void parse_iwcustom_buffer(const void *buf, unsigned int len)
                     iwp = data - IW_EV_POINT_OFF;
                     data += IW_EV_POINT_LEN - IW_EV_POINT_OFF;
                     switch (iwp->flags) {
+                    case IEEE80211_EV_PRECAC_STARTED:
                     case IEEE80211_EV_CAC_STARTED:
                         radio_channel_param.sub_event = WIFI_EVENT_RADAR_CAC_STARTED;
                         process_event_to_onewifi(ifname, radio_channel_param, data, iwp->length);
                         break;
+                    case IEEE80211_EV_PRECAC_COMPLETED:
                     case IEEE80211_EV_CAC_COMPLETED:
                         radio_channel_param.sub_event = WIFI_EVENT_RADAR_CAC_FINISHED;
                         process_event_to_onewifi(ifname, radio_channel_param, data, iwp->length);


### PR DESCRIPTION
Reason for change:
Expose the actual PreCAC status in the Wifi_Radio_State table.

Test Procedure:
1. Run `cfg80211tool wifi1 preCACEn 1`
2. Run `cfg80211tool wifi1 precac_start`
2. Verify that the channel state changes in Wifi_Radio_State

Risks: Low
Priority: P1