### PR TITLE
RDKB-61450 : Assoc Resp reconnect PerSta profile fix

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -1383,7 +1383,7 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
                 reason = station->disconnect_reason_code;
             }
 #endif
-#if !defined(CONFIG_GENERIC_MLO)
+#if !defined(CONFIG_GENERIC_MLO) && (HOSTAPD_VERSION <= 210)
             ap_free_sta(&interface->u.ap.hapd, station);
 #endif // !defined(CONFIG_GENERIC_MLO)
         } else {
@@ -1464,7 +1464,7 @@ int process_frame_mgmt(wifi_interface_info_t *interface, struct ieee80211_mgmt *
                     reason = station->disconnect_reason_code;
                 }
 #endif
-#if !defined(CONFIG_GENERIC_MLO)
+#if !defined(CONFIG_GENERIC_MLO) && (HOSTAPD_VERSION <= 210)
             ap_free_sta(&interface->u.ap.hapd, station);
 #endif // !defined(CONFIG_GENERIC_MLO)
         }

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -487,7 +487,7 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
                     reason = station->disconnect_reason_code;
                 }
 #endif
-#if !defined(CONFIG_GENERIC_MLO)
+#if !defined(CONFIG_GENERIC_MLO) && (HOSTAPD_VERSION <= 210)
                 ap_free_sta(&interface->u.ap.hapd, station);
 #endif // !defined(CONFIG_GENERIC_MLO)
             }
@@ -534,7 +534,7 @@ static void nl80211_frame_tx_status_event(wifi_interface_info_t *interface, stru
                     wifi_hal_info_print("reason from disconnect reason code is %d\n",reason);
                 }
 #endif
-#if !defined(CONFIG_GENERIC_MLO)
+#if !defined(CONFIG_GENERIC_MLO) && (HOSTAPD_VERSION <= 210)
                 ap_free_sta(&interface->u.ap.hapd, station);
 #endif // !defined(CONFIG_GENERIC_MLO)
             }


### PR DESCRIPTION
Reason for change:
for some reason, the HAL calls ap_free_sta() on the deauth/disassoc. And due to this, the hostapd cannot properly handle it. Specifically for MLO connections, the hostapd should clear the STA from all links, but since the HAL has call free() already, the hostapd does nothing. So, on the next association, the ieee80211_ml_process_link() function sees that the STA is presented on the link already and returns following Per-Sta profile inside Multi-Link IE:
            Subelement ID: Per-STA Profile (0x00)
            Subelement Length: 26
	    ...................
                    Status code: Unspecified failure (0x0001)

Due to this, some MLO clients can't connect in MLO mode

Since it's not clear why the ap_free_sta() is being called by HAL in the first place, I will assume that it's due to insufficient hostapd behavior. So, I will assume that this is only relevant for old hostapd versoins. Starting from the version 2.11, the hostapd clears the connection properly.

Test Procedure: make sure that MLO clients are able to connect back after disconnection

Risk: Medium
Prio: High