### PR TITLE
DTMESH-820: Filter non-VAP interfaces in recv_link_status (#695)

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -2529,6 +2529,11 @@ void recv_link_status()
                 return;
             }
 
+            if (interface && (int)interface->vap_info.vap_index < 0) {
+                wifi_hal_dbg_print("%s:%d: Interface %s is not VAP\n", __func__, __LINE__, interface->name);
+                return;
+            }
+
             if (ifi->ifi_flags & IFF_UP) {
                 status = true;
             } else {


### PR DESCRIPTION
Reason for change: recv_link_status() may receive RTM_NEWLINK/RTM_DELLINK
                   events for radio interfaces such as wifi0/wifi1 in
                   addition to VAP interfaces. These interfaces have
                   invalid vap_index values (-1), which could trigger
                   invalid vapstatus callbacks and lead to monitor-side
                   crashes during sta_map processing.

Test Procedure: Confirmed no crashes/reboots observed on OneWifi side

Risks: Low
Priority: P1