### PR TITLE
RDKB-64668 Fix crash in OneWifi in BPI during vap creation

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -56,7 +56,7 @@
 #endif
 #include <linux/filter.h>
 #include <fcntl.h>
-#if defined(BANANA_PI_PORT)
+#if defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 #include <linux/sched.h>
 #endif
 
@@ -4020,7 +4020,7 @@ int get_vap_state(const char *ifname, short *flags)
     ifr.ifr_name[IFNAMSIZ - 1] = '\0';
     wifi_hal_dbg_print("%s:%d interface name = '%s'\n", __func__, __LINE__, ifr.ifr_name);
 
-#if defined(BANANA_PI_PORT)
+#if defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
     int current_ns_fd = -1;
     int target_ns_fd = -1;
     current_ns_fd = open("/proc/self/ns/net", O_RDONLY);
@@ -4046,7 +4046,7 @@ int get_vap_state(const char *ifname, short *flags)
         wifi_hal_error_print("%s:%d ioctl failed: (%d) %s\n", __func__, __LINE__, res, strerror(errno));
     }
     close(fd);
-#if defined(BANANA_PI_PORT)
+#if defined(CONFIG_WIFI_EMULATOR_EXT_AGENT)
 cleanup:
     if (current_ns_fd != -1) {
         setns(current_ns_fd, CLONE_NEWNET);


### PR DESCRIPTION
Impacted Platforms:
All RDKB Platforms

Reason for change: To have the netns switch changes only
                   banana-pi with cci

Test Procedure: Run the onewifi on BPI and check for crash

Risks: None

Priority: P1

Signed-off-by:Pavithra_Sundaravadivel@comcast.com