### PR TITLE
XER10-3003 : WiFi temperature subscription not working as expected

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -2741,7 +2741,7 @@ int nvram_get_mgmt_frame_power_control(int vap_index, int* output_dbm)
     return RETURN_OK;
 }
 
-#if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(RDKB_ONE_WIFI_PROD)
+#if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || defined(RDKB_ONE_WIFI_PROD) || defined(SCXER10_PORT)
 
 static int get_radio_phy_temp_handler(struct nl_msg *msg, void *arg)
 {


### PR DESCRIPTION
Reason for change: XER10 product flag addition is done for radio temp handler
Test Procedure: Check whether we could retrieve the wifi radio temperature
Risks: Low
Priority: P1