### PR TITLE
RDKB-64893: Port BCAWLAN-290139 and make changes in RDKB_ONE_WIFI_PROD caused by RDKB-61540

### DIFF
--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -331,29 +331,29 @@ static wifi_interface_name_idex_map_t static_interface_index_map[] = {
 #endif
 
 #ifdef RDKB_ONE_WIFI_PROD
-{0, 0,  "wl0.1",   "brlan0",   100,   0,      "private_ssid_2g"},
-{2, 1,  "wl1.1",   "brlan0",   100,   1,      "private_ssid_5g"},
-{0, 0,  "wl0.2",   "brlan1",   101,   2,      "iot_ssid_2g"},
-{2, 1,  "wl1.2",   "brlan1",   101,   3,      "iot_ssid_5g"},
-{0, 0,  "wl0.3",   "brlan2",   102,   4,      "hotspot_open_2g"},
-{2, 1,  "wl1.3",   "brlan3",   103,   5,      "hotspot_open_5g"},
-{0, 0,  "wl0.4",   "br106",    106,   6,      "lnf_psk_2g"},
-{2, 1,  "wl1.4",   "br106",    106,   7,      "lnf_psk_5g"},
-{0, 0,  "wl0.5",   "brlan4",   104,   8,      "hotspot_secure_2g"},
-{2, 1,  "wl1.5",   "brlan5",   105,   9,      "hotspot_secure_5g"},
-{0, 0,  "wl0.6",   "br106",    106,   10,     "lnf_radius_2g"},
-{2, 1,  "wl1.6",   "br106",    106,   11,     "lnf_radius_5g"},
-{0, 0,  "wl0.7",   "brlan112", 112,   12,     "mesh_backhaul_2g"},
-{2, 1,  "wl1.7",   "brlan113", 113,   13,     "mesh_backhaul_5g"},
-{0, 0,  "wl0",     "",         0,     14,     "mesh_sta_2g"},
-{2, 1,  "wl1",     "",         0,     15,     "mesh_sta_5g"},
+{0, 0,  "wl0.1",   "",  "brlan0",   100,   0,      "private_ssid_2g"},
+{2, 1,  "wl1.1",   "",  "brlan0",   100,   1,      "private_ssid_5g"},
+{0, 0,  "wl0.2",   "",  "brlan1",   101,   2,      "iot_ssid_2g"},
+{2, 1,  "wl1.2",   "",  "brlan1",   101,   3,      "iot_ssid_5g"},
+{0, 0,  "wl0.3",   "",  "brlan2",   102,   4,      "hotspot_open_2g"},
+{2, 1,  "wl1.3",   "",  "brlan3",   103,   5,      "hotspot_open_5g"},
+{0, 0,  "wl0.4",   "",  "br106",    106,   6,      "lnf_psk_2g"},
+{2, 1,  "wl1.4",   "",  "br106",    106,   7,      "lnf_psk_5g"},
+{0, 0,  "wl0.5",   "",  "brlan4",   104,   8,      "hotspot_secure_2g"},
+{2, 1,  "wl1.5",   "",  "brlan5",   105,   9,      "hotspot_secure_5g"},
+{0, 0,  "wl0.6",   "",  "br106",    106,   10,     "lnf_radius_2g"},
+{2, 1,  "wl1.6",   "",  "br106",    106,   11,     "lnf_radius_5g"},
+{0, 0,  "wl0.7",   "",  "brlan112", 112,   12,     "mesh_backhaul_2g"},
+{2, 1,  "wl1.7",   "",  "brlan113", 113,   13,     "mesh_backhaul_5g"},
+{0, 0,  "wl0",     "",  "",         0,     14,     "mesh_sta_2g"},
+{2, 1,  "wl1",     "",  "",         0,     15,     "mesh_sta_5g"},
 #ifdef RDKB_ONE_WIFI_3_RADIO_SUPPORT
-{1, 2,  "wl2.1",   "brlan0",   100,   16,     "private_ssid_6g"},
-{1, 2,  "wl2.2",   "brlan1",   101,   17,     "iot_ssid_6g"},
-{1, 2,  "wl2.3",   "bropen6g", 2253,  18,     "hotspot_open_6g"},
-{1, 2,  "wl2.5",   "brsecure6g",2256, 20,     "hotspot_secure_6g"},
-{1, 2,  "wl2.7",   "brlan114", 114,   22,     "mesh_backhaul_6g"},
-{1, 2,  "wl2",     "",         0,     23,     "mesh_sta_6g"},
+{1, 2,  "wl2.1",   "",  "brlan0",   100,   16,     "private_ssid_6g"},
+{1, 2,  "wl2.2",   "",  "brlan1",   101,   17,     "iot_ssid_6g"},
+{1, 2,  "wl2.3",   "",  "bropen6g", 2253,  18,     "hotspot_open_6g"},
+{1, 2,  "wl2.5",   "",  "brsecure6g",2256, 20,     "hotspot_secure_6g"},
+{1, 2,  "wl2.7",   "",  "brlan114", 114,   22,     "mesh_backhaul_6g"},
+{1, 2,  "wl2",     "",  "",         0,     23,     "mesh_sta_6g"},
 #endif /* RDKB_ONE_WIFI_3_RADIO_SUPPORT */
 #endif /* RDKB_ONE_WIFI_PROD */
   
@@ -3080,51 +3080,6 @@ static int find_country_code_match(const char *const cc[], const char *const cou
 }
 #ifdef RDKB_ONE_WIFI_PROD
 
-static bool parse_wiphy_band_mapping(FILE *fp, int *pcie_index) {
-    char line[LINE_MAX];
-    int curr_phy_idx;
-    bool in_wiphy = false;
-
-    while (fgets(line, sizeof(line), fp)) {
-        // Detect start of Wiphy
-        char *wiphy_ptr = strstr(line, "Wiphy ");
-        if (wiphy_ptr == line) {
-            // Example: "Wiphy phy2"
-            if (sscanf(line, "Wiphy phy%d", &curr_phy_idx) == 1) {
-                in_wiphy = true;
-            }
-            continue;
-        }
-        // If in a Wiphy stanza, look for "Band N:"
-        if (in_wiphy) {
-            // Skip leading spaces
-            char *trimmed = line;
-            while (*trimmed == ' ' || *trimmed == '\t') ++trimmed;
-
-            // Look for "Band N:"
-            if (strncmp(trimmed, "Band ", 5) == 0) {
-                int band_num;
-                if (sscanf(trimmed, "Band %d:", &band_num) == 1) {
-                    --band_num; /* The iw tool prints nl_band->nla_type + 1 */
-                    if (curr_phy_idx < MAX_NUM_RADIOS &&
-                        ((band_num < NUM_NL80211_BANDS) && (band_num >= 0)))
-                        pcie_index[curr_phy_idx] = ((band_num == NL80211_BAND_6GHZ) ? 2 : band_num);
-                    else {
-                        wifi_hal_error_print("%s:%d: Recieved phy_index:%d Num Radios:%d \
-                            band_num:%d NUM_NL80211_BANDS:%d\n", __func__, __LINE__, \
-                            curr_phy_idx, MAX_NUM_RADIOS, band_num, NUM_NL80211_BANDS);
-                        return false;
-                    }
-                } else {
-                    wifi_hal_error_print("%s:%d: Unable to read the band num %s\n", __func__, __LINE__, trimmed);
-                    return false;
-                }
-                in_wiphy = false;
-            }
-        }
-    }
-    return true;
-}
 
 static void remap_phy_index(wifi_interface_name_idex_map_t *map, int map_size, const int *pcie_index, int pcie_size)
 {
@@ -3153,14 +3108,79 @@ static void remap_phy_index(wifi_interface_name_idex_map_t *map, int map_size, c
 }
 
 void remap_wifi_interface_name_index_map() {
-    FILE *fp;
-    int pcie_index[MAX_NUM_RADIOS] = {-1, -1, -1};
+    /*
+     * Determine which kernel phy number is assigned to each wlN base interface
+     * by reading /sys/class/net/wlN/phy80211/name.  This sysfs entry is created
+     * the moment the interface is registered with cfg80211 — well before full
+     * band-capability information is published — and is far more reliable than
+     * spawning a subprocess to run "iw list".
+     *
+     * pcie_index[N] will hold the kernel phy number for wlN (e.g. pcie_index[0]=2
+     * means wl0 is registered as phy2).  remap_phy_index() then sets every
+     * interface_index_map entry whose name starts with "wlN" to use that phy
+     * number, correcting the static map's phy_index values.
+     */
+    int pcie_index[MAX_NUM_RADIOS];
+    int retries = 30;
 
-    fp = popen("iw list", "r");
-    if (parse_wiphy_band_mapping(fp, pcie_index)) {
-        remap_phy_index(interface_index_map, interface_index_map_size, pcie_index, MAX_NUM_RADIOS);
-    }
-    pclose(fp);
+    memset(pcie_index, -1, sizeof(pcie_index));
+
+    do {
+        int i;
+        bool all_found = true;
+
+        for (i = 0; i < MAX_NUM_RADIOS; i++) {
+            char sysfs_path[64];
+            char phy_name[32];
+            int kern_phy;
+            FILE *f;
+
+            if (pcie_index[i] != -1)
+                continue; /* already resolved */
+
+            snprintf(sysfs_path, sizeof(sysfs_path),
+                     "/sys/class/net/wl%d/phy80211/name", i);
+            f = fopen(sysfs_path, "r");
+            if (!f) {
+                all_found = false;
+                continue;
+            }
+
+            phy_name[0] = '\0';
+            if (fgets(phy_name, sizeof(phy_name), f) &&
+                sscanf(phy_name, "phy%d", &kern_phy) == 1) {
+                pcie_index[i] = kern_phy;
+                wifi_hal_dbg_print("%s:%d: wl%d -> phy%d (from sysfs)\n",
+                                   __func__, __LINE__, i, kern_phy);
+            } else {
+                wifi_hal_error_print("%s:%d: could not parse phy name from %s\n",
+                                     __func__, __LINE__, sysfs_path);
+                all_found = false;
+            }
+            fclose(f);
+        }
+
+        if (all_found) {
+            remap_phy_index(interface_index_map, interface_index_map_size,
+                            pcie_index, MAX_NUM_RADIOS);
+            wifi_hal_dbg_print("%s:%d: phy remap complete\n", __func__, __LINE__);
+            return;
+        }
+
+        /* Log which base interfaces are still missing */
+        for (i = 0; i < MAX_NUM_RADIOS; i++) {
+            if (pcie_index[i] == -1) {
+                wifi_hal_error_print(
+                    "%s:%d: wl%d not yet visible in sysfs, retrying (%d left)\n",
+                    __func__, __LINE__, i, retries - 1);
+            }
+        }
+        sleep(1);
+    } while (--retries > 0);
+
+    wifi_hal_error_print(
+        "%s:%d: wl base interfaces did not appear in sysfs after retries; skipping phy_index remap\n",
+        __func__, __LINE__);
 }
 
 #endif /* RDKB_ONE_WIFI_PROD */


### PR DESCRIPTION
BCAWLAN-290139: Change the call from iw list to reading from /sys/class/net/wlN/phy80211/name

Problem:

remap_wifi_interface_name_index_map() uses popen("iw list") to determine which kernel phy number (phy0/phy1/phy2) is assigned to each wl interface (wl0/wl1/wl2), then corrects the static interface_index_map phy_index values so that wiphy_dump_handler maps each phy to the right RDK radio index. On some boots, this function runs before the driver has published full band-capability information to nl80211, causing iw list to return empty output even though the HAL's own nl80211 socket can already see the phys. The result is a corrupted interface map, wrong phy-to-radio assignments, and HAL initialization failure.

Fix:

Replace the iw list subprocess approach with direct sysfs reads from /sys/class/net/wlN/phy80211/name. This file is created by the kernel the moment a wireless interface registers with cfg80211 — before band info is published and without requiring a subprocess. Reading it gives the kernel phy number for each wl interface directly (e.g., wl0/phy80211/name → "phy2" means wl0 belongs to kernel phy2). The parse_wiphy_band_mapping() function and its band-ID-to-phy-index translation logic are removed entirely. A retry loop (up to 30 seconds) waits for the sysfs entries to appear before proceeding; if they never appear, the remap is skipped, and the static map is used as-is.

 RDKB-61540:  RDKB-61540 added a new field in wifi_interface_name_idex_map_t  "wifi_interface_name_t mld_interface_name; /**< MLD interface name. */"
 However, the corresponding change under RDKB_ONE_WIFI_PROD  in static_interface_index_map was not done. This will cause our internal builds to fail