### PR TITLE
TCXB8-4143: Improve wifi_hal_init() resiliency on boot.

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -6191,9 +6191,52 @@ int nl80211_delete_interfaces(wifi_radio_info_t *radio)
     return 0;
 }
 
+/* TCXB8-4143: the wl driver registers the primary wlX netdevs asynchronously
+ * after its module reports "Live" in /proc/modules, so the wait at the lsmod
+ * gate in wifi_hal_init() is not sufficient. Poll the per-wiphy interface
+ * dump until the primary netdev shows up or the budget expires.
+ * Repeated calls are safe, as interface_info_handler() filters out duplicate names.
+ *
+ * Keep PRIMARY_IF_WAIT_BUDGET_MS
+ * comfortably below the 12 s wifi-hal watchdog. */
+#define PRIMARY_IF_WAIT_BUDGET_MS   5000
+#define PRIMARY_IF_WAIT_STEP_MS     100
+
+static wifi_interface_info_t *nl80211_wait_for_primary_interface(wifi_radio_info_t *radio)
+{
+    wifi_interface_info_t *primary_interface;
+    struct nl_msg *msg;
+    int waited_ms = 0;
+
+    while ((primary_interface = get_primary_interface(radio)) == NULL &&
+        waited_ms < PRIMARY_IF_WAIT_BUDGET_MS) {
+        usleep(PRIMARY_IF_WAIT_STEP_MS * 1000);
+        waited_ms += PRIMARY_IF_WAIT_STEP_MS;
+
+        /* re-enumerate this wiphy's netdevs */
+        msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, NULL, NLM_F_DUMP,
+            NL80211_CMD_GET_INTERFACE);
+        if (msg == NULL) {
+            return NULL;
+        }
+        nla_put_u32(msg, NL80211_ATTR_WIPHY, radio->index);
+        if (nl80211_send_and_recv(msg, interface_info_handler, radio, NULL, NULL)) {
+            /* temporary dump failure: keep polling until the budget expires */
+            continue;
+        }
+    }
+
+    if (primary_interface != NULL && waited_ms != 0) {
+        wifi_hal_info_print("%s:%d: primary interface of dev:%d appeared after %d ms\n",
+            __func__, __LINE__, radio->index, waited_ms);
+    }
+    return primary_interface;
+}
+
 int nl80211_init_primary_interfaces()
 {
-    unsigned int i, ret;
+    unsigned int i;
+    int ret;
     struct nl_msg *msg;
     wifi_radio_info_t *radio;
     wifi_interface_info_t *primary_interface;
@@ -6205,7 +6248,7 @@ int nl80211_init_primary_interfaces()
             wifi_hal_error_print("%s:%d: Skip the Radio %d .This is sleeping in ECO mode \n", __func__, __LINE__, radio->index);
             continue;
         }
