### PR TITLE
SHARMAN-4192 Eco mode not working in 6.3 SDK

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -3034,6 +3034,9 @@ static int enable_echo_feature_and_power_control_configs(void)
         wifi_hal_dbg_print("%s:%d cmd [%s] unsuccessful \n", __func__, __LINE__, cmd);
     }
 
+#if defined(SCXER10_PORT) || defined(SKYSR213_PORT)
+    /* dpden command discontinued in DSPS SDK - nvram set directly above */
+#else
     snprintf(cmd, sizeof(cmd), "%s dpden 1", ECOMODE_SCRIPT_FILE);
     rc = system(cmd);
     if (rc == 0) {
@@ -3041,6 +3044,7 @@ static int enable_echo_feature_and_power_control_configs(void)
     } else {
         wifi_hal_dbg_print("%s:%d cmd [%s] unsuccessful \n", __func__, __LINE__, cmd);
     }
+#endif
 
     return rc;
 }
@@ -3057,8 +3061,13 @@ static int check_dpd_feature_enabled(void)
     char cmd[BUFLEN_128] = {0};
     char buf[BUFLEN_2] = {0};
 
+#if defined(SCXER10_PORT) || defined(SKYSR213_PORT)
+    snprintf(cmd, sizeof(cmd), "sh %s dsps mode 2>/dev/null | cut -d '|' -f1",
+             ECOMODE_SCRIPT_FILE);
+#else
     snprintf(cmd, sizeof(cmd), "%s dpden",
              ECOMODE_SCRIPT_FILE);
+#endif
     if ((fp = popen(cmd, "r")) != NULL)
     {
         if (fgets(buf, sizeof(buf), fp) != NULL)
@@ -3281,12 +3290,21 @@ int platform_set_ecomode_for_radio(const int wl_idx, const bool eco_pwr_down)
     int rc = 0;
 
     /* Put radio into eco mode (power down) */
+#if defined(SCXER10_PORT) || defined(SKYSR213_PORT)
+    if (eco_pwr_down)
+        snprintf(cmd, sizeof(cmd), "sh %s dsps power_down wl%d",
+                 ECOMODE_SCRIPT_FILE, wl_idx);
+    else
+        snprintf(cmd, sizeof(cmd), "sh %s dsps power_up wl%d",
+                 ECOMODE_SCRIPT_FILE, wl_idx);
+#else
     if (eco_pwr_down)
         snprintf(cmd, sizeof(cmd), "sh %s edpddn wl%d",
                  ECOMODE_SCRIPT_FILE, wl_idx);
     else
         snprintf(cmd, sizeof(cmd), "sh %s edpdup wl%d",
                  ECOMODE_SCRIPT_FILE, wl_idx);
+#endif
 
     rc = system(cmd);
     if (rc == 0)

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -775,6 +775,57 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
         return RETURN_OK;
     }
 
+    /* After eco mode power_up, the PCIe device re-enumerates with a NEW phy/wiphy
+     * index AND new nl80211 interface indices. Both radio->index (phy index) and
+     * each interface->index (ifindex) must be refreshed before any nl80211 calls.
+     *
+     * 1. Use if_nametoindex() to update each interface->index from the OS -
+     *    immune to any stale radio->index and requires no nl80211.
+     * 2. Read the new phy/wiphy index from /sys/class/net/wl0/phy80211/index
+     *    and update radio->index.  This avoids the circular dependency where
+     *    interface_info_handler() uses the stale radio->index to look up
+     *    the radio via get_radio_by_phy_index().
+     * 3. With radio->index fresh, run the standard GET_INTERFACE dump. */
+    {
+        wifi_interface_info_t *iface_iter;
+        char radio_ifname[IFNAMSIZ];
+
+        /* Step 1: refresh each interface's ifindex by name */
+        hash_map_foreach(radio->interface_map, iface_iter) {
+            unsigned int new_ifidx = if_nametoindex(iface_iter->name);
+            if (new_ifidx > 0) {
+                wifi_hal_dbg_print("%s:%d: radio %d iface %s ifidx %d->%u\n",
+                    __func__, __LINE__, index, iface_iter->name,
+                    iface_iter->index, new_ifidx);
+                iface_iter->index = (int)new_ifidx;
+            }
+        }
+
+        /* Step 2: refresh radio->index (phy/wiphy index) via sysfs.
+         * On this platform /sys/class/net/wl0/phy80211/ is a directory
+         * (not a cfg80211 symlink); read the index file directly. */
+        snprintf(radio_ifname, sizeof(radio_ifname), "wl%d", index);
+        {
+            char sysfs[128];
+            FILE *fp;
+
+            snprintf(sysfs, sizeof(sysfs),
+                "/sys/class/net/%s/phy80211/index", radio_ifname);
+            fp = fopen(sysfs, "r");
+            if (fp) {
+                unsigned int new_phy_idx = radio->index;
+                if (fscanf(fp, "%u", &new_phy_idx) == 1 &&
+                        new_phy_idx != radio->index) {
+                    wifi_hal_dbg_print(
+                        " refresh - %s:%d: radio %d phy index %u->%u\n",
+                        __func__, __LINE__, index,
+                        radio->index, new_phy_idx);
+                    radio->index = new_phy_idx;
+                }
+                fclose(fp);
+            }
+        }
+    }
     primary_interface = get_primary_interface(radio);
     if (primary_interface == NULL) {
         wifi_hal_error_print("%s:%d: Error updating dev:%d no vprimary interface exist\n", __func__, __LINE__, radio->index);

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -2201,11 +2201,14 @@ int set_interface_properties(unsigned int phy_index, wifi_interface_info_t *inte
 
     vap->vap_index = 0;
 
-    /* Set interface properties for VAP interfaces */
+    /* Set interface properties for VAP interfaces 
+    * Match by interface name only: phy_index is not checked because the
+     * phy/wiphy index can change after a PCIe power cycle (eco mode power-up)
+     * while interface names remain stable.  Names are unique per platform
+     * (e.g. wl0.1 vs wl1.1) so name-only lookup is unambiguous. */
     for (i = 0; i < get_sizeof_interfaces_index_map(); i++) {
         map = &interface_index_map[i];
-        if ((strcmp(interface->name, map->interface_name) == 0) &&
-            (phy_index == map->phy_index)) {
+        if (strcmp(interface->name, map->interface_name) == 0) {
             vap->radio_index = map->rdk_radio_index;
             vap->vap_index = map->index;
             strcpy(vap->vap_name, map->vap_name);
@@ -2215,11 +2218,10 @@ int set_interface_properties(unsigned int phy_index, wifi_interface_info_t *inte
         }
     }
 
-    /* Set interface properties for radio interfaces */
+    /* Set interface properties for radio interfaces (same reasoning). */
     for (i = 0; i < get_sizeof_radio_interfaces_map(); i++) {
         radio_map = &l_radio_interface_map[i];
-        if ((strcmp(interface->name, radio_map->interface_name) == 0) &&
-            (phy_index == radio_map->phy_index)) {
+        if (strcmp(interface->name, radio_map->interface_name) == 0) {
             vap->radio_index = radio_map->radio_index;
             vap->vap_index = -1;
             return 0;


### PR DESCRIPTION
Reason for change:

Test Procedure: Enable and disable eco mode

Risks: low

Priority: P0