### PR TITLE
BCOMB-3566: Fix cli_MLDEnable inference for 1-link MLO clients

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -3587,9 +3587,9 @@ static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
          * Driver does not set RDK_VENDOR_ATTR_STA_INFO_MLD_ENAB for 1-link MLO clients.
          * Infer MLD Enable flag from the presence of a non-zero MLD address. */
         if (stats->cli_MLDEnable == 0 && !is_zero_ether_addr(stats->cli_MLDAddr)) {
-            wifi_hal_stats_error_print("%s:%d MLD address " MACSTR
-                                       " is present but cli_MLDEnable is %d."
-                                       " Force enabling cli_MLDEnable to %d.\n",
+            wifi_hal_stats_dbg_print("%s:%d MLD address " MACSTR
+                                     " is present but cli_MLDEnable is %d."
+                                     " Force enabling cli_MLDEnable to %d.\n",
                 __func__, __LINE__, MAC2STR(stats->cli_MLDAddr), stats->cli_MLDEnable, 1);
             stats->cli_MLDEnable = 1;
         }

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -3583,6 +3583,16 @@ static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
     if (tb_sta_info[RDK_VENDOR_ATTR_STA_INFO_MLD_MAC]) {
         memcpy(stats->cli_MLDAddr, nla_data(tb_sta_info[RDK_VENDOR_ATTR_STA_INFO_MLD_MAC]),
                nla_len(tb_sta_info[RDK_VENDOR_ATTR_STA_INFO_MLD_MAC]));
+        /* Temporary workaround for the case where
+         * Driver does not set RDK_VENDOR_ATTR_STA_INFO_MLD_ENAB for 1-link MLO clients.
+         * Infer MLD Enable flag from the presence of a non-zero MLD address. */
+        if (stats->cli_MLDEnable == 0 && !is_zero_ether_addr(stats->cli_MLDAddr)) {
+            wifi_hal_stats_error_print("%s:%d MLD address " MACSTR
+                                       " is present but cli_MLDEnable is %d."
+                                       " Force enabling cli_MLDEnable to %d.\n",
+                __func__, __LINE__, MAC2STR(stats->cli_MLDAddr), stats->cli_MLDEnable, 1);
+            stats->cli_MLDEnable = 1;
+        }
     } else {
         memset(stats->cli_MLDAddr, 0, sizeof(stats->cli_MLDAddr));
     }


### PR DESCRIPTION
Reason for change: MLDEnable parameter changes to "false" for a client using only one MLO link Test Procedure: 1. Connect a client that supports MLO with only one link to the device.
                2. Observe that the cli_MLDEnable parameter is set to "true" for that client as in driver.
Risks: Low
Priority: P1