### PR TITLE
XB10-2705: Store mbssid_num_frames configuration persistently (#727)

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -128,7 +128,7 @@ static wl_runtime_params_t g_wl_runtime_params[] = {
 
 #if defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL)
 #if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
-static bool needs_conf_mbssid_num_frames(uint vap_index, int hostap_mgt_frame_ctrl, int *mbssid_num_frames);
+static bool needs_conf_mbssid_num_frames(int radio_index, int *mbssid_num_frames);
 #endif
 static bool needs_conf_split_assoc_req(uint vap_index, int hostap_mgt_frame_ctrl, int *assoc_ctrl);
 #endif // FEATURE_HOSTAP_MGMT_FRAME_CTRL
@@ -506,6 +506,12 @@ static bool platform_down_reqd(wifi_radio_index_t r_index, wifi_vap_info_map_t *
     bool reqd = false;
 
     /* Check all params that require down for the given radio */
+#if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
+        reqd |= needs_conf_mbssid_num_frames(r_index, &ctrl);
+        if (reqd)
+            return reqd;
+#endif
+
     /* Check all params that require down for the given VAPs */
     if (map == NULL)
         return reqd;
@@ -514,10 +520,6 @@ static bool platform_down_reqd(wifi_radio_index_t r_index, wifi_vap_info_map_t *
 
         reqd |= needs_conf_split_assoc_req(
             vap_index,map->vap_array[index].u.bss_info.hostap_mgt_frame_ctrl, &ctrl);
-#if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
-        reqd |= needs_conf_mbssid_num_frames(
-            vap_index,map->vap_array[index].u.bss_info.hostap_mgt_frame_ctrl, &ctrl);
-#endif
         if (reqd)
             break;
     }
@@ -1845,23 +1847,18 @@ static bool needs_conf_split_assoc_req(uint vap_index, int hostap_mgt_frame_ctrl
 
 /*
  * Check if mbssid_num_frames need reconfiguration to new value
- * [in] vap_index
- * [in] hostap_mgt_frame_ctrl
+ * [in] radio_index
  * [out] mbssid_num_frames
 */
 #if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
-static bool needs_conf_mbssid_num_frames(uint vap_index, int hostap_mgt_frame_ctrl, int *mbssid_num_frames)
+static bool needs_conf_mbssid_num_frames(int radio_index, int *mbssid_num_frames)
 {
-    char interface_name[8] = { 0 };
+    char interface_name[IFNAMSIZ] = { 0 };
     int curr_mbssid_num_frames;
 
     *mbssid_num_frames = 1;
 
-    if (get_interface_name_from_vap_index(vap_index, interface_name) != RETURN_OK) {
-        wifi_hal_error_print("%s:%d failed to get interface name for vap index: %d, err: %d (%s)\n",
-            __func__, __LINE__, vap_index, errno, strerror(errno));
-        return false;
-    }
+    snprintf(interface_name, sizeof(interface_name), "wl%d", radio_index);
 
     if (wl_iovar_getint(interface_name, "mbssid_num_frames", &curr_mbssid_num_frames) < 0) {
         wifi_hal_error_print("%s:%d failed to get mbssid_num_frames for %s, err: %d (%s)\n",
@@ -1932,7 +1929,7 @@ static int platform_set_hostap_ctrl(wifi_radio_info_t *radio, uint vap_index, in
 
     split_assoc_req_change = needs_conf_split_assoc_req(vap_index, enable, &assoc_ctrl);
 #if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
-    mbssid_num_frames_change = needs_conf_mbssid_num_frames(vap_index, enable, &mbssid_num_frames);
+    mbssid_num_frames_change = needs_conf_mbssid_num_frames(radio->rdk_radio_index, &mbssid_num_frames);
 #endif
     if (split_assoc_req_change == false && mbssid_num_frames_change == false) {
         return RETURN_OK;
@@ -1959,18 +1956,28 @@ static int platform_set_hostap_ctrl(wifi_radio_info_t *radio, uint vap_index, in
         (void)snprintf(name, sizeof(name), "%s_split_assoc_req", interface_name);
         wifi_hal_info_print("%s:%d Writing nvram %s=%d\n", __func__,__LINE__, name, assoc_ctrl);
         set_decimal_nvram_param(name, assoc_ctrl);
-        nvram_commit();
     }
 
 #if defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
-    // supported by driver version 23.2.1
-    if (wl_iovar_set(interface_name, "mbssid_num_frames", &mbssid_num_frames,
-            sizeof(mbssid_num_frames)) < 0) {
-        wifi_hal_error_print("%s:%d failed to set mbssid_num_frames %d for %s, err: %d (%s)\n",
-            __func__, __LINE__, mbssid_num_frames, interface_name, errno, strerror(errno));
-        return RETURN_ERR;
+    if (mbssid_num_frames_change) {
+        char nvram_name[IFNAMSIZ + sizeof("_mbssid_num_frames")];
+        char radio_dev[IFNAMSIZ];
+
+        snprintf(radio_dev, sizeof(radio_dev), "wl%d", radio->rdk_radio_index);
+        // supported by driver version 23.2.1
+        if (wl_iovar_set(radio_dev, "mbssid_num_frames", &mbssid_num_frames,
+                sizeof(mbssid_num_frames)) < 0) {
+            wifi_hal_error_print("%s:%d failed to set mbssid_num_frames %d for %s, err: %d (%s)\n",
+                __func__, __LINE__, mbssid_num_frames, radio_dev, errno, strerror(errno));
+            return RETURN_ERR;
+        }
+        snprintf(nvram_name, sizeof(nvram_name), "%s_mbssid_num_frames", radio_dev);
+        wifi_hal_info_print("%s:%d Writing nvram %s=%d\n", __func__,__LINE__, 
+            nvram_name, mbssid_num_frames);
+        set_decimal_nvram_param(nvram_name, mbssid_num_frames);
     }
 #endif // defined(XB10_PORT) || defined(SCXER10_PORT) || defined(SCXF10_PORT) || defined(TCXB8_PORT)
+    nvram_commit();
 
 #if !(defined(MLO_ENAB))
     if (wl_ioctl(interface_name, WLC_UP, NULL, 0) < 0) {

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -3229,8 +3229,8 @@ static int set_mld_shared_resources(struct hostapd_data *hapd)
 
             ret = hostapd_setup_bss_internal(link);
             if (ret) {
-                wifi_hal_error_print("%s:%d: set shared resources failed for link: %s\n",
-                    __func__, __LINE__, hapd->conf->iface);
+                wifi_hal_error_print("%s:%d: set shared resources failed for link: %s - first_bss %s\n",
+                    __func__, __LINE__, link->conf->iface, hapd->conf->iface);
                 return RETURN_ERR;
             }
         }


### PR DESCRIPTION
Reason for change: Store mbssid_num_frames configuration persistently in nvram.

Test Procedure: Verify if the configured mbssid_num_frames is stored persistently over the reboot and not being configured by OneWifi on each boot.

Risks: Low