### PR TITLE
RDKB-64858 : Increase in WIFI_PASSWORD_FAIL and WIFI_POSSIBLE_WPS_PSK_FAIL (#694)

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -12801,7 +12801,7 @@ int wifi_drv_sta_remove(void *priv, const u8 *addr)
 
     wifi_hal_dbg_print("%s:%d: Enter\n", __func__, __LINE__);
 
-    return wifi_sta_remove(interface, addr, -1, 0);
+    return wifi_sta_remove(interface, addr, -1, 1);
 }
 
 int wifi_drv_sta_add(void *priv, struct hostapd_sta_add_params *params)


### PR DESCRIPTION
Reason for change: wifi_drv_sta_remove from rdk-wifi-hal sends the reason code as 0, resulting in NL80211_ATTR_REASON_CODE not being added. Upon receiving this request, the kernel sets the reason code to 0. Test Procedure: 1) connect a client with wrong password we should see WIFI_PASSWORD_FAIL and WIFI_POSSIBLE_WPS_PSK_FAIL marker in wifihealth.txt 2) for additional scenarios refer to the ticket.
Risks: Low
Priority: P1