### PR TITLE
RDKBWIFI-472: wifi_hal: Add API stub for BTM disassociation timer control

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -4865,7 +4865,7 @@ INT wifi_getNASta(INT apIndex, const wifi_na_sta_req_params_t *params, wifi_na_s
 
 INT wifi_setApIgnoreBTMDisassocTimer(INT apIndex, BOOL ignoreBTMDisassocTimer)
 {
-    (void)apIndex;
+    AP_INDEX_ASSERT(apIndex);
     (void)ignoreBTMDisassocTimer;
 
     wifi_hal_dbg_print("%s:%d: not supported (stub)\n", __func__, __LINE__);

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -4870,5 +4870,5 @@ INT wifi_setApIgnoreBTMDisassocTimer(INT apIndex, BOOL ignoreBTMDisassocTimer)
 
     wifi_hal_dbg_print("%s:%d: not supported (stub)\n", __func__, __LINE__);
 
-    return RETURN_ERR;
+    return WIFI_HAL_UNSUPPORTED;
 }

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -4863,9 +4863,9 @@ INT wifi_getNASta(INT apIndex, const wifi_na_sta_req_params_t *params, wifi_na_s
 #endif /* MXL_WIFI */
 }
 
-INT wifi_setApIgnoreBTMDisassocTimer(INT ap_index, BOOL ignoreBTMDisassocTimer)
+INT wifi_setApIgnoreBTMDisassocTimer(INT apIndex, BOOL ignoreBTMDisassocTimer)
 {
-    (void)ap_index;
+    (void)apIndex;
     (void)ignoreBTMDisassocTimer;
 
     wifi_hal_dbg_print("%s:%d: not supported (stub)\n", __func__, __LINE__);

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -4862,3 +4862,13 @@ INT wifi_getNASta(INT apIndex, const wifi_na_sta_req_params_t *params, wifi_na_s
     return WIFI_HAL_ERROR;
 #endif /* MXL_WIFI */
 }
+
+INT wifi_setApIgnoreBTMDisassocTimer(INT ap_index, BOOL ignoreBTMDisassocTimer)
+{
+    (void)ap_index;
+    (void)ignoreBTMDisassocTimer;
+
+    wifi_hal_dbg_print("%s:%d: not supported (stub)\n", __func__, __LINE__);
+
+    return RETURN_ERR;
+}


### PR DESCRIPTION
Reason for change:
This change introduces a new HAL API wifi_setApIgnoreBTMDisassocTimer() to control whether the HAL arms the internal disassociation timer associated with BTM requests.

The API is currently implemented as a stub and returns not supported, serving as a placeholder for future platform-specific implementation.

This enables integration with the OneWifi control path without impacting existing behavior.

Dep PR: https://github.com/rdkcentral/rdkb-halif-wifi/pull/113/
