### PR TITLE
RDKB-63816: 2g/5g LnF status is down at driver level after reboot

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -774,7 +774,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
     conf->rdkb_eap_request_timeout = sec->eap_req_timeout;
     conf->rdkb_eap_request_retries = sec->eap_req_retries;
 #endif
-    if (conf->ieee802_1x || is_open_sec_radius_auth(sec) || conf->mdu) {
+    if (conf->ieee802_1x || is_open_sec_radius_auth(sec) || (conf->mdu && sec->repurposed_radius.ip[0] != '\0')) {
         wifi_radius_settings_t *radius_cfg;
         if (conf->mdu) {
             radius_cfg = &sec->repurposed_radius;


### PR DESCRIPTION
Reason for change:

lnf_psk_* VAPs with MDU enabled fail initial wifi_hal_createVAP when repurposed_radius.ip is empty (waiting for Hotspot RFC to populate it).

Risks: Low
Priority: P1