### PR TITLE
RDKB-66207 : Import clang-format fixes from OneWifi branch

### DIFF
--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -48,16 +48,38 @@ jobs:
         if: steps.dl.outcome != 'success'
         run: echo "Stage 1 produced no formatting changes; done."
 
-      - name: Load PR metadata (strictly validated)
+      - name: Load and verify PR metadata (strictly validated)
         if: steps.dl.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed via env, not inlined into the script. This prevents hijacking of it.
+          EXPECTED_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          EXPECTED_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          # A PR can modify stage 1/2 workflow file, so treat pr-meta.env as
-          # attacker-controlled. Accept ONLY a bare integer and a SHA,
-          # never append the file to GITHUB_ENV directly (possible env injection).
+          # A fork PR can modify workflow file, so any envs from it as attacker-controlled.
+          # Validate in two steps:
+          #
+          # 1. FORMAT — Accept ONLY a bare integer and a SHA. Never source
+          #    the file into GITHUB_ENV directly (that would allow env injection).
           PR="$(grep -oP '^pr_number=\K[0-9]+$' pr-meta.env | head -1)"
           SHA="$(grep -oP '^head_sha=\K[0-9a-f]{40}$' pr-meta.env | head -1)"
           if [ -z "$PR" ] || [ -z "$SHA" ]; then
             echo "::error::Malformed PR metadata; refusing to continue."
+            exit 1
+          fi
+          # 2. IDENTITY — a number could still name a *different* PR, which would let a fork post
+          #    suggestions onto an arbitrary PR. Bind pr_number back to the run that triggered us.
+          #    PR #PR must have the same head repo + branch GitHub recorded for this workflow_run
+          #    — values a fork cannot forge. (head_sha freshness is re-checked at post time,
+          #    so it is not gated here.)
+          gh api "/repos/${{ github.repository }}/pulls/${PR}" > /tmp/pr.json || {
+            echo "::error::Could not read PR #${PR} from the API."
+            exit 1
+          }
+          pr_repo="$(jq -r '.head.repo.full_name' /tmp/pr.json)"
+          pr_branch="$(jq -r '.head.ref' /tmp/pr.json)"
+          if [ "$pr_repo" != "$EXPECTED_REPO" ] || [ "$pr_branch" != "$EXPECTED_BRANCH" ]; then
+            echo "::error::PR #${PR} ($pr_repo:$pr_branch) does not belong to the triggering run ($EXPECTED_REPO:$EXPECTED_BRANCH); refusing to continue."
             exit 1
           fi
           echo "pr_number=$PR" >> "$GITHUB_ENV"

--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -112,15 +112,33 @@ jobs:
           python3 /tmp/conv.py < clang-format.diff
           python3 - <<'PYEOF'
           import json, os
+          # Large reviews trip rate limiting, and fail (often as a misleading 404).
+          # Retrying does not help, and GH doesn't publish a number. Cap instead.
+          # A PR needing more than this many fixes should just be formatted locally.
+          MAX = int(os.environ.get("MAX_COMMENTS", "25"))
           comments = json.load(open("/tmp/comments.json"))
+          total = len(comments)
+          if total > MAX:
+              comments = comments[:MAX]
+              json.dump(comments, open("/tmp/comments.json", "w"))   # keep the post step in sync
+          body = ("`clang-format` suggests the formatting changes below. "
+                  "Use **Commit suggestion** to apply them.")
+          if total > MAX:
+              body += (f"\n\n> **Note:** showing the first {MAX} of {total} suggestions. "
+                       "Apply these and push, and the rest will be posted on the next run — "
+                       "or fix them all at once locally:\n"
+                       "> ```\n"
+                       "> pip install clang-format==18.1.8\n"
+                       "> git-clang-format --style=file --extensions c,h <merge-base>\n"
+                       "> ```")
           review = {
               "commit_id": os.environ["head_sha"],
               "event": "COMMENT",
-              "body": "`clang-format` suggests the formatting changes below. "
-                      "Use **Commit suggestion** to apply them.",
+              "body": body,
               "comments": comments,
           }
           json.dump(review, open("/tmp/review.json", "w"))
+          print(f"posting {len(comments)} of {total} suggestion(s)")
           PYEOF
 
       - name: Post the review
