### PR TITLE
XB10-2684 Populate link address for MLO client's assoc events

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -6938,6 +6938,8 @@ static int get_sta_handler(struct nl_msg *msg, void *arg)
             associated_dev.cli_MLDInfo.cli_LinkInfo[link_idx].cli_LinkID = link_id;
             associated_dev.cli_MLDInfo.cli_LinkInfo[link_idx].cli_RSSI = rssi;
             associated_dev.cli_MLDInfo.cli_LinkInfo[link_idx].cli_Valid = true;
+            memcpy(associated_dev.cli_MLDInfo.cli_LinkInfo[link_idx].cli_LinkAddress,
+                link->peer_addr, sizeof(associated_dev.cli_MLDInfo.cli_LinkInfo[link_idx].cli_LinkAddress));
             link_idx++;
             has_link_stats = true;
         }


### PR DESCRIPTION
Reason for change: LinkAddress is empty for MLO client's assoc events Test Procedure: Connect MLO client to AP and verify the link address is
		correctly populated in the stats and events.
Risks: Low
Priority: P1

Depends on https://github.com/rdkcentral/rdkb-halif-wifi/pull/106