### PR TITLE
RDKBACCL-1651 : Observing build issues when we disable generic_mlo distro in BPI RDKB builds

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -866,7 +866,7 @@ INT wifi_setApManagementFramePowerControl(INT apIndex, INT dBm)
     return 0;
 }
 
-#ifdef CONFIG_IEEE80211BE
+#if defined(CONFIG_IEEE80211BE) && defined(CONFIG_MLO)
 int nl80211_drv_mlo_msg(struct nl_msg *msg, struct nl_msg **msg_mlo, void *priv,
     struct wpa_driver_ap_params *params)
 {
@@ -884,7 +884,9 @@ int nl80211_send_mlo_msg(struct nl_msg *msg)
 
     return 0;
 }
+#endif /* CONFIG_IEEE80211BE && CONFIG_MLO */
 
+#if defined(CONFIG_IEEE80211BE)
 void wifi_drv_get_phy_eht_cap_mac(struct eht_capabilities *eht_capab, struct nlattr **tb)
 {
     if (tb[NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC] &&
@@ -895,7 +897,9 @@ void wifi_drv_get_phy_eht_cap_mac(struct eht_capabilities *eht_capab, struct nla
         eht_capab->mac_cap = WPA_GET_LE16(pos);
     }
 }
+#endif /* CONFIG_IEEE80211BE */
 
+#if defined(CONFIG_IEEE80211BE) && defined(CONFIG_MLO)
 static struct hostapd_mld *find_mld(struct wifi_interface_info_t *interface)
 {
     struct hostapd_mld *mld_it = NULL;
@@ -1037,5 +1041,5 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
 #endif
     return 0;
 }
-#endif /* CONFIG_IEEE80211BE */
+#endif /* CONFIG_IEEE80211BE && CONFIG_MLO */
 


### PR DESCRIPTION
Reason for change: Observed below errors,
../git/src/../platform/banana-pi/platform.c:860:44: error: 'wifi_hal_priv_t' has no member named 'mld_count'
|   860 |     for (unsigned int i = 0; i < g_wifi_hal.mld_count; ++i) {
|       |                                            ^
| ../git/src/../platform/banana-pi/platform.c:861:28: error: 'wifi_hal_priv_t' has no member named 'mld_array'
|   861 |         mld_it = g_wifi_hal.mld_array[i];
|       |                            ^
| ../git/src/../platform/banana-pi/platform.c: In function 'alloc_mld':
| ../git/src/../platform/banana-pi/platform.c:909:39: error: 'wifi_hal_priv_t' has no member named 'mld_array'
|   909 |     new_mld_array = realloc(g_wifi_hal.mld_array,
|       |                                       ^
| ../git/src/../platform/banana-pi/platform.c:910:20: error: 'wifi_hal_priv_t' has no member named 'mld_count'
|   910 |         (g_wifi_hal.mld_count + 1) * sizeof(struct hostapd_mld *));
|       |                    ^
| ../git/src/../platform/banana-pi/platform.c:924:29: error: 'wifi_hal_priv_t' has no member named 'mld_count'
|   924 |     new_mld_array[g_wifi_hal.mld_count] = mld;
|       |                             ^
| ../git/src/../platform/banana-pi/platform.c:926:15: error: 'wifi_hal_priv_t' has no member named 'mld_array'
|   926 |     g_wifi_hal.mld_array = new_mld_array;
|       |               ^
| ../git/src/../platform/banana-pi/platform.c:928:15: error: 'wifi_hal_priv_t' has no member named 'mld_count'
|   928 |     g_wifi_hal.mld_count++;
Test Procedure:  Build successful
Risks: None