@@ -137,7 +155,9 @@ jobs:
                  --input /tmp/review.json > /tmp/resp.json 2>/tmp/err.txt; then
             echo "::error::Failed to post review:"
             cat /tmp/err.txt
-            # 422 usually means a suggestion targeted a line outside the PR diff.
+            # 422 = a suggestion targeted a line outside the PR diff.
+            # 404 = usually rate limit from too many comments at once;
+            #       retrying will NOT help (same payload) — lower MAX_COMMENTS.
             exit 1
           fi
           echo "Review posted: $(python3 -c 'import json;print(json.load(open("/tmp/resp.json")).get("html_url",""))')"

--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -162,7 +162,7 @@ jobs:
                        "or fix them all at once locally:\n"
                        "> ```\n"
                        "> pip install clang-format==18.1.8\n"
-                       "> git-clang-format --style=file --extensions c,h <merge-base>\n"
+                       "> git-clang-format --style=file --extensions c,h,cpp <merge-base>\n"
                        "> ```")
           review = {
               "commit_id": os.environ["head_sha"],

--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -3,7 +3,7 @@ name: clang-format-suggestions
 # Stage 2/2. Fires when the "clang-format" workflow finishes.
 # Runs in the BASE-repo (trusted) context with a write-capable token, but it
 # NEVER checks out or executes PR code. It only reads the diff artifact from
-# stage 1 as passive data and posts it as review suggestions. 
+# stage 1 as passive data and posts it as review suggestions.
 # The actual commit to the branch happens only
 # when a human clicks "Commit suggestion".
 on:
@@ -16,15 +16,29 @@ permissions:
   pull-requests: write        # the only write scope required
   actions: read               # to download the artifact from the triggering run
 
+# Cancel run when a newer one starts AND dismiss stale/outdated review.
+# Both freshness check and the cancelled-run one MUST use fields populated 
+# in a workflow_run context. Use head_repository.full_name + head_branch, they always exist.
+# Alternatives: pull_request.number is absent here, and workflow_run.pull_requests is empty
+# for fork PRs (known GH bug: actions/runner#3444, github/docs#22501). 
+concurrency:
+  group: >-
+    clang-format-suggest-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   suggest:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    # Exclude cancelled runs at the source (they can leave outdated artifact yet
+    # fire 'completed'). Allow failure too (if stage 1 fails, suggestions are still useful!
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion != 'cancelled'
     steps:
       - name: Download the diff artifact
         id: dl
         continue-on-error: true                # absent artifact == nothing to suggest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: clang-format-suggestions
           run-id: ${{ github.event.workflow_run.id }}
@@ -38,8 +52,8 @@ jobs:
         if: steps.dl.outcome == 'success'
         run: |
           # A PR can modify stage 1/2 workflow file, so treat pr-meta.env as
-          # attacker-controlled: accept ONLY a bare integer and a 40-hex SHA,
-          # never append the file to GITHUB_ENV directly (env injection).
+          # attacker-controlled. Accept ONLY a bare integer and a SHA,
+          # never append the file to GITHUB_ENV directly (possible env injection).
           PR="$(grep -oP '^pr_number=\K[0-9]+$' pr-meta.env | head -1)"
           SHA="$(grep -oP '^head_sha=\K[0-9a-f]{40}$' pr-meta.env | head -1)"
           if [ -z "$PR" ] || [ -z "$SHA" ]; then
@@ -52,12 +66,9 @@ jobs:
       - name: Convert diff into review suggestions
         if: steps.dl.outcome == 'success'
         run: |
-          # A GitHub "Commit suggestion" button is just a review comment whose
-          # body contains a ```suggestion fenced block. No extra tooling needed.
-          #
-          # In stage 1's diff the OLD side (-) is the code currently in the PR
-          # head, so those are the lines we comment on; the NEW side (+) is the
-          # replacement text that goes inside the suggestion block.
+          # A "Commit suggestion" button is just a review comment containing
+          # a ```suggestion block. Stage 1's diff OLD side (-) = lines currently in
+          # the PR head (what we comment on); NEW side (+) = the replacement text.
           cat > /tmp/conv.py <<'PYEOF'
           import json, re, sys
           HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
@@ -113,8 +124,8 @@ jobs:
           python3 - <<'PYEOF'
           import json, os
           # Large reviews trip rate limiting, and fail (often as a misleading 404).
-          # Retrying does not help, and GH doesn't publish a number. Cap instead.
-          # A PR needing more than this many fixes should just be formatted locally.
+          # Retrying won't help, and GH doesn't publish a number. Cap instead.
+          # A PR needing more than this, should just be formatted locally.
           MAX = int(os.environ.get("MAX_COMMENTS", "25"))
           comments = json.load(open("/tmp/comments.json"))
           total = len(comments)
@@ -149,15 +160,48 @@ jobs:
           if [ "$(python3 -c 'import json;print(len(json.load(open("/tmp/comments.json"))))')" = "0" ]; then
             echo "No suggestions to post."; exit 0
           fi
-          # gh is preinstalled on GitHub-hosted runners.
+
+          # Freshness check: concurrency only cancels an IN-FLIGHT run, so a run
+          # that already moved past can still post outdated suggestions. Fail
+          # CLOSED-TO-ERROR on empty (transient API failure), skip only on a
+          # positively-observed different sha (gh stderr flows to the log).
+          current_sha="$(gh api "/repos/${{ github.repository }}/pulls/${pr_number}" --jq .head.sha)" || true
+          if [ -z "$current_sha" ]; then
+            echo "::error::Could not read current PR head sha (see log above)."
+            exit 1
+          fi
+          if [ "$current_sha" != "$head_sha" ]; then
+            echo "PR has moved past $head_sha (now at $current_sha) — skipping stale review."
+            exit 0
+          fi
+
+          # Stale-review cleanup: two quick pushes can leave two review threads
+          # (one soon to be outdated). Dismiss our OWN prior clang-format reviews first, so
+          # maximum one (current) set is live. Identify "ours" by the token's server-resolved
+          # identity (github-actions[bot]/Bot) + body marker,
+          # NEVER by any actor field that crossed the trust boundary. Non-fatal.
+          gh api "/repos/${{ github.repository }}/pulls/${pr_number}/reviews" --paginate \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.user.type == "Bot")) | select(.body | startswith("`clang-format` suggests")) | select(.state != "DISMISSED") | .id' \
+            > /tmp/stale_ids.txt \
+            || { echo "::warning::Could not list existing reviews for cleanup (continuing)."; : > /tmp/stale_ids.txt; }
+          while read -r rid; do
+            [ -n "$rid" ] || continue
+            echo "Dismissing prior clang-format review $rid"
+            gh api --method PUT \
+              "/repos/${{ github.repository }}/pulls/${pr_number}/reviews/${rid}/dismissals" \
+              -f message="Superseded by a newer clang-format suggestion run." \
+              -f event="DISMISS" >/dev/null \
+              || echo "::warning::Failed to dismiss review $rid (continuing)."
+          done < /tmp/stale_ids.txt
+
+          # Post the fresh review. gh is preinstalled on GitHub-hosted runners.
           if ! gh api --method POST \
                  "/repos/${{ github.repository }}/pulls/${pr_number}/reviews" \
