### PR TITLE
XB10-2803: [25Q2 Sprint] After Factory Reset apsta value is 0 (#767)

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -912,6 +912,22 @@ void platform_mlo_post_init(void)
     }
     platform_mlo_up();
 }
+
+/* apsta iovar is per-radio, not per-BSS */
+static int platform_set_apsta(wifi_radio_index_t index, bool enable)
+{
+    int apsta_enable = enable ? 1 : 0;
+    char osifname[IFNAMSIZ] = { 0 };
+
+    snprintf(osifname, sizeof(osifname), "wl%d", index);
+    if (wl_iovar_set(osifname, "apsta", &apsta_enable, sizeof(apsta_enable)) < 0) {
+        wifi_hal_error_print("%s: failed to set apsta %d for %s, err: %d (%s)\n", __func__,
+            apsta_enable, osifname, errno, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
 #endif /* MLO_ENAB */
 
 int platform_pre_init()
@@ -942,6 +958,11 @@ int platform_pre_init()
     _platform_init_done = FALSE;
 
     platform_radio_up(-1, FALSE); /* Bring all radios down */
+
+    for(int radio_idx = 0; radio_idx < MAX_NUM_RADIOS; radio_idx++) {
+	    platform_set_apsta(radio_idx, true);
+    }
+
     platform_mlo_init();
 #endif /* MLO_ENAB */
     return 0;


### PR DESCRIPTION
* XB10-2803: [25Q2 Sprint] After Factory Reset apsta value is 0

Reason for change: force radio interfaces (wlX) to apsta mode during platform init as suggested in BCM recommendation (BCOMB-3470)

Test Procedure: verify that wlX interfaces are in AP mode in following cases:
1) After FR boot
2) After plain reboot

Risks: Low



* Potential fix for pull request finding



---------




(cherry picked from commit 57c516401cd534301e5e83bcbee4d30458292185)