### PR TITLE
RDKBWIFI-499: Neighbor scan fails on non-MLO Interfaces

### DIFF
--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -1813,8 +1813,10 @@ int process_global_nl80211_event(struct nl_msg *msg, void *arg)
         /* Special case for SCAN events - don't drop these event even if the interface is not fully
          * configured */
 #if defined(CONFIG_GENERIC_MLO)
-        /* If driver did not provide LINK_ID, fallback safely */
-        if (link_id == NL80211_DRV_LINK_ID_NA) {
+        /* Only for MLD interface when driver does not send LINK_ID, fallback safely */
+        if (link_id == NL80211_DRV_LINK_ID_NA && interface != NULL &&
+             interface->mld_name[0] != '\0' && strcmp(interface->mld_name, MLD_INTERFACE_NAME) == 0) {
+            wifi_hal_dbg_print("%s:%d: Using MLO fallback path\n",__func__, __LINE__);
             for (unsigned int i = 0; i < priv->num_radios; i++) {
                 radio = &priv->radio_info[i];
 


### PR DESCRIPTION
**Problem statement: **
Neighbor scan results are not processed for non-MLO interfaces under certain scenarios. The current scan event handling logic introduces an MLO fallback path when NL80211_ATTR_MLO_LINK_ID is not present. However, this path is intended only for MLD interfaces and can result in scan events being processed exclusively for MLO interfaces while non-MLO interfaces are skipped.

**Fix:**
Update scan event handling to ensure non-MLO interfaces are processed through the normal interface lookup path while restricting MLO fallback processing only to applicable MLD interfaces. This guarantees delivery of scan result events for all valid interfaces.

Test Procedure: Checked with onboarding the collocated agent and connected the extender device as well, observed the scan is being processed for all the band and able to see the scan result as well.

Risks: Low