-                 --input /tmp/review.json > /tmp/resp.json 2>/tmp/err.txt; then
-            echo "::error::Failed to post review:"
-            cat /tmp/err.txt
-            # 422 = a suggestion targeted a line outside the PR diff.
-            # 404 = usually rate limit from too many comments at once;
-            #       retrying will NOT help (same payload) — lower MAX_COMMENTS.
+                 --input /tmp/review.json > /tmp/resp.json; then
+            echo "::error::Failed to post review (see log above)."
+            # 422 = suggestion targeted a line outside the PR diff.
+            # 404 = usually rate limit from too many comments; retrying won't help
+            #       (same payload) — lower MAX_COMMENTS.
             exit 1
           fi
           echo "Review posted: $(python3 -c 'import json;print(json.load(open("/tmp/resp.json")).get("html_url",""))')"

--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -30,7 +30,7 @@ jobs:
   suggest:
     runs-on: ubuntu-latest
     # Exclude cancelled runs at the source (they can leave outdated artifact yet
-    # fire 'completed'). Allow failure too (if stage 1 fails, suggestions are still useful!
+    # fire 'completed'). Allow failure too (if stage 1 fails, suggestions are still useful!)
     if: >-
       github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion != 'cancelled'
@@ -125,7 +125,7 @@ jobs:
           import json, os
           # Large reviews trip rate limiting, and fail (often as a misleading 404).
           # Retrying won't help, and GH doesn't publish a number. Cap instead.
