### PR TITLE
RDKBWIFI-477 wifi_hal: Add ACS exclusion list API stub

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -5035,3 +5035,15 @@ INT wifi_hal_get_RegDomain(wifi_radio_index_t radioIndex, UINT *reg_domain)
     }
     return RETURN_ERR;
 }
+
+INT wifi_hal_set_acs_exclusion_list(wifi_radio_index_t radioIndex, wifi_hal_acs_exclude_t *list, INT count, INT *operating_channel_excluded)
+{
+    (void)radioIndex;
+    (void)list;
+    (void)count;
+    (void)operating_channel_excluded;
+
+    wifi_hal_error_print("%s:%d: not supported\n", __func__, __LINE__);
+
+    return WIFI_HAL_ERROR;
+}


### PR DESCRIPTION
Introduce wifi_hal_set_acs_exclusion_list() API in wifi_hal.c to support ACS channel exclusion list functionality added in OneWifi. This provides a default stub implementation that logs "not supported" and returns WIFI_HAL_ERROR.

Signed-off-by: sgunasekaran@maxlinear.com

Dep PR: https://github.com/rdkcentral/rdkb-halif-wifi/pull/115