### PR TITLE
XB10-2853: Check if WLC_UP/DOWN is needed prior this action

### DIFF
--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -596,7 +596,7 @@ int platform_radio_up(int radio_index, bool up)
         rc = wl_ioctl(osifname, WLC_GET_UP, &isup, sizeof(isup));
         if (rc < 0) {
             wifi_hal_error_print("%s:%d failed to get interface status up for %s, err: %d (%s)\n",
-                __func__,__LINE__, osifname, errno, strerror(errno));
+                __func__, __LINE__, osifname, errno, strerror(errno));
         }
         do_ioctl = (rc == 0 && isup != up) ? TRUE : FALSE;
 

--- a/platform/broadcom/platform.c
+++ b/platform/broadcom/platform.c
@@ -591,18 +591,14 @@ int platform_radio_up(int radio_index, bool up)
             /* Skip ioctl for any non-MLO radio */
             if (is_mlo_radio(i) == FALSE)
                 continue;
-            /* MLO radio, issue ioctl for other MLO radios */
-            do_ioctl = TRUE;
-            isup = -1;	/* don't care */
-        } else {
-            /* non-MLO radio, no need to check other radios */
-            rc = wl_ioctl(osifname, WLC_GET_UP, &isup, sizeof(isup));
-            if (rc < 0) {
-                wifi_hal_error_print("%s:%d failed to get interface status up for %s, err: %d (%s)\n",
-                    __func__,__LINE__, osifname, errno, strerror(errno));
-            }
-            do_ioctl = (rc == 0 && isup != up) ? TRUE : FALSE;
         }
+
+        rc = wl_ioctl(osifname, WLC_GET_UP, &isup, sizeof(isup));
+        if (rc < 0) {
+            wifi_hal_error_print("%s:%d failed to get interface status up for %s, err: %d (%s)\n",
+                __func__,__LINE__, osifname, errno, strerror(errno));
+        }
+        do_ioctl = (rc == 0 && isup != up) ? TRUE : FALSE;
 
         if (do_ioctl) {
             wifi_hal_info_print("### %s: %s ismlo=%d isup=%d up=%d ###\n", __func__,


### PR DESCRIPTION
Reason for change:
	Check if WLC_UP/DOWN is required prior to interface UP/DOWN action to avoid unnecessary WLC_UP/DOWN.
	Change is applicable for Broadcom MLO enabled platforms.

Test Procedure: Verify wifi client connectivity in MLO and in NON MLO configurations.
	Verify DFS functionality.

Risks: Low
Priority: P1