-          # A PR needing more than this, should just be formatted locally.
+          # A PR needing more than this should just be formatted locally.
           MAX = int(os.environ.get("MAX_COMMENTS", "25"))
           comments = json.load(open("/tmp/comments.json"))
           total = len(comments)

--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -49,35 +49,95 @@ jobs:
           echo "pr_number=$PR" >> "$GITHUB_ENV"
           echo "head_sha=$SHA" >> "$GITHUB_ENV"
 
-      - name: Install reviewdog (pinned, no third-party action)
+      - name: Convert diff into review suggestions
         if: steps.dl.outcome == 'success'
         run: |
-          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
-            | sh -s -- -b /usr/local/bin v0.21.0
-          reviewdog -version
+          # A GitHub "Commit suggestion" button is just a review comment whose
+          # body contains a ```suggestion fenced block. No extra tooling needed.
+          #
+          # In stage 1's diff the OLD side (-) is the code currently in the PR
+          # head, so those are the lines we comment on; the NEW side (+) is the
+          # replacement text that goes inside the suggestion block.
+          cat > /tmp/conv.py <<'PYEOF'
+          import json, re, sys
+          HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+          comments, path, old_ln = [], None, 0
+          removed, added, start = [], [], None
 
-      - name: Post clang-format suggestions
+          def flush():
+              global removed, added, start
+              if start is None or (not removed and not added):
+                  removed, added, start = [], [], None
+                  return
+              body = "```suggestion\n" + "".join(l + "\n" for l in added) + "```"
+              c = {"path": path, "side": "RIGHT", "body": body}
+              if removed:
+                  c["line"] = start + len(removed) - 1
+                  if len(removed) > 1:
+                      c["start_line"] = start
+                      c["start_side"] = "RIGHT"
+              else:
+                  c["line"] = max(start - 1, 1)
+              comments.append(c)
+              removed, added, start = [], [], None
+
+          for raw in sys.stdin.read().splitlines():
+              if raw.startswith("diff --git"):
+                  flush(); path = None; continue
+              if raw.startswith("--- "):
+                  continue
+              if raw.startswith("+++ "):
+                  p = raw[4:].strip()
+                  path = p[2:] if p.startswith("b/") else p
+                  continue
+              m = HUNK.match(raw)
+              if m:
+                  flush(); old_ln = int(m.group(1)); continue
+              if path is None:
+                  continue
+              if raw.startswith("-"):
+                  if start is None: start = old_ln
+                  removed.append(raw[1:]); old_ln += 1
+              elif raw.startswith("+"):
+                  if start is None: start = old_ln
+                  added.append(raw[1:])
+              elif raw.startswith("\\"):
+                  continue
+              else:
+                  flush(); old_ln += 1
+          flush()
+          json.dump(comments, open("/tmp/comments.json", "w"))
+          print(f"{len(comments)} suggestion(s) generated")
+          PYEOF
+          python3 /tmp/conv.py < clang-format.diff
+          python3 - <<'PYEOF'
+          import json, os
+          comments = json.load(open("/tmp/comments.json"))
+          review = {
+              "commit_id": os.environ["head_sha"],
+              "event": "COMMENT",
+              "body": "`clang-format` suggests the formatting changes below. "
+                      "Use **Commit suggestion** to apply them.",
+              "comments": comments,
+          }
+          json.dump(review, open("/tmp/review.json", "w"))
+          PYEOF
+
+      - name: Post the review
         if: steps.dl.outcome == 'success'
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_EVENT_NAME: pull_request     # workflow_run's payload lacks fork-PR details,
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # ...so synthesize a pull_request event that points reviewdog at the right PR.
-          cat > /tmp/event.json <<EOF
-          {
-            "pull_request": { "number": ${pr_number}, "head": { "sha": "${head_sha}" } },
-            "repository": {
-              "name": "${{ github.event.repository.name }}",
-              "owner": { "login": "${{ github.repository_owner }}" }
-            }
-          }
-          EOF
-          export GITHUB_EVENT_PATH=/tmp/event.json
-          export GITHUB_REPOSITORY="${{ github.repository }}"
-          export GITHUB_SHA="${head_sha}"
-          reviewdog \
-            -name="clang-format" \
-            -f=diff -f.diff.strip=1 \
-            -filter-mode=nofilter \
-            -reporter=github-pr-review \
-            -level=warning < clang-format.diff
+          if [ "$(python3 -c 'import json;print(len(json.load(open("/tmp/comments.json"))))')" = "0" ]; then
+            echo "No suggestions to post."; exit 0
+          fi
+          # gh is preinstalled on GitHub-hosted runners.
+          if ! gh api --method POST \
+                 "/repos/${{ github.repository }}/pulls/${pr_number}/reviews" \
+                 --input /tmp/review.json > /tmp/resp.json 2>/tmp/err.txt; then
+            echo "::error::Failed to post review:"
+            cat /tmp/err.txt
+            # 422 usually means a suggestion targeted a line outside the PR diff.
+            exit 1
+          fi
+          echo "Review posted: $(python3 -c 'import json;print(json.load(open("/tmp/resp.json")).get("html_url",""))')"

