### PR TITLE
XB10-2634: Fix mld_ap condition to check mld_enable before link assignment

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -4896,8 +4896,6 @@ void platform_bss_enable(char* ifname, bool enable)
 #ifdef CONFIG_IEEE80211BE
 
 static struct hostapd_mld g_mlo_mld[MLD_UNIT_COUNT] = {0};
-static struct hostapd_mld g_slo_mld[MAX_VAP] = {0};
-
 extern void hostapd_bss_link_deinit(struct hostapd_data *hapd);
 
 /*
@@ -5091,6 +5089,7 @@ static unsigned char platform_get_link_id_for_radio_index(unsigned int radio_ind
     return res;
 }
 
+#if 0
 static unsigned char platform_iface_is_mlo_ap(const char *iface)
 {
     char name[32 + sizeof("_bss_mlo_mode")];
@@ -5104,6 +5103,7 @@ static unsigned char platform_iface_is_mlo_ap(const char *iface)
     wifi_hal_dbg_print("%s:%d mld_ap:%u for the iface:%s\n", __func__, __LINE__, res, iface);
     return res;
 }
+#endif
 
 static void nvram_update_wl_mlo_apply(const char *iface, unsigned char mlo_apply, int *nvram_changed)
 {
@@ -5203,23 +5203,6 @@ static struct hostapd_mld *get_mlo_mld(unsigned char mld_unit, char *mac)
     return &g_mlo_mld[mld_unit];
 }
 
-static struct hostapd_mld *get_slo_mld(wifi_vap_index_t vap_index, char *mac)
-{
-    if (vap_index >= MAX_VAP) {
-        wifi_hal_error_print("%s:%d: vap_index:%d out of range (max vap_index: %d)!\n", __func__,
-            __LINE__, vap_index, MAX_VAP - 1);
-        return NULL;
-    }
-
-    if (g_slo_mld[vap_index].name[0] == '\0') {
-        /* Not initialized yet - Initializing it during the first usage */
-        dl_list_init(&g_slo_mld[vap_index].links);
-        snprintf(g_slo_mld[vap_index].name, sizeof(g_slo_mld[vap_index].name), "slo_mld_id_%u",
-            vap_index);
-    }
-    memcpy(g_slo_mld[vap_index].mld_addr, mac, ETH_ALEN);
-    return &g_slo_mld[vap_index];
-}
 
 /**
  * @brief Add MLO link and reorganize links to be main link (link_id 0) first_bss
@@ -5327,29 +5310,23 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
 
     old_mld_link_id = hapd->mld_link_id;
     hapd->mld_link_id = platform_get_link_id_for_radio_index(vap->radio_index, vap->vap_index);
-    mld_ap = vap->u.bss_info.enabled && (!conf->disable_11be && (hapd->mld_link_id < MAX_NUM_MLD_LINKS));
-    nvram_update_wl_bss_mlo_mode(conf->iface, mld_ap ? mld_conf->mld_enable : 0, &nvram_changed);
+    mld_ap = vap->u.bss_info.enabled && (!conf->disable_11be && mld_conf->mld_enable &&
+        (hapd->mld_link_id < MAX_NUM_MLD_LINKS));
+    nvram_update_wl_bss_mlo_mode(conf->iface, mld_ap, &nvram_changed);
     if (nvram_changed) {
         wifi_hal_info_print("%s:%d nvram was changed => nvram_commit()\n", __func__, __LINE__);
         nvram_commit();
     }
 
     if (mld_ap) {
-        unsigned char is_mlo_ap;
-
         conf->mld_ap = mld_ap;
-        is_mlo_ap = platform_iface_is_mlo_ap(conf->iface);
-        if (is_mlo_ap) {
-            set_mld_unit(conf, mld_conf->mld_id);
-            new_mld = get_mlo_mld(get_mld_unit(conf), mld_conf->mld_addr);
-            /*
-             * NOTE: For MLO, we need to enable okc=1, or disable_pmksa_caching=1, otherwise there
-             * will be problems with PMKID for link AP
-             */
-            conf->okc = 1;
-        } else {
-            new_mld = get_slo_mld(vap->vap_index, hapd->own_addr);
-        }
+        set_mld_unit(conf, mld_conf->mld_id);
+        new_mld = get_mlo_mld(get_mld_unit(conf), mld_conf->mld_addr);
+        /*
+            * NOTE: For MLO, we need to enable okc=1, or disable_pmksa_caching=1, otherwise there
+            * will be problems with PMKID for link AP
+            */
+        conf->okc = 1;
         if (hapd->mld != new_mld || old_mld_link_id != hapd->mld_link_id) {
             if (hapd->mld)
                 mlo_remove_link(hapd);
@@ -5357,9 +5334,9 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
             mlo_add_link(hapd);
         }
 
-        wifi_hal_dbg_print("%s:%d: Setup of first (%d) link (%u) BSS of %s %s for VAP %s\n",
+        wifi_hal_dbg_print("%s:%d: Setup of first (%d) link (%u) BSS of MLO %s for VAP %s\n",
             __func__, __LINE__, hostapd_mld_is_first_bss(hapd), hapd->mld_link_id,
-            (is_mlo_ap ? "MLO" : "SLO"), hapd->mld->name, vap->vap_name);
+            hapd->mld->name, vap->vap_name);
     } else {
         if (hapd->mld) {
             mlo_remove_link(hapd);


### PR DESCRIPTION
Reason for change: Multi-Link IE is present in mgmt frames after disabling MLO 
Test Procedure: Disable MLO by disabling the main link
		Check beacon on all disabled mlo VAPS
Risks: Low
Priority: P1