### PR TITLE
RDKB-63466: Onewifi testcases are failed due to missing frames.

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -16939,7 +16939,7 @@ static int register_data_frame_socket(wifi_interface_info_t *interface)
     }
 #endif // CONFIG_GENERIC_MLO
 
-#ifndef WIFI_CONFIG_EMULATOR
+#ifndef CONFIG_WIFI_EMULATOR
     if (interface->data_frames_registered == 1) {
         wifi_hal_dbg_print("%s:%d: data frame socket already registered for %s\n", __func__,
             __LINE__, wifi_hal_get_interface_name(interface));

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -16939,11 +16939,13 @@ static int register_data_frame_socket(wifi_interface_info_t *interface)
     }
 #endif // CONFIG_GENERIC_MLO
 
+#ifndef WIFI_CONFIG_EMULATOR
     if (interface->data_frames_registered == 1) {
         wifi_hal_dbg_print("%s:%d: data frame socket already registered for %s\n", __func__,
             __LINE__, wifi_hal_get_interface_name(interface));
         return 0;
     }
+#endif
 
     vap = &interface->vap_info;
 


### PR DESCRIPTION
Impacted Platforms: All platforms

Reason for change:  When bridge changes for particular interface , the socket is not re-registered 
for that bridge , so the EAPOL frames were missing.

Test Procedure: Run the client connectivity test cases from the autobot and check for eapol frames miss.

Risks: Medium

Priority: P1

Signed-off-by: sanjayvenkatesan1902@comcast.com