### PR TITLE
RDKBWIFI-464: EasyMesh : AP Capability Report (Wi-Fi 7 Agent Capabilities

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -532,11 +532,46 @@ int platform_get_radio_caps(wifi_radio_index_t index)
 #if HOSTAPD_VERSION >= 211
     wifi_radio_info_t *radio;
     wifi_interface_info_t *interface;
+    wifi_multi_link_modes_t mld_oper_cap = 0;
+    BOOL tid_negotiation = false;
+    u16 eml_capa = 0, mld_capa_and_ops = 0;
+    unsigned int i;
+    BOOL ap_ext_capa_present = false;
+
     radio = get_radio_by_rdk_index(index);
     if (radio == NULL) {
         wifi_hal_dbg_print("%s:%d failed to get radio for index\n", __func__, __LINE__);
         return RETURN_ERR;
     }
+
+    for (i = 0; i < radio->driver_data.num_iface_ext_capa; i++) {
+        if (radio->driver_data.iface_ext_capa[i].iftype == NL80211_IFTYPE_AP) {
+            ap_ext_capa_present = true;
+            eml_capa = radio->driver_data.iface_ext_capa[i].eml_capa;
+            mld_capa_and_ops = radio->driver_data.iface_ext_capa[i].mld_capa_and_ops;
+            break;
+        }
+    }
+
+    /* Fallback to UNSPECIFIED if AP-specific data is not present */
+    if (!ap_ext_capa_present) {
+        for (i = 0; i < radio->driver_data.num_iface_ext_capa; i++) {
+            if (radio->driver_data.iface_ext_capa[i].iftype == NL80211_IFTYPE_UNSPECIFIED) {
+                eml_capa = radio->driver_data.iface_ext_capa[i].eml_capa;
+                mld_capa_and_ops = radio->driver_data.iface_ext_capa[i].mld_capa_and_ops;
+                break;
+            }
+        }
+    }
+
+    wifi_get_mld_eml_cap(mld_capa_and_ops, eml_capa, &mld_oper_cap, &tid_negotiation);
+
+    if (mld_capa_and_ops || eml_capa) {
+        radio->driver_data.capa.flags2 |= WPA_DRIVER_FLAGS2_MLO;
+    }
+
+    radio->capab.TIDLinkMapNegotiation = tid_negotiation;
+    radio->capab.mldOperationalCap = mld_oper_cap;
 
     for (interface = hash_map_get_first(radio->interface_map); interface != NULL;
         interface = hash_map_get_next(radio->interface_map, interface)) {


### PR DESCRIPTION
RDKBWIFI-464: EasyMesh : AP Capability Report (Wi-Fi 7 Agent Capabilities

Reason for change: Added changes to retrive WiFi7 MLD capabilities and tid link map negotiation for BPI device.
Test Procedure: Ensure Wi-Fi 7 Agent Capabilities are updated properly.
Risks: Medium
Priority: P1