-        primary_interface = get_primary_interface(radio);
+        primary_interface = nl80211_wait_for_primary_interface(radio);
         if (primary_interface == NULL) {
             wifi_hal_error_print("%s:%d: Error updating dev:%d no primary interfaces exist\n", __func__, __LINE__, radio->index);
             return -1;
@@ -6228,7 +6271,7 @@ int nl80211_init_primary_interfaces()
         if ((ret = nl80211_send_and_recv(msg, interface_info_handler, radio, NULL, NULL))) {
             wifi_hal_error_print("%s:%d: Error updating %s interface on dev:%d error: %d (%s) \n",
                 __func__, __LINE__, interface->name, radio->index, ret, strerror(-ret));
-            if (ret != ENODEV) {
+            if (ret != -ENODEV) {
                 // Try updating the mode again after bringing the interface down
                 nl80211_interface_enable(interface->name, false);
                 wifi_hal_dbg_print(

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -5798,6 +5798,11 @@ static u32 get_nl80211_protocol_features(int nl_id)
 int init_nl80211()
 {
     int ret;
+    /* TCXB8-4143: keep WIPHY_DUMP_WAIT_BUDGET_MS + PRIMARY_IF_WAIT_BUDGET_MS
+     * comfortably below the 12s wifi-hal watchdog. */
+#define WIPHY_DUMP_WAIT_BUDGET_MS   5000
+#define WIPHY_DUMP_WAIT_STEP_MS     200
+    int wiphy_wait_ms = 0;
 #if defined(VNTXER5_PORT) || defined(TARGET_GEMINI7_2) || defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT) || \
     defined(SCXER10_PORT) || defined(SCXF10_PORT)
     u32 feat;
@@ -5908,6 +5913,7 @@ int init_nl80211()
     remap_wifi_interface_name_index_map();
     #endif /* RDKB_ONE_WIFI_PROD */
 
+retry_wiphy_dump:
 #if !defined(VNTXER5_PORT) && !defined(TARGET_GEMINI7_2) && !defined(TCXB7_PORT) && !defined(TCXB8_PORT) && \
     !defined(XB10_PORT) && !defined(SCXER10_PORT) && !defined(SCXF10_PORT)
     msg = nl80211_drv_cmd_msg(g_wifi_hal.nl80211_id, NULL, NLM_F_DUMP, NL80211_CMD_GET_WIPHY);
@@ -5928,6 +5934,23 @@ int init_nl80211()
 
     if (nl80211_send_and_recv(msg, wiphy_dump_handler, &g_wifi_hal, NULL, NULL)) {
         return -1;
+    }
+
+    /* TCXB8-4143: a wiphy whose registration is still in progress is invisible in
+     * this snapshot and would be misclassified as an ECO-sleeping radio by
+     * create_ecomode_interfaces(). Retry (wiphy_dump_handler filters duplicates)
+     * while an expected, non-ECO radio is missing and the wait budget
+     * lasts; after the budget the old behaviour applies. */
+    if (nl80211_expected_radio_missing() &&
+        wiphy_wait_ms < WIPHY_DUMP_WAIT_BUDGET_MS) {
+        usleep(WIPHY_DUMP_WAIT_STEP_MS * 1000);
+        wiphy_wait_ms += WIPHY_DUMP_WAIT_STEP_MS;
+        goto retry_wiphy_dump;
+    }
+
+    if (wiphy_wait_ms != 0) {
+        wifi_hal_info_print("%s:%d: wiphy dump settled after %d ms, %d radios\n",
+            __func__, __LINE__, wiphy_wait_ms, g_wifi_hal.num_radios);
     }
 
     wifi_hal_dbg_print("%s:%d: Number of supported radios: %d\n", __func__, __LINE__, g_wifi_hal.num_radios);

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -4159,7 +4159,7 @@ void update_ecomode_radio_capabilities(wifi_radio_info_t *radio)
 /* TCXB8-4143: helpers to distinguish "wiphy not registered yet" (transient,
  * worth waiting for) from "radio in ECO deep power down" (permanent for this
  * boot, backfilled by create_ecomode_interfaces()). */
-+static bool rdk_radio_discovered(int rdk_radio_index)
+static bool rdk_radio_discovered(int rdk_radio_index)
 {
     unsigned int i;
 

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -4156,6 +4156,61 @@ void update_ecomode_radio_capabilities(wifi_radio_info_t *radio)
             break;
     }
 }
+/* TCXB8-4143: helpers to distinguish "wiphy not registered yet" (transient,
+ * worth waiting for) from "radio in ECO deep power down" (permanent for this
+ * boot, backfilled by create_ecomode_interfaces()). */
++static bool rdk_radio_discovered(int rdk_radio_index)
+{
+    unsigned int i;
+
+    for (i = 0; i < g_wifi_hal.num_radios; i++) {
+        if (g_wifi_hal.radio_info[i].rdk_radio_index == rdk_radio_index) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool radio_in_eco_sleep(int rdk_radio_index)
+{
+#if defined(TCXB8_PORT)
+    /* same source of truth as platform_update_radio_presence() */
+    char cmd[32] = { 0 };
+    char buf[2] = { 0 };
+    bool sleeping = false;
+    FILE *fp;
+
+    snprintf(cmd, sizeof(cmd), "nvram kget wl%d_dpd", rdk_radio_index);
+    if ((fp = popen(cmd, "r")) != NULL) {
+        if (fgets(buf, sizeof(buf), fp) != NULL) {
+            sleeping = (atoi(buf) == 1);
+        }
+        pclose(fp);
+    }
+    return sleeping;
+#else
+    /* platforms without ECO deep power down: a mapped radio is always
+     * expected to register a wiphy */
+    (void)rdk_radio_index;
+    return false;
+#endif
+}
+
+bool nl80211_expected_radio_missing(void)
+{
+    unsigned int i;
+
+    for (i = 0; i < get_sizeof_radio_interfaces_map(); i++) {
+        if (!rdk_radio_discovered(l_radio_interface_map[i].radio_index) &&
+            !radio_in_eco_sleep(l_radio_interface_map[i].radio_index)) {
+            wifi_hal_info_print("%s:%d: radio %s (rdk index %d) not registered yet\n",
+                __func__, __LINE__, l_radio_interface_map[i].radio_name,
+                l_radio_interface_map[i].radio_index);
+            return true;
+        }
+    }
+    return false;
+}
 
 int create_ecomode_interfaces(void)
 {

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -960,6 +960,7 @@ int nl80211_disconnect_sta(wifi_interface_info_t *interface);
 int wifi_hal_purgeScanResult(unsigned int vap_index, unsigned char *sta_mac);
 void get_wifi_interface_info_map(wifi_interface_name_idex_map_t *interface_map);
 void get_radio_interface_info_map(radio_interface_mapping_t *radio_interface_map);
+bool nl80211_expected_radio_missing(void);
 unsigned int get_sizeof_interfaces_index_map(void);
 int validate_radio_operation_param(wifi_radio_operationParam_t *param);
 int validate_wifi_interface_vap_info_params(wifi_vap_info_t *vap_info, char *msg, int len);


### PR DESCRIPTION
Reason for change : OneWifi crashes with SIGABRT via assert (hal_initialized == RETURN_OK), raised because wifi_hal_init() failed before nl_recv_func creation. The most likely source is nl80211_init_primary_interfaces(): wifi_hal_init() busy-waits for the wl *module* to be Live, but takes exactly one shot at enumerating the primary wlX *netdevs*, which the driver registers asynchronously only after the module flips to Live.
Proposed Fix : When the primary interface of a present radio is not found, re-run the per-wiphy NL80211_CMD_GET_INTERFACE in a bounded poll loop before failing. On healthy boots the first lookup succeeds and no latency is added.  Also fixes the sign bug in the SET_INTERFACE error path, which made fail-fast branch dead code.
Test Procedure : Crash should not occur. On previously failed builds log should appear: "primary interface of dev:N appeared after X ms".
Priority: P0
Risks: Low