### PR TITLE
RDK-65811: Fix Banana Pi issues

### DIFF
--- a/platform/banana-pi/platform.c
+++ b/platform/banana-pi/platform.c
@@ -148,6 +148,10 @@ int platform_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             continue;
         }
 
+        if (!interface->vap_info.u.bss_info.enabled) {
+            continue;
+        }
+
         if (interface->u.ap.conf.disable_11be) {
             continue;
         }
@@ -359,10 +363,12 @@ int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             continue;
         }
 
+        // Evaluate the current state vs incoming - do not alter incoming mld_enable or VAP enable
+        bool is_mlo_enabled = interface->vap_info.u.bss_info.enabled && wifi_hal_is_mld_enabled(interface);
+        bool should_enable_mlo = vap->u.bss_info.enabled && vap->u.bss_info.mld_info.common_info.mld_enable;
+
         // Verify the incoming params against current MLD state
-        if (wifi_hal_is_mld_enabled(interface) &&
-            (vap->u.bss_info.mld_info.common_info.mld_enable == false ||
-                vap->u.bss_info.enabled == false)) {
+        if (is_mlo_enabled == true && should_enable_mlo == false) {
             if (teardown_mlo_vap(interface) != 0) {
                 wifi_hal_error_print("%s:%d: Failed to teardown link for MLD ID %d on VAP idx %d\n",
                     __func__, __LINE__, vap->u.bss_info.mld_info.common_info.mld_id,
@@ -370,16 +376,42 @@ int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                 return -1;
             }
 
+            // Before possibly disabling MLD on interface, get the new first interface.
+            // Currently OneWifi allows for improper config on Bpi where mld_enable is true
+            // even if VAP has been disabled.
+            wifi_interface_info_t *first_interface = wifi_hal_get_first_mld_interface(interface);
+
+            // We need to update data now since at this point vap_info is not yet copied
             interface->vap_info.u.bss_info.mld_info.common_info.mld_enable =
                 vap->u.bss_info.mld_info.common_info.mld_enable;
+            interface->vap_info.u.bss_info.enabled = vap->u.bss_info.enabled;
+
+            //TODO: Above order - first getting interface, then changing the mld_enable/enabled values
+            //seems weird but it is important, as wifi_hal_get_first_mld_interface due to its structure
+            //may return invalid value in some cases. Also, Currently NULL here means there was an
+            //error. This function should be reworked in future.
+            if (first_interface == NULL) {
+                 wifi_hal_error_print("%s:%d: Failed to determine first MLD interface for %s\n",
+                     __func__, __LINE__, interface->mld_name);
+                 return -1;
+            }
 
             // Reload to update MLD
-            wifi_interface_info_t *first_interface = wifi_hal_get_first_mld_interface(interface);
-            if (first_interface != NULL && hostapd_mld_is_first_bss(&first_interface->u.ap.hapd)) {
+            if (first_interface->u.ap.hapd.mld != NULL &&
+                hostapd_mld_is_first_bss(&first_interface->u.ap.hapd)) {
                 if (reload_vap_configuration(first_interface) != 0) {
                     wifi_hal_error_print(
                         "%s:%d: Failed to reload VAP configuration for MLD ID %d\n", __func__,
                         __LINE__, interface->vap_info.u.bss_info.mld_info.common_info.mld_id);
+                    return -1;
+                }
+            }
+
+            // If first interface does not have MLD, then MLD is gone.
+            if (first_interface->u.ap.hapd.mld == NULL) {
+                if (nl80211_interface_enable(interface->mld_name, false) < 0) {
+                    wifi_hal_error_print("%s:%d: Failed to enable MLD interface %s\n", __func__,
+                        __LINE__, interface->mld_name);
                     return -1;
                 }
             }
@@ -389,11 +421,12 @@ int platform_pre_create_vap(wifi_radio_index_t index, wifi_vap_info_map_t *map)
             interface->vap_info.u.bss_info.mld_info.common_info.mld_link_id =
                 NL80211_DRV_LINK_ID_NA;
             continue;
-        } else if (wifi_hal_is_mld_enabled(interface) == false &&
-            (vap->u.bss_info.mld_info.common_info.mld_enable == true &&
-                vap->u.bss_info.enabled == true)) {
+        } else if (is_mlo_enabled == false && should_enable_mlo == true) {
+            // We need to update data now since at this point vap_info is not yet copied
             interface->vap_info.u.bss_info.mld_info.common_info.mld_enable =
                 vap->u.bss_info.mld_info.common_info.mld_enable;
+            interface->vap_info.u.bss_info.enabled = vap->u.bss_info.enabled;
+
             if (setup_mlo_vap(interface, vap) != 0) {
                 wifi_hal_error_print("%s:%d: Failed to setup link for MLD ID %d with VAP idx %d\n",
                     __func__, __LINE__, vap->u.bss_info.mld_info.common_info.mld_id,
@@ -1023,10 +1056,14 @@ int update_hostap_mlo(wifi_interface_info_t *interface)
         return 0;
     }
 
+    hapd = &interface->u.ap.hapd;
+
+    if (hapd->mld == NULL) {
+        return 0;
+    }
+
     wifi_hal_info_print("%s:%d: interface:%s link id:%d update MLD links\n", __func__, __LINE__,
         wifi_hal_get_interface_name(interface), wifi_hal_get_mld_link_id(interface));
-
-    hapd = &interface->u.ap.hapd;
 
     /* Links have been removed due to interface down-up. Re-add all links and enable them,
      * but enable the first link BSS before doing that. */

--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -788,8 +788,10 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
     }
     memcpy((unsigned char *)old_operationParam, (unsigned char *)&radio->oper_param, sizeof(wifi_radio_operationParam_t));
 
+#if !defined(BANANA_PI_PORT) && !defined(CONFIG_GENERIC_MLO)
     nl80211_interface_enable(wifi_hal_get_interface_name(primary_interface),
         operationParam->enable);
+#endif
 #if defined(TCXB8_PORT) || defined(XB10_PORT) || defined(SCXER10_PORT)
     if (nl80211_set_amsdu_tid(primary_interface, operationParam->amsduTid) != RETURN_OK)
     {
@@ -835,17 +837,58 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
                                 __func__, __LINE__, ret);
                         }
                     }
+#if defined(BANANA_PI_PORT) && defined(CONFIG_GENERIC_MLO)
+                    if (wifi_hal_is_mld_enabled(interface)) {
+                        if (setup_mlo_vap(interface, &interface->vap_info) != RETURN_OK) {
+                            free(old_operationParam);
+                            old_operationParam = NULL;
+                            return RETURN_ERR;
+                        }
+                    }
+
+                    //Important side effect to this is that this will make sure we trigger the beacon twice
+                    if (restart_interface(interface)) {
+                            free(old_operationParam);
+                            old_operationParam = NULL;
+                            return RETURN_ERR;
+                    }
+
+                    if (nl80211_create_bridge(interface_name, interface->vap_info.bridge_name) != 0) {
+                        wifi_hal_error_print("%s:%d: Failed add interface %s to bridge %s\n",
+                            __func__, __LINE__, interface_name, interface->vap_info.bridge_name);
+                        free(old_operationParam);
+                        old_operationParam = NULL;
+                        return RETURN_ERR;
+                    }
+
+#else
                     if (update_hostap_interface_params(interface) != RETURN_OK) {
                         free(old_operationParam);
                         old_operationParam = NULL;
                         return RETURN_ERR;
                     }
+#endif // defined(BANANA_PI_PORT) && defined(CONFIG_GENERIC_MLO)
                     interface->beacon_set = 0;
                     start_bss(interface);
                     interface->bss_started = true;
                 }
 
                 if (radio->oper_param.enable == false && interface->bss_started) {
+#if defined(BANANA_PI_PORT) && defined(CONFIG_GENERIC_MLO)
+                    if (wifi_hal_is_mld_enabled(interface)) {
+                        if (teardown_mlo_vap(interface)) {
+                            free(old_operationParam);
+                            old_operationParam = NULL;
+                            return RETURN_ERR;
+                        }
+                    }
+
+                    if (reload_interface(interface)) {
+                        free(old_operationParam);
+                        old_operationParam = NULL;
+                        return RETURN_ERR;
+                    }
+#else
                     /* Clear beacon interval in wdev by stoping AP */
                     nl80211_interface_enable(interface_name, false);
                     nl80211_interface_enable(interface_name, true);
@@ -872,9 +915,9 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
                     }
                     interface->bss_started = false;
                     nl80211_interface_enable(interface_name, false);
+#endif // BANANA_PI_PORT && CONFIG_GENERIC_MLO
                 }
             }
