### PR TITLE
Revert "XB10-2247 : Group Cipher suite and Group Management Cipher Suite (#658)"

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -721,23 +721,10 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
             conf->wpa_pairwise = WPA_CIPHER_CCMP;
             switch (sec->mode) {
             case wifi_security_mode_wpa3_personal:
+            case wifi_security_mode_wpa3_transition:
             case wifi_security_mode_wpa3_enterprise:
             case wifi_security_mode_enhanced_open:
-                if (!conf->disable_11be) {
-                    conf->wpa_pairwise |= WPA_CIPHER_GCMP_256;
-                    conf->group_cipher = WPA_CIPHER_GCMP_256;
-                    conf->group_mgmt_cipher = WPA_CIPHER_BIP_GMAC_256;
-                } else {
-                    conf->group_cipher = WPA_CIPHER_CCMP;
-                    conf->group_mgmt_cipher = WPA_CIPHER_AES_128_CMAC;
-                }
-                break;
-            case wifi_security_mode_wpa3_transition:
-                if (!conf->disable_11be) {
-                    conf->wpa_pairwise |= WPA_CIPHER_GCMP_256;
-                }
-                conf->group_cipher = WPA_CIPHER_CCMP;
-                conf->group_mgmt_cipher = WPA_CIPHER_AES_128_CMAC;
+                conf->wpa_pairwise |= (conf->disable_11be ? 0 : WPA_CIPHER_GCMP_256);
                 break;
             case wifi_security_mode_wpa3_compatibility:
                 /* GCMP-256 is advertised via rsn_pairwise_rsno_2 in RSNO2 IE only;


### PR DESCRIPTION
Revert "XB10-2247 : Group Cipher suite and Group Management Cipher Suite (#658)"

This reverts commit 950df243bf5f8ba34a12bc9bb014a1d8f2e80e11.

Reson for revert: Too strict WPA3 requirements brake the Iphone WPA3 association. 