### PR TITLE
XB10-2872: Add per radio-level MLD link ID

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -140,6 +140,9 @@ static bool needs_conf_split_assoc_req(uint vap_index, int hostap_mgt_frame_ctrl
 
 static void set_wl_runtime_configs (const wifi_vap_info_map_t *vap_map);
 static int get_chanspec_string(wifi_radio_operationParam_t *operationParam, char *chspec, wifi_radio_index_t index);
+#if defined(CONFIG_IEEE80211BE)
+static void nvram_update_wl_mlo_config(unsigned int radio_index, int mld_link_id, int *nvram_changed);
+#endif /* CONFIG_IEEE80211BE */
 int sta_disassociated(int ap_index, char *mac, int reason);
 int sta_deauthenticated(int ap_index, char *mac, int reason);
 int sta_associated(int ap_index, wifi_associated_dev_t *associated_dev);
@@ -1913,6 +1916,9 @@ static int get_chanspec_string(wifi_radio_operationParam_t *operationParam, char
 
 int platform_set_radio(wifi_radio_index_t index, wifi_radio_operationParam_t *operationParam)
 {
+#if defined(CONFIG_IEEE80211BE)
+    int nvram_changed = 0;
+#endif /* CONFIG_IEEE80211BE */
     char temp_buff[BUF_SIZE];
     char param_name[NVRAM_NAME_SIZE];
     char chspecbuf[NVRAM_NAME_SIZE];
@@ -1966,6 +1972,16 @@ int platform_set_radio(wifi_radio_index_t index, wifi_radio_operationParam_t *op
     memset(param_name, 0 ,sizeof(param_name));
     sprintf(param_name, "wl%d_bcn", index);
     set_decimal_nvram_param(param_name, operationParam->beaconInterval);
+
+#if defined(CONFIG_IEEE80211BE)
+    nvram_update_wl_mlo_config(index,
+        operationParam->mldLinkId < MAX_NUM_MLD_LINKS ? (int)operationParam->mldLinkId : -1,
+        &nvram_changed);
+    if (nvram_changed) {
+        nvram_commit();
+    }
+#endif /* CONFIG_IEEE80211BE */
+
 
 #if defined(MLO_ENAB)
     if (_platform_init_done != FALSE) {
@@ -5283,9 +5299,6 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
     radio_enabled = (radio != NULL) ? radio->oper_param.enable : false;
     mld_conf = &vap->u.bss_info.mld_info.common_info;
     nvram_update_wl_mlo_apply(conf->iface, 1, &nvram_changed);
-
-    nvram_update_wl_mlo_config(vap->radio_index,
-        mld_conf->mld_link_id < MAX_NUM_MLD_LINKS ? mld_conf->mld_link_id : -1, &nvram_changed);
 
     old_mld_link_id = hapd->mld_link_id;
     hapd->mld_link_id = platform_get_link_id_for_radio_index(vap->radio_index, vap->vap_index);

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -1004,6 +1004,18 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
         }
     }
 
+#if defined(CONFIG_IEEE80211BE) && defined(XB10_PORT)
+    if (radio->configured && radio->oper_param.mldLinkId != operationParam->mldLinkId) {
+        radio->oper_param.mldLinkId = operationParam->mldLinkId;
+
+        if (memcmp((unsigned char *)&radio->oper_param, (unsigned char *)operationParam, sizeof(wifi_radio_operationParam_t)) == 0) {
+            wifi_hal_dbg_print("%s:%d: radio %d: MLD link id changed to %d; light  refresh, no radio/VAP reconfiguration\n",
+                __func__, __LINE__, index, radio->oper_param.mldLinkId);
+            goto Exit;
+        }
+    }
+#endif /* CONFIG_IEEE80211BE */
+
 try_hostap_config_update:
     if (radio->configured && is_channel_changed) {
         radio->configuration_in_progress = true;
@@ -1045,31 +1057,6 @@ Exit:
     if (!radio->configured) {
         radio->configured = true;
     }
-
-#if defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL) && (HOSTAPD_VERSION >= 210)
-    for (unsigned int radio_index = 0; radio_index < g_wifi_hal.num_radios; radio_index++) {
-        wifi_interface_info_t *interface_iter = NULL;
-
-        if (index == radio_index) {
-            continue;
-        }
-        wifi_radio_info_t *radio_iter = get_radio_by_rdk_index(radio_index);
-        if (radio_iter == NULL) {
-            continue;
-        }
-
-        hash_map_foreach(radio_iter->interface_map, interface_iter) {
-            if (interface_iter->vap_info.vap_mode != wifi_vap_mode_ap ||
-                !interface_iter->vap_info.u.bss_info.enabled ||
-                !interface_iter->vap_info.u.bss_info.hostap_mgt_frame_ctrl) {
-                continue;
-            }
-
-            ieee802_11_set_beacon(&interface_iter->u.ap.hapd);
-        }
-    }
-
-#endif // defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL) &&  (HOSTAPD_VERSION >= 210)
 
     free(old_operationParam);
     old_operationParam = NULL;

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -964,6 +964,38 @@ static void ch_switch_update_hostap_config(wifi_radio_info_t *radio, u8 channel,
     pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
 }
 
+#if defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL) && (HOSTAPD_VERSION >= 210)
+/*
+ * A channel switch on switched_interface's radio makes the RNR / AP Channel
+ * Report that other radios' beacons advertise for this radio stale. Refresh
+ * every enabled AP VAP on the other radios so their beacons are regenerated.
+ * Caller must hold g_wifi_hal.hapd_lock.
+ */
+static void nl80211_refresh_colocated_beacons(wifi_interface_info_t *switched_interface)
+{
+    for (unsigned int radio_index = 0; radio_index < g_wifi_hal.num_radios; radio_index++) {
+        wifi_interface_info_t *interface_iter = NULL;
+        wifi_radio_info_t *radio_iter;
+
+        if (radio_index == switched_interface->vap_info.radio_index) {
+            continue;
+        }
+        radio_iter = get_radio_by_rdk_index(radio_index);
+        if (radio_iter == NULL) {
+            continue;
+        }
+        hash_map_foreach(radio_iter->interface_map, interface_iter) {
+            if (interface_iter->vap_info.vap_mode != wifi_vap_mode_ap ||
+                !interface_iter->vap_info.u.bss_info.enabled ||
+                !interface_iter->vap_info.u.bss_info.hostap_mgt_frame_ctrl) {
+                continue;
+            }
+            ieee802_11_update_beacons(interface_iter->u.ap.hapd.iface);
+        }
+    }
+}
+#endif // FEATURE_HOSTAP_MGMT_FRAME_CTRL && HOSTAPD_VERSION >= 210
+
 static void nl80211_ch_switch_notify_event(wifi_interface_info_t *interface, struct nlattr **tb, wifi_chan_eventType_t wifi_chan_event_type)
 {
     int ifidx = 0, freq = 0, bw = NL80211_CHAN_WIDTH_20_NOHT, cf1 = 0, cf2 = 0;
@@ -1151,6 +1183,9 @@ static void nl80211_ch_switch_notify_event(wifi_interface_info_t *interface, str
             if (interface->beacon_set) {
                 ieee802_11_set_beacon(&interface->u.ap.hapd);
             }
+#if defined(FEATURE_HOSTAP_MGMT_FRAME_CTRL) && (HOSTAPD_VERSION >= 210)
+            nl80211_refresh_colocated_beacons(interface);
+#endif // FEATURE_HOSTAP_MGMT_FRAME_CTRL && HOSTAPD_VERSION >= 210
             pthread_mutex_unlock(&g_wifi_hal.hapd_lock);
         }
     }


### PR DESCRIPTION
Reason for change: Move MLD link ID ownership to radio configuration
                   Optimize beacon update logic only when channel is changed
                   to avoid unnecessary beacon updates.
Test Procedure: Configure MLO and check client connectivity Risks: Medium
Priority: P1