-
             if (interface->vap_info.vap_mode == wifi_vap_mode_sta) {
                 if (radio->oper_param.enable == false) {
                     if (interface->u.sta.state == WPA_COMPLETED) {

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -5925,6 +5925,8 @@ int wifi_hal_set_mld_id(wifi_interface_info_t *interface, int mld_id)
 }
 
 #ifdef CONFIG_GENERIC_MLO
+// TODO: Considering this function structure, it should be changed to use
+//  MLD id and not rely on the interface itself.
 wifi_interface_info_t *wifi_hal_get_first_mld_interface(wifi_interface_info_t *interface)
 {
     wifi_radio_info_t *radio;
@@ -6333,6 +6335,9 @@ static int reload_mlo_vap_configuration(wifi_interface_info_t *interface)
         }
 
         hash_map_foreach(radio->interface_map, interface_iter) {
+            if (interface_iter->vap_info.u.bss_info.enabled == false) {
+                continue;
+            }
 
             if (!wifi_hal_is_mld_enabled(interface_iter)) {
                 continue;
@@ -6366,6 +6371,10 @@ static int reload_mlo_vap_configuration(wifi_interface_info_t *interface)
         wifi_radio_info_t *radio = get_radio_by_rdk_index(i);
 
         hash_map_foreach(radio->interface_map, interface_iter) {
+            if (interface_iter->vap_info.u.bss_info.enabled == false) {
+                continue;
+            }
+
             if (!wifi_hal_is_mld_enabled(interface_iter)) {
                 continue;
             }
@@ -6515,7 +6524,7 @@ static int dealloc_mld(wifi_interface_info_t *interface)
     int ret = 0;
 
     if (hapd->mld == NULL) {
-        wifi_hal_info_print("%s:%d hapd->mld empty, nothing to free \n", __func__, __LINE__);
+        wifi_hal_dbg_print("%s:%d hapd->mld empty, nothing to free \n", __func__, __LINE__);
         return 0;
     }
 
@@ -6540,11 +6549,13 @@ static int dealloc_mld(wifi_interface_info_t *interface)
 
     if (hapd->mld->refcount == 0) {
         remove_mld_from_array(hapd->mld);
+        wifi_hal_dbg_print("%s:%d MLD group destroyed \n", __func__, __LINE__);
     }
 
     hapd->mld = NULL;
     hapd->conf->mld_ap = 0;
     hapd->conf->okc = 0;
+    wifi_hal_dbg_print("%s:%d VAP removed from MLD group \n", __func__, __LINE__);
     return ret;
 }
 
@@ -6558,7 +6569,7 @@ int teardown_mlo_vap(wifi_interface_info_t *interface)
             __LINE__, interface->mld_name, wifi_hal_get_mld_link_id(interface));
     }
 
-    if (hostapd_mld_is_first_bss(&interface->u.ap.hapd)) {
+    if (hostapd_mld_is_first_bss(&interface->u.ap.hapd) && interface->u.ap.hapd.mld != NULL) {
         wifi_interface_info_t *first_interface = NULL;
         // We are removing the first link.
         // First interface pointer could point to invalid data
@@ -6598,7 +6609,8 @@ int teardown_mlo_vap(wifi_interface_info_t *interface)
         }
 
         first_interface = wifi_hal_get_first_mld_interface(interface);
-        if (first_interface != NULL && hostapd_mld_is_first_bss(&first_interface->u.ap.hapd)) {
+        if (first_interface != NULL && first_interface->u.ap.hapd.mld != NULL &&
+            hostapd_mld_is_first_bss(&first_interface->u.ap.hapd)) {
             first_interface->vap_configured = false;
             wifi_drv_set_operstate(first_interface, 1);
         }
@@ -6686,6 +6698,12 @@ int setup_mlo_vap(wifi_interface_info_t *interface, wifi_vap_info_t *new_vap_con
     if (if_idx == 0) {
         wifi_hal_error_print("%s:%d: Failed to find interface %s for MLD setup\n", __func__,
             __LINE__, interface->mld_name);
+        return -1;
+    }
+
+    if (nl80211_interface_enable(interface->mld_name, true) < 0) {
+        wifi_hal_error_print("%s:%d: Failed to enable MLD interface %s\n", __func__, __LINE__,
+            interface->mld_name);
         return -1;
     }
 


### PR DESCRIPTION
Reason for change: Link reconfig changes uncovered several existing issues that are being fixed in this commit:
- disable possibility of applying invalid configuration (i.e. MLD enabled while VAP is down)
- add checks for disabled VAPs during MLO/non-MLO related operations
- fix crash when disabling radio Test Procedure: Perform different operations on MLO and non-MLO VAPs, i.e. SSID/password change, disable SSIDs while leaving MLO enabled, disable radio.
Risks: None
Priority: P1 ('P0'-->high , 'P1'-->medium, 'P2'-->low)