### PR TITLE
RDKB-65001 : Add deterministic fallback channel logic for DFS radar events

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17854,14 +17854,14 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
     }
 
     if (radio->oper_param.band == WIFI_FREQUENCY_5_BAND || radio->oper_param.band == WIFI_FREQUENCY_5L_BAND) {
-        if (is_valid_evac_channel(radio->dfs_evacuation_channel))
+        if (is_valid_evac_channel(radio->dfs_evacuation_channel, radio))
             return radio->dfs_evacuation_channel;
         wifi_hal_info_print("%s:%d: [DFS]: evacuating to channel 44\n", __func__, __LINE__);
         return 44;
     }
 
     if (radio->oper_param.band == WIFI_FREQUENCY_5H_BAND) {
-        if (is_valid_evac_channel(radio->dfs_evacuation_channel)) {
+        if (is_valid_evac_channel(radio->dfs_evacuation_channel, radio)) {
             wifi_hal_info_print("%s:%d: [DFS]: evacuating to configured channel %u\n",
                 __func__, __LINE__, radio->dfs_evacuation_channel);
             return radio->dfs_evacuation_channel;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -18152,9 +18152,12 @@ int nl80211_start_dfs_cac(wifi_radio_info_t *radio)
 Fail:
     radio_param = radio->oper_param;
     radio_param.channel = get_non_dfs_chan(interface, &seg0, &seg1, &sec_chan_offset);
-    radio_param.channelWidth = is_valid_evac_width(radio->dfs_evacuation_channel_width)
-                               ? radio->dfs_evacuation_channel_width
-                               : WIFI_CHANNELBANDWIDTH_80MHZ;
+    if (is_valid_evac_width(radio->dfs_evacuation_channel_width)) {
+        radio_param.channelWidth = radio->dfs_evacuation_channel_width;
+    }
+    if (radio_param.channelWidth == WIFI_CHANNELBANDWIDTH_160MHZ) {
+        radio_param.channelWidth = WIFI_CHANNELBANDWIDTH_80MHZ;
+    }
 
     wifi_hal_info_print("Radio will switch to a new channel %d seg0:%u seg1:%u sec_chan_offset:%d \n", radio_param.channel, seg0, seg1, sec_chan_offset);
     if( wifi_hal_setRadioOperatingParameters(interface->vap_info.radio_index, &radio_param) ) {

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17857,6 +17857,11 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
             wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
             return 157;
         }
+		else {
+		    wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 132\n", __func__, __LINE__);
+			return 132;
+		}
+		
     }
 
 #if HOSTAPD_VERSION >= 210 // 2.10

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17856,12 +17856,7 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
         if (is_unii3_channel157_usable(radio)) {
             wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
             return 157;
-        }
-		else {
-		    wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 132\n", __func__, __LINE__);
-			return 132;
-		}
-		
+        }		
     }
 
 #if HOSTAPD_VERSION >= 210 // 2.10

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17793,6 +17793,8 @@ int wifi_drv_commit(void *priv)
 #if defined(CMXB7_PORT) || defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL)
 #define WIFI_DFS_CHAN_FIRST  52
 #define WIFI_DFS_CHAN_LAST  144
