### PR TITLE
RDKB-65271 : MLO support for XER10 and XF10

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -631,7 +631,11 @@ int platform_bss_up(int vap_index, bool up)
 int platform_mlo_init(void)
 {
     int i;
+#if defined(SCXF10_PORT) || defined(SCXER10_PORT)
+    char *value = nvram_kget("wl_mlo_config");
+#else
     char *value = nvram_get("wl_mlo_config");
+#endif
 
     mlo_radio_cnt = mlo_radio_map = 0;
     mlo_MAP = mlo_init_map = -1;
@@ -4865,7 +4869,11 @@ static unsigned char platform_get_link_id_for_radio_index(unsigned int radio_ind
     if (radio_index < (sizeof(mlo_config) / sizeof(*mlo_config))) {
         char *wl_mlo_config;
 
+#if defined(SCXF10_PORT) || defined(SCXER10_PORT)
+        wl_mlo_config = nvram_kget("wl_mlo_config");
+#else
         wl_mlo_config = nvram_get("wl_mlo_config");
+#endif
         if (wl_mlo_config != NULL) {
             int ret;
 
@@ -4955,7 +4963,11 @@ static void nvram_update_wl_mlo_config(unsigned int radio_index, int mld_link_id
         mld_link_id = -1;
     }
 
+#if defined(SCXF10_PORT) || defined(SCXER10_PORT)
+    wl_mlo_config = nvram_kget("wl_mlo_config");
+#else
     wl_mlo_config = nvram_get("wl_mlo_config"); /* Format of nvram wl_mlo_config="-1 -1 -1 -1" */
+#endif
     if (wl_mlo_config != NULL) {
         int ret;
 
@@ -4975,8 +4987,13 @@ static void nvram_update_wl_mlo_config(unsigned int radio_index, int mld_link_id
     memset(new_nvram_val, 0, sizeof(new_nvram_val));
     snprintf(new_nvram_val, sizeof(new_nvram_val), "%d %d %d %d", mlo_config[0], mlo_config[1],
         mlo_config[2], mlo_config[3]);
+#if defined(SCXF10_PORT) || defined(SCXER10_PORT)
+    nvram_kset("wl_mlo_config", new_nvram_val);
+    *nvram_changed |= 2;
+#else
     set_string_nvram_param("wl_mlo_config", new_nvram_val);
     *nvram_changed |=1;
+#endif
     wifi_hal_info_print("%s:%d Updating nvram wl_mlo_config with new value: %s\n", __func__,
         __LINE__, new_nvram_val);
 }
@@ -5109,10 +5126,15 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
     mld_ap = vap->u.bss_info.enabled && (!conf->disable_11be && mld_conf->mld_enable &&
         (hapd->mld_link_id < MAX_NUM_MLD_LINKS));
     nvram_update_wl_bss_mlo_mode(conf->iface, mld_ap, &nvram_changed);
-    if (nvram_changed) {
+    if (nvram_changed & 0x01) {
         wifi_hal_info_print("%s:%d nvram was changed => nvram_commit()\n", __func__, __LINE__);
         nvram_commit();
     }
+#if defined(SCXF10_PORT) || defined(SCXER10_PORT)
+    if (nvram_changed & 0x02) {
+        nvram_kcommit();
+    }
+#endif
 
     if (mld_ap) {
         conf->mld_ap = mld_ap;

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -467,7 +467,7 @@ void set_string_nvram_param(char *param_name, char *value)
 #if defined(MLO_ENAB)
 #define MAX_MLO_RADIOS (4)
 #define USER_NVRAM_CHANGED		0x01
-#define KERNEL_NVRAM_CHANGED	0X02
+#define KERNEL_NVRAM_CHANGED	0x02
 
 static int _platform_init_done = FALSE;
 static int mlo_MAP = -1; /* Main AP index */

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -466,6 +466,8 @@ void set_string_nvram_param(char *param_name, char *value)
 
 #if defined(MLO_ENAB)
 #define MAX_MLO_RADIOS (4)
+#define USER_NVRAM_CHANGED		0x01
+#define KERNEL_NVRAM_CHANGED	0X02
 
 static int _platform_init_done = FALSE;
 static int mlo_MAP = -1; /* Main AP index */
@@ -4924,7 +4926,7 @@ static void nvram_update_wl_mlo_apply(const char *iface, unsigned char mlo_apply
     }
 
     set_decimal_nvram_param(name, mlo_apply);
-    *nvram_changed |=1;
+    *nvram_changed |= USER_NVRAM_CHANGED;
     wifi_hal_info_print("%s:%d Updating wl_mlo_apply nvram %s=%u for the iface:%s\n", __func__,
         __LINE__, name, mlo_apply, iface);
 }
@@ -4943,7 +4945,7 @@ static void nvram_update_wl_bss_mlo_mode(const char *iface, unsigned char bss_ml
     }
 
     set_decimal_nvram_param(name, bss_mlo_mode);
-    *nvram_changed |=1;
+    *nvram_changed |= USER_NVRAM_CHANGED;
     wifi_hal_info_print("%s:%d Updating wl_bss_mlo_mode nvram %s=%u for the iface:%s\n", __func__,
         __LINE__, name, bss_mlo_mode, iface);
 }
@@ -4962,11 +4964,11 @@ static void nvram_update_wl_mlo_config(unsigned int radio_index, int mld_link_id
     if ((u8)mld_link_id == (u8)NL80211_DRV_LINK_ID_NA) {
         mld_link_id = -1;
     }
-
+	/* Format of nvram wl_mlo_config="-1 -1 -1 -1" */
 #if defined(SCXF10_PORT) || defined(SCXER10_PORT)
     wl_mlo_config = nvram_kget("wl_mlo_config");
 #else
-    wl_mlo_config = nvram_get("wl_mlo_config"); /* Format of nvram wl_mlo_config="-1 -1 -1 -1" */
+    wl_mlo_config = nvram_get("wl_mlo_config");
 #endif
     if (wl_mlo_config != NULL) {
         int ret;
@@ -4989,10 +4991,10 @@ static void nvram_update_wl_mlo_config(unsigned int radio_index, int mld_link_id
         mlo_config[2], mlo_config[3]);
 #if defined(SCXF10_PORT) || defined(SCXER10_PORT)
     nvram_kset("wl_mlo_config", new_nvram_val);
-    *nvram_changed |= 2;
+    *nvram_changed |= KERNEL_NVRAM_CHANGED;
 #else
     set_string_nvram_param("wl_mlo_config", new_nvram_val);
-    *nvram_changed |=1;
+    *nvram_changed |= USER_NVRAM_CHANGED;
 #endif
     wifi_hal_info_print("%s:%d Updating nvram wl_mlo_config with new value: %s\n", __func__,
         __LINE__, new_nvram_val);
@@ -5126,12 +5128,12 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
     mld_ap = vap->u.bss_info.enabled && (!conf->disable_11be && mld_conf->mld_enable &&
         (hapd->mld_link_id < MAX_NUM_MLD_LINKS));
     nvram_update_wl_bss_mlo_mode(conf->iface, mld_ap, &nvram_changed);
-    if (nvram_changed & 0x01) {
+    if (nvram_changed & USER_NVRAM_CHANGED) {
         wifi_hal_info_print("%s:%d nvram was changed => nvram_commit()\n", __func__, __LINE__);
         nvram_commit();
     }
 #if defined(SCXF10_PORT) || defined(SCXER10_PORT)
-    if (nvram_changed & 0x02) {
+    if (nvram_changed & KERNEL_NVRAM_CHANGED) {
         nvram_kcommit();
     }
 #endif

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -466,8 +466,8 @@ void set_string_nvram_param(char *param_name, char *value)
 
 #if defined(MLO_ENAB)
 #define MAX_MLO_RADIOS (4)
-#define USER_NVRAM_CHANGED		0x01
-#define KERNEL_NVRAM_CHANGED	0x02
+#define USER_NVRAM_CHANGED        0x01
+#define KERNEL_NVRAM_CHANGED      0x02
 
 static int _platform_init_done = FALSE;
 static int mlo_MAP = -1; /* Main AP index */

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -5134,6 +5134,7 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
     }
 #if defined(SCXF10_PORT) || defined(SCXER10_PORT)
     if (nvram_changed & KERNEL_NVRAM_CHANGED) {
+		wifi_hal_info_print("%s:%d kernel nvram was changed => nvram_kcommit()\n", __func__, __LINE__);
         nvram_kcommit();
     }
 #endif


### PR DESCRIPTION
RDKB-65271 : MLO support

Reason for change: The nvram variable wl_mlo_config is a kernel nvram variable.
                                  Modify the MLO functions to get and set the variable from kernel nvram.
Test Procedure: kernel nvram should contain wl_mlo_config same as
                user nvram wl_mlo_config.
Risks: None
Priority: P1

Signed-off-by: Jonathan Wu <Jonathan_Wu@comcast.com>