### PR TITLE
RDKBACCL-1799:WPS is not working mlo enabled builds

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -17849,7 +17849,12 @@ int wifi_drv_wps_event_notify_cb(void *ctx, unsigned int event, void *data)
 
 #if !defined(TARGET_GEMINI7_2)
     if (event == WPS_EV_SUCCESS) {
-        wifi_hal_wps_cancel_on_other_radios(interface);
+        if (!wifi_hal_is_mld_enabled(interface)) {
+            wifi_hal_wps_cancel_on_other_radios(interface);
+        } else {
+            wifi_hal_dbg_print("%s:%d: MLD enabled - skip wps_cancel_on_other_radios "
+                "to avoid deauthing the just-enrolled STA\n", __func__, __LINE__);
+        }
     }
 #endif
 


### PR DESCRIPTION
Reason for change:For MLD, all 3 radios share the same hostapd MLD AP, so canceling WPS "on other radios" cancels WPS on the same AP. 
Test Procedure: WPS 2ghz/5ghz should connect on MLD enabled AP's build.
Risks: Low