### PR TITLE
RDKBACCL-1654: [TDK][AUTO][BPI][DML]Unable to toggle value of Device.WiFi.Radio.<i>.X_CISCO_COM_11nGreenfieldEnabled

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8240,6 +8240,7 @@ int nl80211_update_wiphy(wifi_radio_info_t *radio)
     while (interface != NULL) {
         if (interface->bss_started) {
                 reconfigure = true;
+#if !defined(CONFIG_GENERIC_MLO)
                 nl80211_enable_ap(interface, false);
                 pthread_mutex_lock(&g_wifi_hal.hapd_lock);
                 deinit_bss(&interface->u.ap.hapd);
@@ -8248,6 +8249,7 @@ int nl80211_update_wiphy(wifi_radio_info_t *radio)
 
                 pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
                 nl80211_interface_enable(wifi_hal_get_interface_name(interface), false);
+#endif
         }
         interface = hash_map_get_next(radio->interface_map, interface);
     }


### PR DESCRIPTION
Reason for Change: 
-> During RadioOperatingParameter toggle, Generic MLO reconfiguration flow disables the AP, deinitializes BSS, and brings down mld0, causing SSID broadcast and MLO link IDs to be lost. 
-> Skip the teardown sequence for CONFIG_GENERIC_MLO to maintain the MLD interface state. 
Test Procedure: After toggling the RadioOperatingParameter, verify that mld0 remains up, SSIDs continue broadcasting, and MLO link IDs are present. Risks: Low