--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -17,10 +17,10 @@ permissions:
   actions: read               # to download the artifact from the triggering run
 
 # Cancel run when a newer one starts AND dismiss stale/outdated review.
-# Both freshness check and the cancelled-run one MUST use fields populated 
+# Both freshness check and the cancelled-run one MUST use fields populated
 # in a workflow_run context. Use head_repository.full_name + head_branch, they always exist.
 # Alternatives: pull_request.number is absent here, and workflow_run.pull_requests is empty
-# for fork PRs (known GH bug: actions/runner#3444, github/docs#22501). 
+# for fork PRs (known GH bug: actions/runner#3444, github/docs#22501).
 concurrency:
   group: >-
     clang-format-suggest-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/clang-format-suggestions.yml
+++ b/.github/workflows/clang-format-suggestions.yml
@@ -1,0 +1,83 @@
+name: clang-format-suggestions
+
+# Stage 2/2. Fires when the "clang-format" workflow finishes.
+# Runs in the BASE-repo (trusted) context with a write-capable token, but it
+# NEVER checks out or executes PR code. It only reads the diff artifact from
+# stage 1 as passive data and posts it as review suggestions. 
+# The actual commit to the branch happens only
+# when a human clicks "Commit suggestion".
+on:
+  workflow_run:
+    workflows: ["clang-format"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write        # the only write scope required
+  actions: read               # to download the artifact from the triggering run
+
+jobs:
+  suggest:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download the diff artifact
+        id: dl
+        continue-on-error: true                # absent artifact == nothing to suggest
+        uses: actions/download-artifact@v4
+        with:
+          name: clang-format-suggestions
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Nothing to suggest
+        if: steps.dl.outcome != 'success'
+        run: echo "Stage 1 produced no formatting changes; done."
+
+      - name: Load PR metadata (strictly validated)
+        if: steps.dl.outcome == 'success'
+        run: |
+          # A PR can modify stage 1/2 workflow file, so treat pr-meta.env as
+          # attacker-controlled: accept ONLY a bare integer and a 40-hex SHA,
+          # never append the file to GITHUB_ENV directly (env injection).
+          PR="$(grep -oP '^pr_number=\K[0-9]+$' pr-meta.env | head -1)"
+          SHA="$(grep -oP '^head_sha=\K[0-9a-f]{40}$' pr-meta.env | head -1)"
+          if [ -z "$PR" ] || [ -z "$SHA" ]; then
+            echo "::error::Malformed PR metadata; refusing to continue."
+            exit 1
+          fi
+          echo "pr_number=$PR" >> "$GITHUB_ENV"
+          echo "head_sha=$SHA" >> "$GITHUB_ENV"
+
+      - name: Install reviewdog (pinned, no third-party action)
+        if: steps.dl.outcome == 'success'
+        run: |
+          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
+            | sh -s -- -b /usr/local/bin v0.21.0
+          reviewdog -version
+
+      - name: Post clang-format suggestions
+        if: steps.dl.outcome == 'success'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_NAME: pull_request     # workflow_run's payload lacks fork-PR details,
+        run: |
+          # ...so synthesize a pull_request event that points reviewdog at the right PR.
+          cat > /tmp/event.json <<EOF
+          {
+            "pull_request": { "number": ${pr_number}, "head": { "sha": "${head_sha}" } },
+            "repository": {
+              "name": "${{ github.event.repository.name }}",
+              "owner": { "login": "${{ github.repository_owner }}" }
+            }
+          }
+          EOF
+          export GITHUB_EVENT_PATH=/tmp/event.json
+          export GITHUB_REPOSITORY="${{ github.repository }}"
+          export GITHUB_SHA="${head_sha}"
+          reviewdog \
+            -name="clang-format" \
+            -f=diff -f.diff.strip=1 \
+            -filter-mode=nofilter \
+            -reporter=github-pr-review \
+            -level=warning < clang-format.diff

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -37,7 +37,7 @@ jobs:
           python3 -m pip install --quiet "clang-format==18.1.8"   # bundles clang-format + git-clang-format
           clang-format --version
 
-      - name: Reformat only the changed .c/.h lines
+      - name: Reformat only the changed source lines
         id: fmt
         run: |
           # Diff against the MERGE BASE, not the base branch tip. Now that we check

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -59,7 +59,7 @@ jobs:
           # EXCLUDES+=(':!platform/vendor/*')      # whole directory (recursive)
           # EXCLUDES+=(':!src/example_file.c')     # single file
           # ==================================================================
-          # --extensions c,h is why nothing but C sources is ever formatted.
+          # --extensions c,h,cpp is why nothing but C/C++ sources is ever formatted.
           #
           # git-clang-format exit codes: 0 = nothing to do, 1 = it reformatted
           # something (this is NOT an error), 2+ = genuine failure. The default

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -21,6 +21,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0                      # need base history to diff changed lines
+          # For pull_request events actions/checkout defaults to the MERGE commit
+          # (refs/pull/N/merge), whose line numbers do not match the PR head.
+          # Stage 2 posts review comments against head_sha, so the two must agree
+          # or suggestions land on the wrong lines (or are rejected with a 422).
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install clang-format 18.1.8
         run: |
@@ -30,7 +35,16 @@ jobs:
       - name: Reformat only the changed .c/.h lines
         id: fmt
         run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          # Diff against the MERGE BASE, not the base branch tip. Now that we check
+          # out the PR head, commits that landed on the base branch after this PR
+          # forked would otherwise appear as "changed lines", and we would suggest
+          # reformatting code the PR never touched (which stage 2 cannot post,
+          # since those lines are not part of the PR's diff).
+          BASE_SHA="$(git merge-base "${{ github.event.pull_request.base.sha }}" HEAD)" || {
+            echo "::error::Could not compute merge base — is fetch-depth: 0 set?"
+            exit 1
+          }
+          echo "Diffing against merge base: $BASE_SHA"
           # ================== EXCLUDED PATHS (edit me) ======================
           # Files/dirs here are never reformatted (e.g. vendor ports, imported
           # headers/utils). Uses git pathspec syntax: ':!<pattern>'.

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,8 +8,9 @@ name: clang-format
 on:
   pull_request:
     paths:
-      - '**.c'
-      - '**.h'
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.h'
 
 permissions:
   contents: read
@@ -22,7 +23,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0                      # need base history to diff changed lines
           # For pull_request events actions/checkout defaults to the MERGE commit
@@ -94,7 +95,7 @@ jobs:
 
       - name: Upload diff + metadata
         if: steps.fmt.outputs.changed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: clang-format-suggestions
           path: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,7 +7,7 @@ name: clang-format
 # clang-format WOULD change and hands that diff to stage 2 as passive data.
 on:
   pull_request:
-    paths:
+    paths:            # they have to match --extension <args> below
       - '**/*.c'
       - '**/*.cpp'
       - '**/*.h'
@@ -66,7 +66,7 @@ jobs:
           # shell is `bash -e`, so a bare call would abort the step on the
           # perfectly normal exit 1.
           set +e
-          git-clang-format --style=file --extensions c,h "$BASE_SHA" -- . "${EXCLUDES[@]}"
+          git-clang-format --style=file --extensions c,h,cpp "$BASE_SHA" -- . "${EXCLUDES[@]}"
           rc=$?
           set -e
           if [ "$rc" -ge 2 ]; then

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,73 @@
+name: clang-format
+
+# Stage 1/2  (stage 2 = clang-format-suggest.yml).
+# Runs the formatter over the PR's changed C lines. It is deliberately
+# read-only with no secrets: it may run over untrusted fork code, but it holds
+# no write token and can change nothing in the repo. It only records what
+# clang-format WOULD change and hands that diff to stage 2 as passive data.
+on:
+  pull_request:
+    paths:
+      - '**.c'
+      - '**.h'
+
+permissions:
+  contents: read
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0                      # need base history to diff changed lines
+
+      - name: Install clang-format 18.1.8
+        run: |
+          python3 -m pip install --quiet "clang-format==18.1.8"   # bundles clang-format + git-clang-format
+          clang-format --version
+
+      - name: Reformat only the changed .c/.h lines
+        id: fmt
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          # ================== EXCLUDED PATHS (edit me) ======================
+          # Files/dirs here are never reformatted (e.g. vendor ports, imported
+          # headers/utils). Uses git pathspec syntax: ':!<pattern>'.
+          # Uncomment and adapt; List exclusions below instead, one line per exclusion.
+          #
+          EXCLUDES=()
+          # EXCLUDES+=(':!platform/vendor/*')      # whole directory (recursive)
+          # EXCLUDES+=(':!src/example_file.c')     # single file
+          # ==================================================================
+          # --extensions c,h is why nothing but C sources is ever formatted.
+          git-clang-format --style=file --extensions c,h "$BASE_SHA" -- . "${EXCLUDES[@]}"
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Changed lines are already clang-format clean."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff | tee clang-format.diff
+            echo "::warning::clang-format has suggestions; they will be posted on this PR."
+            # ===== TO BLOCK MERGE (make this a required check): uncomment below.
+            # Suggestions still post either way, because workflow_run fires on failure too.
+            # exit 1
+          fi
+
+      - name: Record PR metadata for the suggester
+        if: steps.fmt.outputs.changed == 'true'
+        run: |
+          {
+            echo "pr_number=${{ github.event.pull_request.number }}"
+            echo "head_sha=${{ github.event.pull_request.head.sha }}"
+          } > pr-meta.env
+
+      - name: Upload diff + metadata
+        if: steps.fmt.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-format-suggestions
+          path: |
+            clang-format.diff
+            pr-meta.env
+          retention-days: 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -41,7 +41,19 @@ jobs:
           # EXCLUDES+=(':!src/example_file.c')     # single file
           # ==================================================================
           # --extensions c,h is why nothing but C sources is ever formatted.
+          #
+          # git-clang-format exit codes: 0 = nothing to do, 1 = it reformatted
+          # something (this is NOT an error), 2+ = genuine failure. The default
+          # shell is `bash -e`, so a bare call would abort the step on the
+          # perfectly normal exit 1.
+          set +e
           git-clang-format --style=file --extensions c,h "$BASE_SHA" -- . "${EXCLUDES[@]}"
+          rc=$?
+          set -e
+          if [ "$rc" -ge 2 ]; then
+            echo "::error::git-clang-format failed (exit $rc) — check .clang-format and the base SHA."
+            exit 1
+          fi
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "Changed lines are already clang-format clean."

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,7 +7,7 @@ name: clang-format
 # clang-format WOULD change and hands that diff to stage 2 as passive data.
 on:
   pull_request:
-    paths:            # they have to match --extension <args> below
+    paths:            # they have to match --extensions <args> below
       - '**/*.c'
       - '**/*.cpp'
       - '**/*.h'

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,6 @@
 name: clang-format
 
-# Stage 1/2  (stage 2 = clang-format-suggest.yml).
+# Stage 1/2  (stage 2 = clang-format-suggestions.yml).
 # Runs the formatter over the PR's changed C lines. It is deliberately
 # read-only with no secrets: it may run over untrusted fork code, but it holds
 # no write token and can change nothing in the repo. It only records what

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: clang-format-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   clang-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Next release, consists of several fixes added while preparing this for OneWIfi branch.
- more aggresive concurrency verification (stop runs in progress, try to not post outdated comments )
- updated github runner actions versions of clang-format (would break in a few months at the latest)
- fix pattern matching for files to check (documented issue on github), this should fix any possible issues with recursive subdirs
- add missing 'cpp' extension for files to check, as tests started being written.