+#define WIFI_DFS_EVAC_CHAN_5L    44   /* Default evacuation channel for 5/5L band (UNII-1) */
+#define WIFI_DFS_EVAC_CHAN_5H    157  /* Default evacuation channel for 5H band (UNII-3) */
 
 static bool is_unii3_channel157_usable(wifi_radio_info_t *radio)
 {
@@ -17800,7 +17802,7 @@ static bool is_unii3_channel157_usable(wifi_radio_info_t *radio)
     unsigned int map_size = sizeof(radio->oper_param.channel_map) /
                             sizeof(radio->oper_param.channel_map[0]);
     for (i = 0; i < map_size; i++) {
-        if (radio->oper_param.channel_map[i].ch_number == 157 &&
+        if (radio->oper_param.channel_map[i].ch_number == WIFI_DFS_EVAC_CHAN_5H &&
             radio->oper_param.channel_map[i].ch_state == CHAN_STATE_AVAILABLE)
             return true;
     }
@@ -17850,14 +17852,14 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
     if (radio == NULL) {
         wifi_hal_error_print("%s:%d: [DFS]: no radio for index %d\n", __func__, __LINE__,
             interface->vap_info.radio_index);
-        return 44;
+        return WIFI_DFS_EVAC_CHAN_5L;
     }
 
     if (radio->oper_param.band == WIFI_FREQUENCY_5_BAND || radio->oper_param.band == WIFI_FREQUENCY_5L_BAND) {
         if (is_valid_evac_channel(radio->dfs_evacuation_channel, radio))
             return radio->dfs_evacuation_channel;
         wifi_hal_info_print("%s:%d: [DFS]: evacuating to channel 44\n", __func__, __LINE__);
-        return 44;
+        return WIFI_DFS_EVAC_CHAN_5L;
     }
 
     if (radio->oper_param.band == WIFI_FREQUENCY_5H_BAND) {
@@ -17868,7 +17870,7 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
         }
         if (is_unii3_channel157_usable(radio)) {
             wifi_hal_info_print("%s:%d: [DFS]: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
-            return 157;
+            return WIFI_DFS_EVAC_CHAN_5H;
         }
     }
 
@@ -17881,7 +17883,7 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
 
     if (chan == NULL) {
         wifi_hal_error_print("%s:%d: [DFS]: no channel found, returning 44\n", __func__, __LINE__);
-        return 44;
+        return WIFI_DFS_EVAC_CHAN_5L;
     }
 
     wifi_hal_info_print("%s:%d: [DFS]: hostapd selected channel %u\n", __func__, __LINE__, chan->chan);

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -18165,12 +18165,9 @@ int nl80211_start_dfs_cac(wifi_radio_info_t *radio)
 Fail:
     radio_param = radio->oper_param;
     radio_param.channel = get_non_dfs_chan(interface, &seg0, &seg1, &sec_chan_offset);
-    if (is_valid_evac_width(radio->dfs_evacuation_channel_width)) {
-        radio_param.channelWidth = radio->dfs_evacuation_channel_width;
-    }
-    if (radio_param.channelWidth == WIFI_CHANNELBANDWIDTH_160MHZ) {
-        radio_param.channelWidth = WIFI_CHANNELBANDWIDTH_80MHZ;
-    }
+    radio_param.channelWidth = is_valid_evac_width(radio->dfs_evacuation_channel_width)
+                               ? radio->dfs_evacuation_channel_width
+                               : WIFI_CHANNELBANDWIDTH_80MHZ;
 
     wifi_hal_info_print("Radio will switch to a new channel %d seg0:%u seg1:%u sec_chan_offset:%d \n", radio_param.channel, seg0, seg1, sec_chan_offset);
     if( wifi_hal_setRadioOperatingParameters(interface->vap_info.radio_index, &radio_param) ) {

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17796,17 +17796,11 @@ int wifi_drv_commit(void *priv)
 #define WIFI_DFS_EVAC_CHAN_5L    44   /* Default evacuation channel for 5/5L band (UNII-1) */
 #define WIFI_DFS_EVAC_CHAN_5H    157  /* Default evacuation channel for 5H band (UNII-3) */
 
+static bool is_valid_evac_channel(unsigned int ch, wifi_radio_info_t *radio);
+
 static bool is_unii3_channel157_usable(wifi_radio_info_t *radio)
 {
-    unsigned int i;
-    unsigned int map_size = sizeof(radio->oper_param.channel_map) /
-                            sizeof(radio->oper_param.channel_map[0]);
-    for (i = 0; i < map_size; i++) {
-        if (radio->oper_param.channel_map[i].ch_number == WIFI_DFS_EVAC_CHAN_5H &&
-            radio->oper_param.channel_map[i].ch_state == CHAN_STATE_AVAILABLE)
-            return true;
-    }
-    return false;
+    return is_valid_evac_channel(WIFI_DFS_EVAC_CHAN_5H, radio);
 }
 
 static bool is_valid_evac_channel(unsigned int ch, wifi_radio_info_t *radio)

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17835,7 +17835,7 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
 
     radio = get_radio_by_rdk_index(interface->vap_info.radio_index);
     if (radio == NULL) {
-        wifi_hal_error_print("%s:%d: POORNA: no radio for index %d\n", __func__, __LINE__,
+        wifi_hal_error_print("%s:%d: [DFS]: no radio for index %d\n", __func__, __LINE__,
             interface->vap_info.radio_index);
         return 36;
     }
@@ -17843,18 +17843,18 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
     if (radio->oper_param.band == WIFI_FREQUENCY_5_BAND || radio->oper_param.band == WIFI_FREQUENCY_5L_BAND) {
         if (is_valid_evac_channel(radio->dfs_evacuation_channel))
             return radio->dfs_evacuation_channel;
-        wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 44\n", __func__, __LINE__);
+        wifi_hal_info_print("%s:%d: [DFS]: evacuating to channel 44\n", __func__, __LINE__);
         return 44;
     }
 
     if (radio->oper_param.band == WIFI_FREQUENCY_5H_BAND) {
         if (is_valid_evac_channel(radio->dfs_evacuation_channel)) {
-            wifi_hal_info_print("%s:%d: POORNA: evacuating to configured channel %u\n",
+            wifi_hal_info_print("%s:%d: [DFS]: evacuating to configured channel %u\n",
                 __func__, __LINE__, radio->dfs_evacuation_channel);
             return radio->dfs_evacuation_channel;
         }
         if (is_unii3_channel157_usable(radio)) {
-            wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
+            wifi_hal_info_print("%s:%d: [DFS]: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
             return 157;
         }		
     }
@@ -17867,11 +17867,11 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
 #endif /* HOSTAPD_VERSION >= 210 */
 
     if (chan == NULL) {
-        wifi_hal_error_print("%s:%d: POORNA: no channel found, returning 36\n", __func__, __LINE__);
-        return 36;
+        wifi_hal_error_print("%s:%d: [DFS]: no channel found, returning 44\n", __func__, __LINE__);
+        return 44;
     }
 
-    wifi_hal_info_print("%s:%d: POORNA: hostapd selected channel %u\n", __func__, __LINE__, chan->chan);
+    wifi_hal_info_print("%s:%d: [DFS]: hostapd selected channel %u\n", __func__, __LINE__, chan->chan);
     return chan->chan;
 }
 #endif /* defined(CMXB7_PORT) || defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL) */

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17796,13 +17796,6 @@ int wifi_drv_commit(void *priv)
 #define WIFI_DFS_EVAC_CHAN_5L    44   /* Default evacuation channel for 5/5L band (UNII-1) */
 #define WIFI_DFS_EVAC_CHAN_5H    157  /* Default evacuation channel for 5H band (UNII-3) */
 
-static bool is_valid_evac_channel(unsigned int ch, wifi_radio_info_t *radio);
-
-static bool is_unii3_channel157_usable(wifi_radio_info_t *radio)
-{
-    return is_valid_evac_channel(WIFI_DFS_EVAC_CHAN_5H, radio);
-}
-
 static bool is_valid_evac_channel(unsigned int ch, wifi_radio_info_t *radio)
 {
     unsigned int i;
@@ -17862,7 +17855,7 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
                 __func__, __LINE__, radio->dfs_evacuation_channel);
             return radio->dfs_evacuation_channel;
         }
-        if (is_unii3_channel157_usable(radio)) {
+        if (is_valid_evac_channel(WIFI_DFS_EVAC_CHAN_5H, radio)) {
             wifi_hal_info_print("%s:%d: [DFS]: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
             return WIFI_DFS_EVAC_CHAN_5H;
         }

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17723,30 +17723,87 @@ int wifi_drv_commit(void *priv)
 }
 
 #if defined(CMXB7_PORT) || defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL)
-//Selects a Non-DFS Channel from the list of available channels
+#define WIFI_DFS_CHAN_FIRST  52
+#define WIFI_DFS_CHAN_LAST  144
+
+static bool is_unii3_channel157_usable(wifi_radio_info_t *radio)
+{
+    unsigned int i;
+    unsigned int map_size = sizeof(radio->oper_param.channel_map) /
+                            sizeof(radio->oper_param.channel_map[0]);
+    for (i = 0; i < map_size; i++) {
+        if (radio->oper_param.channel_map[i].ch_number == 157 &&
+            radio->oper_param.channel_map[i].ch_state == CHAN_STATE_AVAILABLE)
+            return true;
+    }
+    return false;
+}
+
+/* ch is non-zero and outside the 5GHz DFS range (52-144) */
+static bool is_valid_evac_channel(unsigned int ch)
+{
+    return ch != 0 && (ch < WIFI_DFS_CHAN_FIRST || ch > WIFI_DFS_CHAN_LAST);
+}
+
+/* Only 20/40/80 MHz are valid evacuation widths */
+static bool is_valid_evac_width(wifi_channelBandwidth_t w)
+{
+    return w == WIFI_CHANNELBANDWIDTH_20MHZ ||
+           w == WIFI_CHANNELBANDWIDTH_40MHZ ||
+           w == WIFI_CHANNELBANDWIDTH_80MHZ;
+}
+
+/* Select radar evacuation channel: 5/5L->ch.44, 5H->ch.157 or hostapd fallback.
+ * Override via radio->dfs_evacuation_channel (must pass is_valid_evac_channel). */
 short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg0_idx, u8 *oper_centr_freq_seg1_idx,
                                               int *secondary_channel)
 {
     struct hostapd_channel_data *chan = NULL;
-#if HOSTAPD_VERSION >= 210 // 2.10
+    wifi_radio_info_t *radio;
 
-    wifi_hal_error_print("%s:%d DFS: Radar detected — selecting non-DFS-only fallback channel\n", __func__,
-            __LINE__);
-    enum dfs_channel_type channel_type = DFS_NON_DFS_ONLY; //select only non-dfs channel
+    *oper_centr_freq_seg0_idx = 0;
+    *oper_centr_freq_seg1_idx = 0;
+    *secondary_channel        = 0;
 
-    chan = dfs_get_valid_channel(&interface->u.ap.iface, secondary_channel,
-                                    oper_centr_freq_seg0_idx,
-                                    oper_centr_freq_seg1_idx,
-                                    channel_type);
-#endif /* HOSTAPD_VERSION >= 210 */
-    if (chan == NULL) {
-        wifi_hal_error_print("%s:%d failed to get new channel, return default\n", __func__,
-            __LINE__);
+    radio = get_radio_by_rdk_index(interface->vap_info.radio_index);
+    if (radio == NULL) {
+        wifi_hal_error_print("%s:%d: POORNA: no radio for index %d\n", __func__, __LINE__,
+            interface->vap_info.radio_index);
         return 36;
     }
 
-    wifi_hal_info_print("%s:%d Selected non-dfs channel:%u \n", __FUNCTION__, __LINE__, chan->chan);
+    if (radio->oper_param.band == WIFI_FREQUENCY_5_BAND || radio->oper_param.band == WIFI_FREQUENCY_5L_BAND) {
+        if (is_valid_evac_channel(radio->dfs_evacuation_channel))
+            return radio->dfs_evacuation_channel;
+        wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 44\n", __func__, __LINE__);
+        return 44;
+    }
 
+    if (radio->oper_param.band == WIFI_FREQUENCY_5H_BAND) {
+        if (is_valid_evac_channel(radio->dfs_evacuation_channel)) {
+            wifi_hal_info_print("%s:%d: POORNA: evacuating to configured channel %u\n",
+                __func__, __LINE__, radio->dfs_evacuation_channel);
+            return radio->dfs_evacuation_channel;
+        }
+        if (is_unii3_channel157_usable(radio)) {
+            wifi_hal_info_print("%s:%d: POORNA: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
+            return 157;
+        }
+    }
+
+#if HOSTAPD_VERSION >= 210 // 2.10
+    chan = dfs_get_valid_channel(&interface->u.ap.iface, secondary_channel,
+                                    oper_centr_freq_seg0_idx,
+                                    oper_centr_freq_seg1_idx,
+                                    DFS_NON_DFS_ONLY);
+#endif /* HOSTAPD_VERSION >= 210 */
+
+    if (chan == NULL) {
+        wifi_hal_error_print("%s:%d: POORNA: no channel found, returning 36\n", __func__, __LINE__);
+        return 36;
+    }
+
+    wifi_hal_info_print("%s:%d: POORNA: hostapd selected channel %u\n", __func__, __LINE__, chan->chan);
     return chan->chan;
 }
 #endif /* defined(CMXB7_PORT) || defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL) */
@@ -18027,6 +18084,9 @@ int nl80211_start_dfs_cac(wifi_radio_info_t *radio)
 Fail:
     radio_param = radio->oper_param;
     radio_param.channel = get_non_dfs_chan(interface, &seg0, &seg1, &sec_chan_offset);
+    radio_param.channelWidth = is_valid_evac_width(radio->dfs_evacuation_channel_width)
+                               ? radio->dfs_evacuation_channel_width
+                               : WIFI_CHANNELBANDWIDTH_80MHZ;
 
     wifi_hal_info_print("Radio will switch to a new channel %d seg0:%u seg1:%u sec_chan_offset:%d \n", radio_param.channel, seg0, seg1, sec_chan_offset);
     if( wifi_hal_setRadioOperatingParameters(interface->vap_info.radio_index, &radio_param) ) {
@@ -18135,14 +18195,10 @@ int nl80211_dfs_radar_cac_aborted(wifi_interface_info_t *interface, int freq, in
     }
 
     radio_param.channel = get_non_dfs_chan(interface, &oper_centr_freq_seg0_idx, &oper_centr_freq_seg1_idx, &sec_chan_offset);
-    radio_param.channelWidth = bandwidth;
+    radio_param.channelWidth = is_valid_evac_width(radio->dfs_evacuation_channel_width)
+                               ? radio->dfs_evacuation_channel_width
+                               : WIFI_CHANNELBANDWIDTH_80MHZ;
     interface->u.ap.iface.dfs_cac_ms = 0;
-
-    if(bandwidth == WIFI_CHANNELBANDWIDTH_160MHZ) {
-        wifi_channelBandwidth_t Chan_width_80MHz = WIFI_CHANNELBANDWIDTH_80MHZ;
-        wifi_hal_info_print("nl80211-%s:%d Setting bandwidth as 80MHz \n", __func__, __LINE__);
-        radio_param.channelWidth = Chan_width_80MHz;
-    }
 
     wifi_hal_info_print("Radio will switch to a new channel %d seg0:%u seg1:%u sec_chan_offset:%d dfs_cac_ms:%u \n", radio_param.channel, oper_centr_freq_seg0_idx, oper_centr_freq_seg1_idx, sec_chan_offset,
                         interface->u.ap.iface.dfs_cac_ms);
@@ -18275,13 +18331,12 @@ int nl80211_dfs_radar_detected (wifi_interface_info_t *interface, int freq, int 
 
     radio_param->channel = get_non_dfs_chan(interface, &oper_centr_freq_seg0_idx,
         &oper_centr_freq_seg1_idx, &sec_chan_offset);
-    radio_param->channelWidth = bandwidth;
+    radio_param->channelWidth = is_valid_evac_width(radio->dfs_evacuation_channel_width)
+                                ? radio->dfs_evacuation_channel_width
+                                : WIFI_CHANNELBANDWIDTH_80MHZ;
 
     if (bandwidth == WIFI_CHANNELBANDWIDTH_160MHZ) {
-        wifi_channelBandwidth_t Chan_width_80MHz = WIFI_CHANNELBANDWIDTH_80MHZ;
-        wifi_hal_info_print("%s:%d Setting bandwidth to 80MHz\n", __func__, __LINE__);
-        radio_param->channelWidth = Chan_width_80MHz;
-        // restore original bandwidth to avoid beacon change before channel switch
+        // restore original hostapd bandwidth config to avoid beacon change before channel switch
         hostapd_set_oper_chwidth(interface->u.ap.hapd.iconf, orig_chan_width);
         interface->u.ap.iface.conf->secondary_channel = orig_secondary_chan;
     }

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17807,10 +17807,23 @@ static bool is_unii3_channel157_usable(wifi_radio_info_t *radio)
     return false;
 }
 
-/* ch is non-zero and outside the 5GHz DFS range (52-144) */
-static bool is_valid_evac_channel(unsigned int ch)
+static bool is_valid_evac_channel(unsigned int ch, wifi_radio_info_t *radio)
 {
-    return ch != 0 && (ch < WIFI_DFS_CHAN_FIRST || ch > WIFI_DFS_CHAN_LAST);
+    unsigned int i;
+    unsigned int map_size;
+
+    if (ch == 0 || (ch >= WIFI_DFS_CHAN_FIRST && ch <= WIFI_DFS_CHAN_LAST))
+        return false;
+
+    /* Verify channel exists in this radio's available channel list */
+    map_size = sizeof(radio->oper_param.channel_map) /
+               sizeof(radio->oper_param.channel_map[0]);
+    for (i = 0; i < map_size; i++) {
+        if (radio->oper_param.channel_map[i].ch_number == ch &&
+            radio->oper_param.channel_map[i].ch_state == CHAN_STATE_AVAILABLE)
+            return true;
+    }
+    return false;
 }
 
 /* Only 20/40/80 MHz are valid evacuation widths */
@@ -17837,7 +17850,7 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
     if (radio == NULL) {
         wifi_hal_error_print("%s:%d: [DFS]: no radio for index %d\n", __func__, __LINE__,
             interface->vap_info.radio_index);
-        return 36;
+        return 44;
     }
 
     if (radio->oper_param.band == WIFI_FREQUENCY_5_BAND || radio->oper_param.band == WIFI_FREQUENCY_5L_BAND) {
@@ -17856,7 +17869,7 @@ short get_non_dfs_chan(wifi_interface_info_t *interface, u8 *oper_centr_freq_seg
         if (is_unii3_channel157_usable(radio)) {
             wifi_hal_info_print("%s:%d: [DFS]: evacuating to channel 157 (UNII-3)\n", __func__, __LINE__);
             return 157;
-        }		
+        }
     }
 
 #if HOSTAPD_VERSION >= 210 // 2.10

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -565,6 +565,8 @@ typedef struct {
     bool radio_presence; //True for ECO mode Active radio, false for ECO mode power down sleeping radio
     bool radar_detected;
     bool configuration_in_progress;
+    unsigned int dfs_evacuation_channel;              /* 0 = default (ch.44/157 by band) */
+    wifi_channelBandwidth_t dfs_evacuation_channel_width; /* 0 = default 80 MHz */
 #ifndef FEATURE_SINGLE_PHY
     rnr_scan_t rnr;
     bool rnr_enabled;


### PR DESCRIPTION
Reason for change: Comcast DFS Experience enhancement

Test Procedure: Trigger radar event and verify AP moves to the correct fallback channel

Risks: Low

Priority: P2

Signed-off-by: poornakumar_mezhiselvam@comcast.com