### PR TITLE
BCOMB-3480: Client connectivity drop due to Gateway blocking Unencrypted frames

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -4319,6 +4319,20 @@ void wifi_hal_apDeAuthEvent_callback_register(wifi_device_deauthenticated_callba
     callbacks->num_apDeAuthEvent_cbs++;
 }
 
+void wifi_hal_apFrameDropUnencrypted_callback_register(wifi_apFrameDropUnencrypted_callback func)
+{
+    wifi_device_callbacks_t *callbacks;
+
+    callbacks = get_hal_device_callbacks();
+
+    if (callbacks == NULL || callbacks->num_frame_drop_unenc_cbs >= MAX_REGISTERED_CB_NUM) {
+        return;
+    }
+
+    callbacks->frame_drop_unenc_cb[callbacks->num_frame_drop_unenc_cbs] = func;
+    callbacks->num_frame_drop_unenc_cbs++;
+}
+
 INT wifi_vapstatus_callback_register(wifi_vapstatus_callback func) {
     wifi_device_callbacks_t *callbacks;
 

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -1714,13 +1714,14 @@ static void nl80211_handle_frame_drop_unenc(wifi_interface_info_t *interface,
         ether_type = nla_get_u16(tb[FRAME_DROP_UNENC_ATTR_ETHER_TYPE]);
     }
 
+    const char *sta = to_mac_str(sta_mac, sta_mac_str);
+
     wifi_hal_dbg_print("%s:%d: nl80211: FRAME_DROP_UNENC ap_index=%d sta=%s ethertype=0x%04x\n",
-        __func__, __LINE__, vap->vap_index, to_mac_str(sta_mac, sta_mac_str), ether_type);
+        __func__, __LINE__, vap->vap_index, sta, ether_type);
 
     for (unsigned int i = 0; i < callbacks->num_frame_drop_unenc_cbs; i++) {
         if (callbacks->frame_drop_unenc_cb[i] != NULL) {
-            callbacks->frame_drop_unenc_cb[i](vap->vap_index,
-                to_mac_str(sta_mac, sta_mac_str), ether_type);
+            callbacks->frame_drop_unenc_cb[i](vap->vap_index, sta, ether_type);
         }
     }
 }

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -1714,14 +1714,14 @@ static void nl80211_handle_frame_drop_unenc(wifi_interface_info_t *interface,
         ether_type = nla_get_u16(tb[FRAME_DROP_UNENC_ATTR_ETHER_TYPE]);
     }
 
