### PR TITLE
BCOMB-3470: Set apsta mode on boot for Broadcom Platforms

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -129,6 +129,8 @@ static wl_runtime_params_t g_wl_runtime_params[] = {
 	{"keep_ap_up", "1"}
 };
 
+static int _platform_init_done = FALSE;
+
 #if defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL)
 #if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
 static bool needs_conf_mbssid_num_frames(uint vap_index, int hostap_mgt_frame_ctrl, int *mbssid_num_frames);
@@ -467,7 +469,6 @@ void set_string_nvram_param(char *param_name, char *value)
 #if defined(MLO_ENAB)
 #define MAX_MLO_RADIOS (4)
 
-static int _platform_init_done = FALSE;
 static int mlo_MAP = -1; /* Main AP index */
 static int mlo_config[MAX_MLO_RADIOS] = { -1, -1, -1, -1 }; /* wl_mlo_config values */
 static int mlo_radio_cnt = 0; /* Number of MLO radios */
@@ -918,6 +919,7 @@ void platform_mlo_post_init(void)
 int platform_pre_init()
 {
     wifi_hal_dbg_print("%s:%d \r\n", __func__, __LINE__);
+    _platform_init_done = FALSE;
 
     system("sysevent set multinet-up 13");
     system("sysevent set multinet-up 14");
@@ -940,8 +942,6 @@ int platform_pre_init()
 
 #if defined(MLO_ENAB)
     /* Start the init process */
-    _platform_init_done = FALSE;
-
     platform_radio_up(-1, FALSE); /* Bring all radios down */
     platform_mlo_init();
 #endif /* MLO_ENAB */
@@ -1093,6 +1093,21 @@ int platform_set_acs_exclusion_list(unsigned int radioIndex, char* str)
     return RETURN_OK;
 }
 
+/* apsta iovar is per-radio, not per-BSS */
+static int platform_set_apsta(wifi_radio_index_t index, bool enable)
+{
+    int apsta_enable = enable ? 1 : 0;
+    char osifname[IFNAMSIZ] = { 0 };
+
+    snprintf(osifname, sizeof(osifname), "wl%d", index);
+    if (wl_iovar_set(osifname, "apsta", &apsta_enable, sizeof(apsta_enable)) < 0) {
+        wifi_hal_error_print("%s: failed to set apsta %d for %s, err: %d (%s)\n", __func__,
+            apsta_enable, osifname, errno, strerror(errno));
+        return RETURN_ERR;
+    }
+    return RETURN_OK;
+}
+
 int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
 {
     if (operationParam == NULL) {
@@ -1110,6 +1125,13 @@ int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationPa
     if (radio == NULL) {
         wifi_hal_dbg_print("%s:%d:Could not find radio index:%d\n", __func__, __LINE__, index);
         return RETURN_ERR;
+    }
+
+    if (!_platform_init_done) {
+        /* OneWifi designates primary IF as sta, so the radio shall always work in apsta mode */
+        if (platform_set_apsta(index, TRUE) != RETURN_OK) {
+           wifi_hal_error_print("%s:%d: Failed to set apsta=1 for radio index:%d\n", __func__, __LINE__, index);
+        }
     }
 
 #if defined (ENABLED_EDPD)
@@ -1294,8 +1316,9 @@ int platform_post_init(wifi_vap_info_map_t *vap_map)
 #if defined(MLO_ENAB)
     platform_mlo_post_init();
     platform_vap_enable_update(vap_map, TRUE);		/* Bring all VAPs up, including MLDs */
-    _platform_init_done = TRUE;
 #endif /* MLO_ENAB */
+    _platform_init_done = TRUE;
+
 
     memset(param_name, 0 ,sizeof(param_name));
     memset(interface_name, 0, sizeof(interface_name));

--- a/platform/xle/platform_xle.c
+++ b/platform/xle/platform_xle.c
@@ -45,6 +45,7 @@ If include secure_wrapper.h, will need to convert other system calls with v_secu
 int v_secure_system(const char *command, ...);
 FILE *v_secure_popen(const char *direction, const char *command, ...);
 int v_secure_pclose(FILE *);
+static int _platform_init_done = FALSE;
 
 typedef struct wl_runtime_params {
     char *param_name;
@@ -162,13 +163,14 @@ extern char *wlcsm_nvram_get(char *name);
 int platform_pre_init()
 {
     wifi_hal_dbg_print("%s \n", __func__);
+    _platform_init_done = FALSE;
     return 0;
 }
 
 int platform_post_init(wifi_vap_info_map_t *vap_map)
 {
     wifi_hal_dbg_print("%s \n", __func__);
-
+    _platform_init_done = TRUE;
     wifi_hal_info_print("%s:%d: start_wifi_apps\n", __func__, __LINE__);
     v_secure_system("wifi_setup.sh start_wifi_apps");
     //set runtime configs using wl command.
@@ -227,6 +229,24 @@ static int disable_dfs_auto_channel_change(int radio_index, int disable)
     return 0;
 }
 
+/* apsta iovar is per-radio, not per-BSS */
+static int platform_set_apsta(wifi_radio_index_t index, bool enable)
+{
+    int apsta_enable = enable ? 1 : 0;
+    char osifname[IFNAMSIZ] = { 0 };
+
+    snprintf(osifname, sizeof(osifname), "wl%d", index);
+    if (wl_iovar_set(osifname, "apsta", &apsta_enable, sizeof(apsta_enable)) < 0) {
+        wifi_hal_error_print("%s: failed to set apsta %d for %s, err: %d (%s)\n", __func__,
+            apsta_enable, osifname, errno, strerror(errno));
+        return RETURN_ERR;
+    }
+    wifi_hal_info_print("%s:  set apsta %d for %s finished successfully\n", __func__,
+            apsta_enable, osifname);
+
+    return RETURN_OK;
+}
+
 int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
 {
     wifi_hal_dbg_print("%s \n", __func__);
@@ -242,6 +262,14 @@ int platform_set_radio_pre_init(wifi_radio_index_t index, wifi_radio_operationPa
         wifi_hal_dbg_print("%s:%d:Could not find radio index:%d\n", __func__, __LINE__, index);
         return RETURN_ERR;
     }
+
+    if (!_platform_init_done) {
+        /* OneWifi designates primary IF as sta, so the radio shall always work in apsta mode */
+        if (platform_set_apsta(index, TRUE) != RETURN_OK) {
+           wifi_hal_error_print("%s:%d: Failed to set apsta=1 for radio index:%d\n", __func__, __LINE__, index);
+        }
+    }
+
     if (radio->radio_presence == false) {
         wifi_hal_dbg_print("%s:%d Skip this radio %d. This is in sleeping mode\n", __FUNCTION__, __LINE__, index);
         return 0;


### PR DESCRIPTION
Reason for change: Changing apsta requires WLC_DOWN/UP, forcing other MLO radios down. OneWifi shall have apsta set to 1 for all radios to allow primary wlX to function as STA operation.

Test Procedure: Verify if all radios are up after mesh_sta configuration is performed
	dmcli Device.WiFi.SSID.15.Enable true/false and ApplyAccessPointSettings

Risks: Low