### PR TITLE
RDKBWIFI-539: Fix nl_recv_func SIGSEGV: steering check called with uninitialized interface

### DIFF
--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -1540,6 +1540,10 @@ static void wifi_hal_steering_check_sta_status(wifi_interface_info_t *interface)
     static time_t old_time;
     mac_address_t temp_sta_mac;
 
+    if (interface == NULL) {
+        return;
+    }
+
     callbacks = get_hal_device_callbacks();
     if (callbacks->steering_event_callback == 0) {
         return;
@@ -3443,7 +3447,7 @@ void *nl_recv_func(void *arg)
     int ret, res;
     struct timeval tv_towait;
     wifi_hal_priv_t *priv = (wifi_hal_priv_t *)arg;
-    wifi_interface_info_t *interface;
+    wifi_interface_info_t *interface = NULL;
     int eloop_timeout_ms;
 #if defined (_PLATFORM_BANANAPI_R4_)
     size_t stack_size2;


### PR DESCRIPTION
The local interface in nl_recv_func() is only assigned when mgmt_fd_isset()/bridge_fd_isset() find a matching descriptor, yet wifi_hal_steering_check_sta_status(interface) runs unconditionally every loop iteration. Once a steering event callback is registered before any mgmt/data frame has been received in the process lifetime (early boot), the function dereferences stack garbage via interface->bm_sta_map and crashes, turning into a crash/restart loop under systemd until traffic arrives. Initialize the local to NULL and return early for NULL; behavior with a valid interface is unchanged.