-    const char *sta = to_mac_str(sta_mac, sta_mac_str);
+    (void)to_mac_str(sta_mac, sta_mac_str);
 
     wifi_hal_dbg_print("%s:%d: nl80211: FRAME_DROP_UNENC ap_index=%d sta=%s ethertype=0x%04x\n",
-        __func__, __LINE__, vap->vap_index, sta, ether_type);
+        __func__, __LINE__, vap->vap_index, sta_mac_str, ether_type);
 
     for (unsigned int i = 0; i < callbacks->num_frame_drop_unenc_cbs; i++) {
         if (callbacks->frame_drop_unenc_cb[i] != NULL) {
-            callbacks->frame_drop_unenc_cb[i](vap->vap_index, sta, ether_type);
+            callbacks->frame_drop_unenc_cb[i](vap->vap_index, sta_mac_str, ether_type);
         }
     }
 }

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -1662,6 +1662,83 @@ void nl80211_vendor_event_ltq(wifi_interface_info_t *interface, unsigned int sub
 
 #endif // CMXB7_PORT
 
+/* Broadcom vendor OUI and the subcmd / NLA attributes used by the driver
+ * for the WLC_E_FRAME_DROP_UNENC vendor event.  Kept in sync with
+ * wlan/wl_25.1P1/.../wl_cfgvendor_common.h.
+ */
+#define OUI_BRCM 0x001018
+#define BRCM_VENDOR_EVENT_FRAME_DROP_UNENC 3
+
+enum frame_drop_unenc_attr {
+    FRAME_DROP_UNENC_ATTR_UNSPEC,
+    FRAME_DROP_UNENC_ATTR_STA_MAC,
+    FRAME_DROP_UNENC_ATTR_ETHER_TYPE,
+    FRAME_DROP_UNENC_ATTR_MAX
+};
+
+static void nl80211_handle_frame_drop_unenc(wifi_interface_info_t *interface,
+                                            unsigned char *data, size_t len)
+{
+    wifi_device_callbacks_t *callbacks = get_hal_device_callbacks();
+    wifi_vap_info_t *vap = &interface->vap_info;
+    struct nlattr *tb[FRAME_DROP_UNENC_ATTR_MAX];
+    mac_address_t sta_mac;
+    mac_addr_str_t sta_mac_str;
+    unsigned short ether_type = 0;
+
+    if (callbacks == NULL || callbacks->num_frame_drop_unenc_cbs == 0) {
+        return;
+    }
+
+    if (data == NULL || len == 0) {
+        wifi_hal_error_print("%s:%d: nl80211: FRAME_DROP_UNENC vendor event with no payload\n",
+            __func__, __LINE__);
+        return;
+    }
+
+    if (nla_parse(tb, FRAME_DROP_UNENC_ATTR_MAX - 1, (struct nlattr *)data, (int)len, NULL) < 0) {
+        wifi_hal_error_print("%s:%d: nl80211: FRAME_DROP_UNENC nla_parse failed\n",
+            __func__, __LINE__);
+        return;
+    }
+
+    if (tb[FRAME_DROP_UNENC_ATTR_STA_MAC] == NULL ||
+        nla_len(tb[FRAME_DROP_UNENC_ATTR_STA_MAC]) < (int)sizeof(mac_address_t)) {
+        wifi_hal_error_print("%s:%d: nl80211: FRAME_DROP_UNENC missing STA MAC\n",
+            __func__, __LINE__);
+        return;
+    }
+    memcpy(sta_mac, nla_data(tb[FRAME_DROP_UNENC_ATTR_STA_MAC]), sizeof(mac_address_t));
+
+    if (tb[FRAME_DROP_UNENC_ATTR_ETHER_TYPE] != NULL) {
+        ether_type = nla_get_u16(tb[FRAME_DROP_UNENC_ATTR_ETHER_TYPE]);
+    }
+
+    wifi_hal_dbg_print("%s:%d: nl80211: FRAME_DROP_UNENC ap_index=%d sta=%s ethertype=0x%04x\n",
+        __func__, __LINE__, vap->vap_index, to_mac_str(sta_mac, sta_mac_str), ether_type);
+
+    for (unsigned int i = 0; i < callbacks->num_frame_drop_unenc_cbs; i++) {
+        if (callbacks->frame_drop_unenc_cb[i] != NULL) {
+            callbacks->frame_drop_unenc_cb[i](vap->vap_index,
+                to_mac_str(sta_mac, sta_mac_str), ether_type);
+        }
+    }
+}
+
+static void nl80211_vendor_event_brcm(wifi_interface_info_t *interface, unsigned int subcmd,
+                                      unsigned char *data, size_t len)
+{
+    switch (subcmd) {
+        case BRCM_VENDOR_EVENT_FRAME_DROP_UNENC:
+            nl80211_handle_frame_drop_unenc(interface, data, len);
+            break;
+        default:
+            wifi_hal_dbg_print("%s:%d: nl80211: Ignore unsupported BRCM vendor event %u\n",
+                __func__, __LINE__, subcmd);
+            break;
+    }
+}
+
 static void nl80211_vendor_event(wifi_interface_info_t *interface,
                     struct nlattr **tb)
 {
@@ -1695,6 +1772,9 @@ static void nl80211_vendor_event(wifi_interface_info_t *interface,
         nl80211_vendor_event_ltq(interface, subcmd, data, len);
         break;
 #endif // CMXB7_PORT
+    case OUI_BRCM:
+        nl80211_vendor_event_brcm(interface, subcmd, data, len);
+        break;
     default:
         wifi_hal_dbg_print("%s:%d: nl80211: Ignore unsupported vendor event\n", __func__, __LINE__);
         break;

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -956,6 +956,7 @@ void wifi_hal_apStatusCode_callback_register(wifi_apStatusCode_callback func);
 void wifi_hal_radiusEapFailure_callback_register(wifi_radiusEapFailure_callback func);
 void wifi_hal_radiusFallback_failover_callback_register(wifi_radiusFallback_failover_callback func);
 void wifi_hal_apDeAuthEvent_callback_register(wifi_device_deauthenticated_callback func);
+void wifi_hal_apFrameDropUnencrypted_callback_register(wifi_apFrameDropUnencrypted_callback func);
 void wifi_hal_ap_max_client_rejection_callback_register(wifi_apMaxClientRejection_callback func);
 INT wifi_hal_BTMQueryRequest_callback_register(UINT apIndex,
                                             wifi_BTMQueryRequest_callback btmQueryCallback,

--- a/src/wifi_hal_rdk_framework.h
+++ b/src/wifi_hal_rdk_framework.h
@@ -155,6 +155,8 @@ typedef struct {
     wifi_device_deauthenticated_callback    apDeAuthEvent_cb[MAX_REGISTERED_CB_NUM];
     wifi_vapstatus_callback                 vapstatus_cb[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_apDeAuthEvent_cbs;
+    wifi_apFrameDropUnencrypted_callback    frame_drop_unenc_cb[MAX_REGISTERED_CB_NUM];
+    unsigned int                            num_frame_drop_unenc_cbs;
     wifi_receivedMgmtFrame_callback         mgmt_frame_rx_callback;
     wifi_receivedDataFrame_callback         data_frame_rx_callback;
        


### PR DESCRIPTION
Reason for change : DHCP discover gets dropped because STA sends it without encryption.
Proposed Fix : Disassociate the client if it doesn't have IP
Test Proceedure : STA sending unprotected frame without having IP should disassociate.
Priority: P0
Risks: Low

Dependent PR : [rdkb-halif-wifi pull#119](https://github.com/rdkcentral/rdkb-halif-wifi/pull/119)