### PR TITLE
RDKBDEV-3370: [Easymesh] Fix rdk-wifi-hal issues found during easymes…

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -1131,6 +1131,10 @@ int update_hostap_bss(wifi_interface_info_t *interface)
     init_hostap_bss(interface);
 
     vap = &interface->vap_info;
+    /* Initialize interface->bridge from vap configuration early, so it's available for all flows */
+    if (vap->bridge_name[0] != '\0') {
+        strncpy(interface->bridge, vap->bridge_name, sizeof(interface->bridge));
+    }
     radio = get_radio_by_rdk_index(vap->radio_index);
     op_param = &radio->oper_param;
 
@@ -1178,8 +1182,15 @@ int update_hostap_bss(wifi_interface_info_t *interface)
     if (is_backhaul_interface(interface)) {
         // For backhaul VAPs, set multi-ap flag to 1
         conf->multi_ap = BACKHAUL_BSS;
-        wifi_hal_info_print("%s:%d: Enabled multi_ap:%d for interface:%s\n", __func__,
-            __LINE__, conf->multi_ap, interface->name);
+
+        /* Enable WDS mode for backhaul STAs to create per-STA virtual interfaces
+         * This allows 4-address frames and proper bridge forwarding
+         */
+        conf->wds_sta = 1;
+        strncpy(conf->wds_bridge, interface->bridge, sizeof(conf->wds_bridge));
+
+        wifi_hal_info_print("%s:%d: Enabled multi_ap:%d for interface:%s, wds_bridge:%s\n",
+            __func__, __LINE__, conf->multi_ap, interface->name, conf->wds_bridge);
     }
 #endif // EASY_MESH_NODE
 

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -12434,6 +12434,26 @@ int wifi_drv_set_wds_sta(void *priv, const u8 *addr, int aid, int val, const cha
         os_strlcpy(ifname_wds, name, IFNAMSIZ + 1);
     }
 
+#ifdef CONFIG_VENDOR_MXL
+    /* For WDS STA creation (val=1), send multi_ap mode to Wave driver BEFORE creating interface.
+     * The Wave driver needs multi_ap_mode set in its PDB before it can create WDS interfaces.
+     * This fixes the "Wrong multi_ap_mode: 0" error when backhaul STA connects.
+     */
+    if (val && interface->u.ap.conf.multi_ap) {
+        wifi_hal_info_print("%s:%d: Sending multi_ap=%d to driver before WDS STA creation for %s\r\n",
+            __func__, __LINE__, interface->u.ap.conf.multi_ap, interface->name);
+
+        ret = wifi_drv_vendor_cmd(interface, OUI_LTQ, LTQ_NL80211_VENDOR_SUBCMD_SET_MESH_MODE,
+                                 (u8 *)&interface->u.ap.conf.multi_ap,
+                                 sizeof(interface->u.ap.conf.multi_ap),
+                                 NESTED_ATTR_NOT_USED, NULL);
+        if (ret < 0) {
+            wifi_hal_error_print("%s:%d: Failed to set multi_ap mode before WDS STA creation: %d\r\n",
+                __func__, __LINE__, ret);
+        }
+    }
+#endif /* CONFIG_VENDOR_MXL */
+
     wifi_hal_info_print("%s:%d:nl80211: Set WDS STA addr=" MACSTR " aid=%d val=%d name=%s ifindex:%d\r\n",
         __func__, __LINE__, MAC2STR(addr), aid, val, name, if_nametoindex(name));
     if (val) {
@@ -12472,7 +12492,7 @@ int wifi_drv_set_wds_sta(void *priv, const u8 *addr, int aid, int val, const cha
         }
         return nl80211_set_sta_vlan(radio, interface, addr, name, 0);
     } else {
-        if (bridge_ifname && (nl80211_remove_from_bridge(bridge_ifname) != RETURN_OK)) {
+        if (strlen(interface->name) && (nl80211_remove_from_bridge(name) != RETURN_OK)) {
             wifi_hal_error_print("%s:%d: nl80211: Failed to remove interface %s "
                 " from bridge %s: %s", __func__, __LINE__, name, bridge_ifname, strerror(errno));
             return RETURN_ERR;


### PR DESCRIPTION
…… (#559)

RDKBDEV-3370: [Easymesh] Fix rdk-wifi-hal issues found during easymesh onboarding

Reason for change: in order to perform proper easymesh onboarding correctly wifi-hal should enable WDS mode for backhaul STAs to create per-STA virtual interfaces This allows 4-address frames and proper bridge forwarding Also initialize interface->bridge from vap configuration early, so it's available for all flows.

Test procedure:
1) VAPs configured correctly;
2) there is no "Wrong multi_ap_mode: 0" error when backhaul STA
   connects;

Priority: P2
Risks: Low
Signed-off-by: Vladislav Safonov <vsafonov@maxlinear.com>

* Fixed condition check before nl80211_remove_from_bridge