### PR TITLE
RDKB-66288 --Change Sleep time to UINT64

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -3545,7 +3545,7 @@ static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
         [RDK_VENDOR_ATTR_STA_INFO_MLD_MAC] = {.type = NLA_BINARY, .minlen = ETHER_ADDR_LEN},
         [RDK_VENDOR_ATTR_STA_INFO_MLD_ENAB] = {.type = NLA_U8},
         [RDK_VENDOR_ATTR_STA_INFO_POWER_SAVE] = {.type = NLA_U8},
-        [RDK_VENDOR_ATTR_STA_INFO_PS_SLEEP_TIME_MS] = {.type = NLA_U32},
+        [RDK_VENDOR_ATTR_STA_INFO_PS_SLEEP_TIME_MS] = {.type = NLA_U64},
     };
     wifi_associated_dev3_t *stats = arg;
 
@@ -3743,7 +3743,7 @@ static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
     }
 
     if (tb_sta_info[RDK_VENDOR_ATTR_STA_INFO_PS_SLEEP_TIME_MS]) {
-        stats->cli_sleepTime = nla_get_u32(tb_sta_info[RDK_VENDOR_ATTR_STA_INFO_PS_SLEEP_TIME_MS]);
+        stats->cli_sleepTime = nla_get_u64(tb_sta_info[RDK_VENDOR_ATTR_STA_INFO_PS_SLEEP_TIME_MS]);
     } else {
         stats->cli_sleepTime = 0;
     }
@@ -3771,7 +3771,7 @@ static int get_sta_stats_handler(struct nl_msg *msg, void *arg)
     }
     stats->cli_PacketsSent = stats->cli_DataFramesSentAck + stats->cli_DataFramesSentNoAck;
 
-    wifi_hal_stats_dbg_print("%s:%d cli_DataFramesSentAck: %lu cli_DataFramesSentNoAck: %lu cli_PacketsSent: %lu cli_BytesSent: %lu cli_PowerSaveMode=%d cli_sleepTime:%d\n", __func__, __LINE__, 
+    wifi_hal_stats_dbg_print("%s:%d cli_DataFramesSentAck: %lu cli_DataFramesSentNoAck: %lu cli_PacketsSent: %lu cli_BytesSent: %lu cli_PowerSaveMode=%d cli_sleepTime: %lu\n", __func__, __LINE__, 
             stats->cli_DataFramesSentAck, stats->cli_DataFramesSentNoAck,
             stats->cli_PacketsSent, stats->cli_BytesSent, stats->cli_PowerSaveMode,stats->cli_sleepTime);
 


### PR DESCRIPTION
Reason for change: Change Sleep time to UINT64

Test Procedure: Update upper layer to parse POWER_SAVE and SLEEP_TIME_MS; Check the output.
Risks: Low
Priority: P1
Signed-off-by: Pramod joshi [pramod.7456@gmail.com](mailto:pramod.7456@gmail.com)